### PR TITLE
Fix MCP server configuration: use fastmcp run instead of direct python3 execution

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,20 +1,24 @@
 {
   "mcpServers": {
-    "market-analysis": {
-      "command": "python3",
-      "args": ["fastMCPTest/market_analysis_server.py"]
-    },
     "stock-price-server": {
-      "command": "python3",
-      "args": ["fastMCPTest/stock_price_server.py"]
+      "command": ".venv/bin/fastmcp",
+      "args": ["run", "fastMCPTest/stock_price_server.py"]
+    },
+    "market-analysis-server": {
+      "command": ".venv/bin/fastmcp",
+      "args": ["run", "fastMCPTest/market_analysis_server.py"]
     },
     "options-analysis-server": {
       "command": ".venv/bin/fastmcp",
       "args": ["run", "fastMCPTest/options_analysis.py"]
     },
     "company-fundamentals-server": {
-      "command": "python3",
-      "args": ["fastMCPTest/company_fundamentals_server.py"]
+      "command": ".venv/bin/fastmcp",
+      "args": ["run", "fastMCPTest/company_fundamentals_server.py"]
+    },
+    "news-sentiment-server": {
+      "command": ".venv/bin/fastmcp",
+      "args": ["run", "fastMCPTest/news_sentiment_server.py"]
     }
   }
 }

--- a/fastMCPTest/.mcp.json
+++ b/fastMCPTest/.mcp.json
@@ -1,16 +1,24 @@
 {
   "mcpServers": {
     "stock-price-server": {
-      "command": "/Users/thomasfowler/source/com/thomasdfowler/StockPortfolioManager/.venv/bin/fastmcp",
-      "args": ["run", "/Users/thomasfowler/source/com/thomasdfowler/StockPortfolioManager/fastMCPTest/stock_price_server.py"]
+      "command": "../.venv/bin/fastmcp",
+      "args": ["run", "stock_price_server.py"]
     },
     "market-analysis-server": {
-      "command": "/Users/thomasfowler/source/com/thomasdfowler/StockPortfolioManager/.venv/bin/fastmcp",
-      "args": ["run", "/Users/thomasfowler/source/com/thomasdfowler/StockPortfolioManager/fastMCPTest/market_analysis_server.py"]
+      "command": "../.venv/bin/fastmcp",
+      "args": ["run", "market_analysis_server.py"]
     },
     "options-analysis-server": {
-      "command": "/Users/thomasfowler/source/com/thomasdfowler/StockPortfolioManager/.venv/bin/fastmcp",
-      "args": ["run", "/Users/thomasfowler/source/com/thomasdfowler/StockPortfolioManager/fastMCPTest/options_analysis.py"]
+      "command": "../.venv/bin/fastmcp",
+      "args": ["run", "options_analysis.py"]
+    },
+    "company-fundamentals-server": {
+      "command": "../.venv/bin/fastmcp",
+      "args": ["run", "company_fundamentals_server.py"]
+    },
+    "news-sentiment-server": {
+      "command": "../.venv/bin/fastmcp",
+      "args": ["run", "news_sentiment_server.py"]
     }
   }
 }

--- a/fastMCPTest/README.md
+++ b/fastMCPTest/README.md
@@ -21,6 +21,9 @@ pip install fastmcp yfinance numpy pandas pyyaml feedparser
 pip install transformers torch
 ```
 
+The `fastMCPTest/.mcp.json` file is set up to run from inside this directory and
+uses the repo virtualenv at `../.venv/bin/fastmcp`.
+
 ---
 
 ## Architecture
@@ -37,7 +40,7 @@ pip install transformers torch
 | `news_collector.py` | Library | RSS + yfinance news fetcher with lazy-loaded FinBERT scoring pipeline |
 | `collect_options.py` | CLI / Cron | EOD snapshot collector; designed to run daily at 4:10 PM ET via cron or launchd |
 | `ohlcv_cache.py` | Library | SQLite-backed OHLCV bar cache; eliminates redundant yfinance calls |
-| `.mcp.json` | Config | Registers all three MCP servers for auto-start |
+| `.mcp.json` | Config | Registers the FastMCP servers in this directory for auto-start |
 
 ---
 

--- a/fastMCPTest/news_collector.py
+++ b/fastMCPTest/news_collector.py
@@ -189,24 +189,52 @@ def _fetch_yfinance_news(symbol: str) -> list[dict]:
 
     articles = []
     for item in raw:
-        # yfinance news dict keys vary by version
-        url = item.get("link") or item.get("url") or ""
+        # yfinance news dict keys vary by version. Newer releases wrap fields
+        # under a nested "content" object; older releases expose them top-level.
+        content = item.get("content") if isinstance(item, dict) else None
+        if not isinstance(content, dict):
+            content = {}
+
+        click_through = content.get("clickThroughUrl")
+        canonical = content.get("canonicalUrl")
+        provider = content.get("provider")
+        click_through_url = click_through.get("url") if isinstance(click_through, dict) else None
+        canonical_url = canonical.get("url") if isinstance(canonical, dict) else None
+
+        url = (
+            item.get("link")
+            or item.get("url")
+            or click_through_url
+            or canonical_url
+            or ""
+        )
         if not url:
             continue
 
         published_at = None
-        ts = item.get("providerPublishTime") or item.get("published")
+        ts = (
+            item.get("providerPublishTime")
+            or item.get("published")
+            or content.get("pubDate")
+        )
         if ts:
             try:
-                published_at = datetime.fromtimestamp(int(ts), tz=timezone.utc).isoformat()
+                if isinstance(ts, (int, float)):
+                    published_at = datetime.fromtimestamp(int(ts), tz=timezone.utc).isoformat()
+                elif isinstance(ts, str):
+                    published_at = datetime.fromisoformat(ts.replace("Z", "+00:00")).isoformat()
             except Exception:
                 pass
 
+        provider_name = provider.get("displayName") if isinstance(provider, dict) else None
+        publisher = item.get("publisher") or provider_name or "Yahoo Finance"
+        summary = content.get("summary")
+
         articles.append({
-            "title":        (item.get("title") or "").strip(),
+            "title":        ((item.get("title") or content.get("title") or "").strip()),
             "url":          url.strip(),
-            "summary":      None,
-            "publisher":    item.get("publisher") or "Yahoo Finance",
+            "summary":      summary.strip() if isinstance(summary, str) and summary.strip() else None,
+            "publisher":    publisher,
             "published_at": published_at,
             "source":       "yfinance",
         })

--- a/readme.md
+++ b/readme.md
@@ -241,7 +241,7 @@ The servers are configured in `.mcp.json` and start automatically when Claude Co
 
 ```bash
 source .venv/bin/activate
-python fastMCPTest/stock_price_server.py
+fastmcp run fastMCPTest/stock_price_server.py
 ```
 
 ---


### PR DESCRIPTION
fastmcp servers require the 'fastmcp run' wrapper to properly initialize the MCP protocol layer and expose tools to Claude Code. Direct python3 execution starts the server but doesn't enable MCP communication."

also:
  - ✓ Renames "market-analysis" → "market-analysis-server" (consistent naming)
  - ✓ Adds news-sentiment-server (was missing)
  - ✓ Ensures all servers use the same execution method