### PR TITLE
Fix CI: make tests tolerate a missing .env

### DIFF
--- a/test_api_smoke.py
+++ b/test_api_smoke.py
@@ -16,11 +16,14 @@ from contextlib import closing
 from pathlib import Path
 
 # Swap in the test DSN BEFORE quantcore.db is imported (it freezes DB_DSN at
-# import time), then let the guard abort if this process would reach prod.
-for _line in (Path(__file__).parent / ".env").read_text().splitlines():
-    if _line.strip().startswith("QUANTCORE_TEST_DB_DSN="):
-        os.environ["QUANTCORE_DB_DSN"] = _line.split("=", 1)[1].strip()
-        break
+# import time), then let the guard abort if this process would reach prod. When
+# .env is absent (e.g. CI), keep whatever QUANTCORE_DB_DSN the environment set.
+_env_file = Path(__file__).parent / ".env"
+if _env_file.exists():
+    for _line in _env_file.read_text().splitlines():
+        if _line.strip().startswith("QUANTCORE_TEST_DB_DSN="):
+            os.environ["QUANTCORE_DB_DSN"] = _line.split("=", 1)[1].strip()
+            break
 
 from quantcore.db_safety import assert_not_production  # noqa: E402
 

--- a/test_harvester_service.py
+++ b/test_harvester_service.py
@@ -5,11 +5,14 @@ from pathlib import Path
 
 # DB-backed tests run against the test database only. Swap the test DSN in
 # BEFORE quantcore.db is imported (it freezes DB_DSN at import time), then let
-# the guard abort if this process would still reach production.
-for _line in (Path(__file__).parent / ".env").read_text().splitlines():
-    if _line.strip().startswith("QUANTCORE_TEST_DB_DSN="):
-        os.environ["QUANTCORE_DB_DSN"] = _line.split("=", 1)[1].strip()
-        break
+# the guard abort if this process would still reach production. When .env is
+# absent (e.g. CI), keep whatever QUANTCORE_DB_DSN the environment set.
+_env_file = Path(__file__).parent / ".env"
+if _env_file.exists():
+    for _line in _env_file.read_text().splitlines():
+        if _line.strip().startswith("QUANTCORE_TEST_DB_DSN="):
+            os.environ["QUANTCORE_DB_DSN"] = _line.split("=", 1)[1].strip()
+            break
 
 from quantcore.db_safety import assert_not_production  # noqa: E402
 

--- a/test_options_contract_tools.py
+++ b/test_options_contract_tools.py
@@ -8,11 +8,14 @@ sys.path.insert(0, str(Path(__file__).parent / "fastMCPTest"))
 
 # DB-backed tests run against the test database only. Swap the test DSN in
 # BEFORE quantcore.db is imported (it freezes DB_DSN at import time), then let
-# the guard abort if this process would still reach production.
-for _line in (Path(__file__).parent / ".env").read_text().splitlines():
-    if _line.strip().startswith("QUANTCORE_TEST_DB_DSN="):
-        os.environ["QUANTCORE_DB_DSN"] = _line.split("=", 1)[1].strip()
-        break
+# the guard abort if this process would still reach production. When .env is
+# absent (e.g. CI), keep whatever QUANTCORE_DB_DSN the environment set.
+_env_file = Path(__file__).parent / ".env"
+if _env_file.exists():
+    for _line in _env_file.read_text().splitlines():
+        if _line.strip().startswith("QUANTCORE_TEST_DB_DSN="):
+            os.environ["QUANTCORE_DB_DSN"] = _line.split("=", 1)[1].strip()
+            break
 
 from quantcore.db_safety import assert_not_production  # noqa: E402
 

--- a/test_portfolio_service.py
+++ b/test_portfolio_service.py
@@ -7,11 +7,14 @@ from pathlib import Path
 
 # DB-backed tests run against the test database only. Swap the test DSN in
 # BEFORE quantcore.db is imported (it freezes DB_DSN at import time), then let
-# the guard abort if this process would still reach production.
-for _line in (Path(__file__).parent / ".env").read_text().splitlines():
-    if _line.strip().startswith("QUANTCORE_TEST_DB_DSN="):
-        os.environ["QUANTCORE_DB_DSN"] = _line.split("=", 1)[1].strip()
-        break
+# the guard abort if this process would still reach production. When .env is
+# absent (e.g. CI), keep whatever QUANTCORE_DB_DSN the environment set.
+_env_file = Path(__file__).parent / ".env"
+if _env_file.exists():
+    for _line in _env_file.read_text().splitlines():
+        if _line.strip().startswith("QUANTCORE_TEST_DB_DSN="):
+            os.environ["QUANTCORE_DB_DSN"] = _line.split("=", 1)[1].strip()
+            break
 
 from quantcore.db_safety import assert_not_production  # noqa: E402
 


### PR DESCRIPTION
Unblocks the prod-rollout gate (4 modules read .env at import; absent in CI).