### PR TITLE
QuantUI/IAP Step 1: Express serve+proxy container

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,7 @@
 # Phase 3 Step 10 — CI/CD for the QuantCore platform (architectural standard v2 §10).
 #
 # PRs + pushes run the gate (tests + wrapper smoke + OpenAPI surface diff). Pushes to
-# main additionally build the 3 images (Cloud Build, native amd64) and roll them out to
+# main additionally build the 4 images (Cloud Build, native amd64) and roll them out to
 # the Cloud Run services + the report Job in the TEST project. Deploys carry ONLY the
 # image tag — every service's env/secrets/Cloud-SQL binding is preserved from its last
 # manual deploy (Steps 8–9), so CI never needs the DB DSN or JWT secret.
@@ -112,7 +112,7 @@ jobs:
           workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
           service_account: ${{ secrets.GCP_DEPLOY_SA }}
       - uses: google-github-actions/setup-gcloud@v2
-      - name: Build + push the 3 images (Cloud Build, amd64)
+      - name: Build + push the 4 images (Cloud Build, amd64)
         run: |
           gcloud builds submit --project "$PROJECT_ID" \
             --config cloudbuild.yaml \
@@ -131,3 +131,15 @@ jobs:
         run: |
           gcloud run jobs update quantcore-report --project "$PROJECT_ID" --region "$REGION" \
             --image "$REGION-docker.pkg.dev/$PROJECT_ID/$AR_REPO/quantcore-report:${GITHUB_SHA::7}"
+      - name: Deploy quantui (image-only; IAP + secret + REST URL preserved)
+        # quantui's FIRST deploy is the manual --iap step (see quantui-iap-plan.md Step 5),
+        # which also sets --no-allow-unauthenticated, the QUANTCORE_API_TOKEN secret, and
+        # QUANTCORE_REST_URL. Those persist across image-only redeploys. Until that one-time
+        # deploy exists, skip rather than fail (a fresh service can't be image-only deployed).
+        run: |
+          if gcloud run services describe quantui --project "$PROJECT_ID" --region "$REGION" >/dev/null 2>&1; then
+            gcloud run deploy quantui --project "$PROJECT_ID" --region "$REGION" \
+              --image "$REGION-docker.pkg.dev/$PROJECT_ID/$AR_REPO/quantcore-ui:${GITHUB_SHA::7}"
+          else
+            echo "quantui service not found — first deploy is the manual --iap step; skipping image roll-out."
+          fi

--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -1,0 +1,41 @@
+# Dockerfile.ui — QuantUI (React/Vite SPA) served on Cloud Run behind IAP.
+#
+# BUILD CONTEXT IS ./frontend (NOT the repo root): the repo-root .dockerignore
+# excludes frontend/ from the python images, so the UI build uses the frontend
+# directory as its own context (frontend/.dockerignore applies). Build with:
+#
+#   docker build -f Dockerfile.ui -t quantcore-ui ./frontend
+#
+# Stage 1 compiles the SPA to static assets; stage 2 serves them from a tiny
+# Express server (server/server.mjs) that reverse-proxies /api/* to quantcore-api,
+# injecting the bearer token server-side. No VITE_* secrets are baked at build
+# time — the app calls /api same-origin and the token is added at runtime.
+
+# ---- builder: compile the Vite SPA ----
+FROM node:22-slim AS builder
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npm run build           # -> /app/dist
+
+# ---- runtime: serve dist/ + proxy /api ----
+FROM node:22-slim
+ENV NODE_ENV=production \
+    PORT=8080
+WORKDIR /app
+
+# Server deps only (express + http-proxy-middleware), installed reproducibly.
+COPY server/package.json server/package-lock.json ./server/
+RUN cd server && npm ci --omit=dev
+
+COPY server/ ./server/
+COPY --from=builder /app/dist ./dist
+
+# node:22-slim already ships a non-root `node` user (uid 1000); reuse it.
+RUN chown -R node:node /app
+USER node
+EXPOSE 8080
+
+# Exec form (proper signal handling); PORT is read from the env inside server.mjs.
+CMD ["node", "server/server.mjs"]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,4 @@
-# cloudbuild.yaml — Phase 3 Step 7: build + push the three QuantCore images.
+# cloudbuild.yaml — Phase 3 Step 7: build + push the QuantCore images.
 #
 # Built natively on linux/amd64 in Cloud Build (the local dev host is arm64, so a
 # local build would need slow QEMU emulation — especially for the torch-bearing api
@@ -6,11 +6,12 @@
 # invoked from CI/the helper) and a moving :latest. The `images:` block pushes them
 # to Artifact Registry after the steps succeed.
 #
-# Three images (one mcp image is reused by all five wrappers — server + port are
+# Images (one mcp image is reused by all five wrappers — server + port are
 # selected at run time via SERVER_MODULE/PORT env, see mcp_gateway/serve.py):
 #   quantcore-api     FastAPI front door + services in-process (carries FinBERT/torch)
 #   quantcore-mcp     the shared thin MCP wrapper image
 #   quantcore-report  main.py once-and-exit (Cloud Run Job)
+#   quantcore-ui      React/Vite SPA + /api proxy (built from the frontend/ context)
 #
 # Manual invocation (from repo root):
 #   gcloud builds submit --project quantcore-test-20260606 --config cloudbuild.yaml \
@@ -68,6 +69,20 @@ steps:
       - ${_REGION}-docker.pkg.dev/${_PROJECT}/${_REPO}/quantcore-report:latest
       - .
 
+  # --- ui (Dockerfile.ui) — React/Vite SPA + /api proxy; build context is frontend/
+  #     (the repo-root .dockerignore excludes frontend/ from the python images). ---
+  - name: gcr.io/cloud-builders/docker
+    id: build-ui
+    args:
+      - build
+      - -f
+      - Dockerfile.ui
+      - -t
+      - ${_REGION}-docker.pkg.dev/${_PROJECT}/${_REPO}/quantcore-ui:${_TAG}
+      - -t
+      - ${_REGION}-docker.pkg.dev/${_PROJECT}/${_REPO}/quantcore-ui:latest
+      - frontend
+
 images:
   - ${_REGION}-docker.pkg.dev/${_PROJECT}/${_REPO}/quantcore-api:${_TAG}
   - ${_REGION}-docker.pkg.dev/${_PROJECT}/${_REPO}/quantcore-api:latest
@@ -75,3 +90,5 @@ images:
   - ${_REGION}-docker.pkg.dev/${_PROJECT}/${_REPO}/quantcore-mcp:latest
   - ${_REGION}-docker.pkg.dev/${_PROJECT}/${_REPO}/quantcore-report:${_TAG}
   - ${_REGION}-docker.pkg.dev/${_PROJECT}/${_REPO}/quantcore-report:latest
+  - ${_REGION}-docker.pkg.dev/${_PROJECT}/${_REPO}/quantcore-ui:${_TAG}
+  - ${_REGION}-docker.pkg.dev/${_PROJECT}/${_REPO}/quantcore-ui:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -130,3 +130,26 @@ services:
         condition: service_healthy
     restart: on-failure
     networks: [quantcore]
+
+  # --- QuantUI: React/Vite SPA served + /api reverse-proxied to quantcore-api ---
+  # Build context is ./frontend (the repo-root .dockerignore excludes frontend/),
+  # so the Dockerfile lives one level up at ../Dockerfile.ui. No QUANTCORE_API_TOKEN
+  # here: the compose api runs AUTH_DISABLED=1, so the proxy sends no bearer (the
+  # token is a Cloud Run / Secret Manager concern only — see Dockerfile.ui).
+  quantui:
+    build: { context: ./frontend, dockerfile: ../Dockerfile.ui }
+    environment:
+      QUANTCORE_REST_URL: "http://quantcore-api:5001"
+      PORT: "8080"
+    ports: ["8080:8080"]
+    depends_on:
+      quantcore-api:
+        condition: service_healthy
+    restart: on-failure
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://localhost:8080/healthz', r => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 15s
+    networks: [quantcore]

--- a/docs/proposals/quantui-iap-plan.md
+++ b/docs/proposals/quantui-iap-plan.md
@@ -1,0 +1,231 @@
+# QuantUI on Cloud Run behind Identity-Aware Proxy (IAP) — plan + checkpoint log
+
+> Status: **in progress.** This doc is the canonical plan and checkpoint log for deploying the
+> QuantUI front end to Cloud Run secured by Google IAP — mirroring the cadence of
+> `phase3-gateway-plan.md` / `prod-rollout-plan.md`. One commit per step, pushed, logged below.
+
+## Checkpoint log
+
+| Step | What | Status | Commit |
+|------|------|--------|--------|
+| 1 | Express serve+proxy (`frontend/server/`), `Dockerfile.ui`, `frontend/.dockerignore` | ☐ in progress | — |
+| 2 | Optional `quantui` service in `docker-compose.yml` (local stack parity) | ☐ | — |
+| 3 | Wire `build-ui` into `cloudbuild.yaml` + Deploy step in `deploy.yml` | ☐ | — |
+| 4 | Secret Manager `quantui-api-token` (test) + accessor grant | ☐ (user/GCP) | — |
+| 5 | First Cloud Run deploy with `--iap` (test) | ☐ (user/GCP) | — |
+| 6 | OAuth consent (External) + IAP IAM grants (test) | ☐ (user/GCP) | — |
+| 7 | Verify IAP login + proxy end-to-end (test) | ☐ | — |
+| 8 | Promote to prod (`quantcore-prod-20260606`, by digest, via `prod-rollout.yml`) | ☐ (user/GCP) | — |
+
+---
+
+## Context
+
+QuantUI (`frontend/`) is the React 19 + Vite 6 SPA front end for the QuantCore platform. The
+backend (`quantcore-api` + 5 MCP wrappers + report Job) is already on Cloud Run in both the
+**test** (`quantcore-test-20260606`) and **prod** (`quantcore-prod-20260606`) projects, but the
+UI still only runs locally via `npm run dev` (`runUI-MAC.sh`). We want the dev team to reach the
+**real UI** from anywhere, restricted to their Google accounts, **without writing auth code** —
+exactly what Cloud Run's **direct IAP integration** provides (Google blocks unauthorized traffic at
+the perimeter of the `*.run.app` URL).
+
+Two facts shape the design:
+
+1. **QuantUI is a static SPA, not a Node server.** `npm run build` (`tsc -b && vite build`) emits a
+   static `dist/`. It needs *something* to serve it on Cloud Run.
+2. **The API is JWT-enforced.** `api/auth.py` requires an app-level HS256 bearer
+   (`QUANTCORE_JWT_SECRET`) on the deployed api in both projects. **IAP secures who can load the
+   UI; it does NOT authenticate the UI→API hop** — that still needs the app JWT. Today
+   `vite.config.ts` proxies `/api/*` to the API server-side (so the browser stays same-origin, no
+   CORS) and the token is supplied out-of-band. We preserve that same-origin + server-side-token
+   model in production.
+
+**Decisions locked with the user:**
+- **API auth model → server-side proxy.** Serve `dist/` from a tiny container that reverse-proxies
+  `/api/*` to `quantcore-api`, injecting the bearer token **server-side** from Secret Manager. The
+  token never reaches the browser; same-origin (no CORS); mirrors the existing Vite dev proxy.
+- **Target → test project first**, validate IAP + team login + proxy end-to-end, **then promote to
+  prod** (same image/pattern in `quantcore-prod-20260606`).
+- **Build/rollout → Dockerfile + CI**, matching the existing `Dockerfile.{api,mcp,report}` +
+  `cloudbuild.yaml` + `.github/workflows/deploy.yml` pattern (reproducible, git-SHA-tagged), not the
+  brief's `--source .` buildpack path.
+
+**Standing constraints (unchanged):** test work targets `quantcore-test-20260606`; the prod DB in
+`.env`'s `QUANTCORE_DB_DSN` is never touched by this work (the UI only issues normal API calls). The
+user runs all GCP/IAM/console commands and commits/pushes git themselves; secrets (the API token, the
+JWT signing secret) are never echoed into the transcript. `frontend/.env.local` is gitignored — never
+commit it.
+
+---
+
+## Target runtime architecture
+
+```text
+                         ┌─────────── Google IAP (perimeter) ───────────┐
+Dev team ──HTTPS──►  *.run.app   │  verifies Google login, injects        │
+(browser)                        │  x-goog-authenticated-user-email/-id   │
+                                 └───────────────────┬────────────────────┘
+                                                     ▼
+                                   Cloud Run service  quantui  (Node/Express)
+                                     ├─ GET /*       → static dist/  (SPA, index.html fallback)
+                                     └─ /api/*        → reverse-proxy to quantcore-api
+                                                         + Authorization: Bearer <secret>   (server-side)
+                                                                     │
+                                                                     ▼
+                                                     quantcore-api (JWT-enforced) ──► services ──► Cloud SQL
+```
+
+- IAP gates **who can load the UI**. The Express layer holds the **service JWT** (from Secret
+  Manager) and attaches it to proxied `/api/*` calls, so the browser bundle never contains a token
+  and there is no CORS surface. This is the production equivalent of `vite.config.ts`'s dev proxy.
+- Cloud Run ingress stays **public** with `--no-allow-unauthenticated --iap`: IAP (not Cloud Run
+  IAM) is the enforcement layer for human access; the container itself runs no auth.
+
+---
+
+## New / changed files
+
+```text
+frontend/server/server.mjs        # NEW Express server: express.static(dist) + SPA fallback +
+                                  #   http-proxy-middleware for /api/* → QUANTCORE_REST_URL, injecting
+                                  #   Authorization: Bearer ${QUANTCORE_API_TOKEN}; listens on $PORT
+frontend/server/package.json      # NEW server-only deps (express, http-proxy-middleware) + lockfile,
+                                  #   kept separate from the SPA's package.json so the build stays lean
+frontend/.dockerignore            # NEW (UI build context is frontend/) — excludes node_modules, dist,
+                                  #   .env*, build artifacts so secrets are never baked
+Dockerfile.ui                     # NEW multi-stage (context ./frontend): node build → dist/, then a
+                                  #   slim node runtime with the server + dist; non-root; $PORT
+cloudbuild.yaml                   # ADD a build-ui step + push quantcore-ui:${_TAG}/:latest
+.github/workflows/deploy.yml      # ADD a "Deploy quantui" step (image-only, after the api/wrappers)
+docker-compose.yml                # ADD an optional `quantui` service for local stack parity
+CLAUDE.md / readme.md             # document the UI service + IAP access + local container run
+```
+
+The React app under `frontend/src/**` is **unchanged** — `frontend/src/api/client.ts` already calls
+`/api/*` with `API_BASE` defaulting to `''`, so a build with **no `VITE_*` env** is same-origin and
+token-less; the Express server supplies the token at runtime. `VITE_API_TOKEN` is therefore **no
+longer baked** into the bundle.
+
+---
+
+## Step-by-step plan (one commit per step; user commits/pushes + checkpoint-logged)
+
+### Part A — Build the serving container (local, no GCP)
+
+- **Step 1 — Express serve+proxy + Dockerfile.**
+  - `frontend/server/server.mjs`: `express.static(dist)`; `/healthz` liveness; SPA `index.html`
+    fallback; `createProxyMiddleware('/api', { target: QUANTCORE_REST_URL, changeOrigin: true,
+    onProxyReq })` adding the bearer only when `QUANTCORE_API_TOKEN` is set (local AUTH_DISABLED → no
+    token). Listens on `process.env.PORT`.
+  - `frontend/server/package.json` (+ `package-lock.json`): `express`, `http-proxy-middleware` only.
+  - `Dockerfile.ui` (build context `./frontend`, mirrors `Dockerfile.api`'s multi-stage + non-root +
+    shell-form `${PORT}`): builder `node:22-slim` → `npm ci && npm run build` → `dist/`; runtime
+    `node:22-slim` → `npm ci --omit=dev` server deps, copy `dist/` + `server/`, non-root,
+    `CMD node server/server.mjs`.
+  - `frontend/.dockerignore` keeps `node_modules`/`dist`/`.env*` out of the image.
+  - **Verify locally:** `docker build -f Dockerfile.ui -t quantui:dev ./frontend`, then run with
+    `-e QUANTCORE_REST_URL=http://host.docker.internal:5001 -e PORT=8080 -p 8080:8080` against a local
+    `uvicorn api.main:app` (AUTH_DISABLED) → UI loads at `:8080`, `/api/health` + a data grid populate
+    through the proxy.
+
+- **Step 2 — (optional) compose parity.** Add a `quantui` service to `docker-compose.yml`
+  (`build: { context: ./frontend, dockerfile: ../Dockerfile.ui }` or root-relative equivalent,
+  `QUANTCORE_REST_URL=http://quantcore-api:5001`, no token since the compose api is `AUTH_DISABLED=1`,
+  `ports: ["8080:8080"]`, `depends_on: quantcore-api healthy`). Lets the team run the whole stack
+  incl. UI via `./runUI-CONTAINERS.sh up --build`.
+
+### Part B — Wire into CI image build
+
+- **Step 3 — cloudbuild + deploy.yml.** Add a `build-ui` step to `cloudbuild.yaml` (build
+  `Dockerfile.ui` with context `frontend`, tag `quantcore-ui:${_TAG}` + `:latest`, add to `images:`).
+  Add a **Deploy quantui** step to `deploy.yml` (image-only `gcloud run deploy quantui --image
+  …:${GITHUB_SHA::7}`, after the api/wrapper/report steps). Like the api, **CI carries only the image
+  tag** — the `--iap`, `--no-allow-unauthenticated`, secret binding, and `QUANTCORE_REST_URL` are set
+  once at first deploy (Step 5) and preserved across image-only redeploys.
+
+### Part C — First deploy + IAP (TEST project; user runs gcloud/console)
+
+- **Step 4 — Secret (test).** Create a Secret Manager secret holding the **service JWT** the proxy
+  presents to the test api — a long-lived HS256 token signed with the test `QUANTCORE_JWT_SECRET` (a
+  valid one already exists locally in `frontend/.env.local`; reuse its value or mint a fresh one).
+  Store as `quantui-api-token` (test project); grant the quantui runtime SA
+  `roles/secretmanager.secretAccessor` on it.
+- **Step 5 — First Cloud Run deploy with IAP (test).**
+  ```bash
+  gcloud run deploy quantui --project quantcore-test-20260606 --region us-central1 \
+    --image us-central1-docker.pkg.dev/quantcore-test-20260606/quantcore/quantcore-ui:<tag> \
+    --no-allow-unauthenticated --iap \
+    --set-env-vars QUANTCORE_REST_URL=https://<test-quantcore-api-url> \
+    --set-secrets QUANTCORE_API_TOKEN=quantui-api-token:latest
+  ```
+- **Step 6 — OAuth consent + IAP IAM (test, one-time).**
+  1. Cloud Run → quantui → **Security** → **Configure in IAP** → set up the **OAuth consent screen**,
+     user type **External** (team uses `@gmail.com`).
+  2. Grant the IAP service agent invoke rights on the private service:
+     ```bash
+     gcloud run services add-iam-policy-binding quantui --region us-central1 \
+       --project quantcore-test-20260606 \
+       --member=serviceAccount:service-493357101423@gcp-sa-iap.iam.gserviceaccount.com \
+       --role=roles/run.invoker
+     ```
+     (test project number = `493357101423`.)
+  3. Authorize each developer (verify the exact `--resource-type` for direct Cloud Run IAP via
+     `gcloud iap web add-iam-policy-binding --help` — the brief's `web-types` is likely outdated):
+     ```bash
+     gcloud iap web add-iam-policy-binding --resource-type=<cloud-run|backend-services> \
+       --service=quantui --region=us-central1 --project=quantcore-test-20260606 \
+       --member='user:<dev>@gmail.com' --role='roles/iap.httpsResourceAccessor'
+     ```
+- **Step 7 — Verify (test).** Open the quantui `*.run.app` URL in an incognito window → Google login
+  prompt (IAP); an unauthorized account is blocked; an authorized dev account loads the SPA; data
+  grids populate (proxy → test api → test DB). Confirm via DevTools that **no JWT appears** in any
+  client-side bundle or browser-issued request (the bearer is added only on the server hop).
+
+### Part D — Promote to PROD
+
+- **Step 8 — Prod promotion.** Repeat Steps 4–7 in `quantcore-prod-20260606` (project #
+  `127961694257`): a `quantui-api-token` secret signed with the **prod** `QUANTCORE_JWT_SECRET`,
+  `QUANTCORE_REST_URL=https://quantcore-api-127961694257.us-central1.run.app`, IAP + OAuth consent +
+  team `iap.httpsResourceAccessor` grants, image promoted **by digest** test→prod (consistent with the
+  existing api/mcp/report promotion). Prod deploy goes through the supervised `prod-rollout.yml`
+  (`workflow_dispatch`, `prod` environment, required reviewers) — not the test auto-deploy.
+
+---
+
+## Verification
+
+- **Container (Step 1):** `docker build -f Dockerfile.ui ./frontend` succeeds; the running container
+  serves the SPA and round-trips `/api/*` through the proxy against a local `uvicorn api.main:app`.
+- **CI (Step 3):** `deploy.yml` `gate` stays green; on push to main the `build-ui` image builds and the
+  `Deploy quantui` step rolls out (image-only; IAP/secret settings preserved).
+- **IAP (Steps 6–7):** incognito visit forces Google login; unauthorized account → 403/blocked;
+  authorized dev → SPA loads and data populates end-to-end (`browser → IAP → quantui → quantcore-api →
+  service → Cloud SQL`).
+- **No-token-in-browser (Step 7):** DevTools Network/Sources show the bearer only on the server hop,
+  never in the delivered bundle or browser-issued requests.
+- **Prod (Step 8):** same checks against the prod project; image matches the test digest.
+
+## Security notes & deferred hardening
+
+- **Shared service token (baseline).** The proxy presents one long-lived service JWT for all UI users;
+  IAP is what restricts access to the team. Adequate for an internal dev-team tool.
+- **Deferred — per-user identity for audit (Rule 5).** IAP injects
+  `x-goog-authenticated-user-email`. A natural follow-up: have the Express proxy **mint a short-lived
+  per-request JWT** with `sub=<that email>` (signed with `QUANTCORE_JWT_SECRET`) instead of the shared
+  token, so `api/auth.py`'s `Principal.owner` attributes work to the real user and the portfolio
+  `?owner=` partition follows the logged-in identity. Noted, not in this plan's baseline.
+- **Token rotation.** Because the token lives in Secret Manager (`:latest`), rotation is a secret
+  update + image-less redeploy — no rebuild.
+
+## Risks & mitigations
+
+- **Direct Cloud Run IAP flag/resource-type drift** (the feature is new; the brief's `web-types` looks
+  off) → verify `--iap` and the `gcloud iap web add-iam-policy-binding` resource-type against current
+  `gcloud --help` before running; fall back to console wiring (Cloud Run → Security tab) if a CLI flag
+  is unavailable.
+- **CI redeploy dropping IAP/secret settings** → mirror the api pattern (image-only redeploys preserve
+  service config); confirm after the first CI deploy that `--iap` and the secret binding survive.
+- **CORS creeping in** → avoided by design: the SPA stays same-origin (`/api/*` via the proxy); never
+  point the browser directly at the api domain.
+- **Wrong-project token** → test and prod use separate `quantui-api-token` secrets signed with each
+  project's own `QUANTCORE_JWT_SECRET`; promotion copies the image by digest, not the secret.

--- a/docs/proposals/quantui-iap-plan.md
+++ b/docs/proposals/quantui-iap-plan.md
@@ -8,8 +8,8 @@
 
 | Step | What | Status | Commit |
 |------|------|--------|--------|
-| 1 | Express serve+proxy (`frontend/server/`), `Dockerfile.ui`, `frontend/.dockerignore` | ☐ in progress | — |
-| 2 | Optional `quantui` service in `docker-compose.yml` (local stack parity) | ☐ | — |
+| 1 | Express serve+proxy (`frontend/server/`), `Dockerfile.ui`, `frontend/.dockerignore` | ☑ done | PR `feature/quantui-iap-deploy` |
+| 2 | Optional `quantui` service in `docker-compose.yml` (local stack parity) | ☑ done | (same branch) |
 | 3 | Wire `build-ui` into `cloudbuild.yaml` + Deploy step in `deploy.yml` | ☐ | — |
 | 4 | Secret Manager `quantui-api-token` (test) + accessor grant | ☐ (user/GCP) | — |
 | 5 | First Cloud Run deploy with `--iap` (test) | ☐ (user/GCP) | — |

--- a/docs/proposals/quantui-iap-plan.md
+++ b/docs/proposals/quantui-iap-plan.md
@@ -10,7 +10,7 @@
 |------|------|--------|--------|
 | 1 | Express serve+proxy (`frontend/server/`), `Dockerfile.ui`, `frontend/.dockerignore` | ☑ done | PR `feature/quantui-iap-deploy` |
 | 2 | Optional `quantui` service in `docker-compose.yml` (local stack parity) | ☑ done | (same branch) |
-| 3 | Wire `build-ui` into `cloudbuild.yaml` + Deploy step in `deploy.yml` | ☐ | — |
+| 3 | Wire `build-ui` into `cloudbuild.yaml` + Deploy step in `deploy.yml` | ☑ done | (same branch) |
 | 4 | Secret Manager `quantui-api-token` (test) + accessor grant | ☐ (user/GCP) | — |
 | 5 | First Cloud Run deploy with `--iap` (test) | ☐ (user/GCP) | — |
 | 6 | OAuth consent (External) + IAP IAM grants (test) | ☐ (user/GCP) | — |

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,13 @@
+# Build context for Dockerfile.ui is THIS directory (frontend/), because the repo-root
+# .dockerignore deliberately excludes frontend/ from the python images. Keep secrets and
+# host build artifacts out of the UI image.
+node_modules
+server/node_modules
+dist
+.env
+.env.*
+.git
+.gitignore
+*.tsbuildinfo
+.DS_Store
+.claude

--- a/frontend/server/package-lock.json
+++ b/frontend/server/package-lock.json
@@ -1,0 +1,1025 @@
+{
+  "name": "quantui-server",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "quantui-server",
+      "version": "1.0.0",
+      "dependencies": {
+        "express": "^4.21.2",
+        "http-proxy-middleware": "^2.0.7"
+      }
+    },
+    "node_modules/@types/http-proxy": {
+      "version": "1.17.17",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.17.tgz",
+      "integrity": "sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-proxy": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/http-proxy-middleware": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
+      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-proxy": "^1.17.8",
+        "http-proxy": "^1.18.1",
+        "is-glob": "^4.0.1",
+        "is-plain-obj": "^3.0.0",
+        "micromatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "@types/express": "^4.17.13"
+      },
+      "peerDependenciesMeta": {
+        "@types/express": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  }
+}

--- a/frontend/server/package.json
+++ b/frontend/server/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "quantui-server",
+  "private": true,
+  "type": "module",
+  "version": "1.0.0",
+  "description": "Static-SPA server + /api reverse proxy for QuantUI on Cloud Run (behind IAP).",
+  "scripts": {
+    "start": "node server.mjs"
+  },
+  "dependencies": {
+    "express": "^4.21.2",
+    "http-proxy-middleware": "^2.0.7"
+  }
+}

--- a/frontend/server/server.mjs
+++ b/frontend/server/server.mjs
@@ -1,0 +1,57 @@
+// QuantUI production server — the Cloud Run equivalent of vite.config.ts's dev proxy.
+//
+// Serves the built static SPA (dist/) AND reverse-proxies /api/* to the JWT-protected
+// REST tier (quantcore-api), injecting the bearer token SERVER-SIDE from the
+// QUANTCORE_API_TOKEN env (a Secret Manager secret on Cloud Run). The token therefore
+// never reaches the browser bundle, and the browser stays same-origin (no CORS).
+//
+// Behind Google IAP on Cloud Run: IAP gates who can load the UI; this server holds the
+// service identity that authenticates the UI->API hop. When QUANTCORE_API_TOKEN is unset
+// (local docker-compose, where the api runs AUTH_DISABLED), no Authorization header is
+// added, preserving the open local contract.
+//
+// Env:
+//   PORT                Cloud Run injects this (default 8080 locally).
+//   QUANTCORE_REST_URL  base URL of quantcore-api (default http://127.0.0.1:5001).
+//   QUANTCORE_API_TOKEN bearer token presented to the api; omitted from requests if unset.
+//   DIST_DIR            override the static root (default ../dist relative to this file).
+
+import express from 'express';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createProxyMiddleware } from 'http-proxy-middleware';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DIST_DIR = process.env.DIST_DIR || path.resolve(__dirname, '..', 'dist');
+
+const PORT = Number(process.env.PORT) || 8080;
+const API_TARGET = process.env.QUANTCORE_REST_URL || 'http://127.0.0.1:5001';
+const API_TOKEN = process.env.QUANTCORE_API_TOKEN || '';
+
+const app = express();
+
+// Lightweight liveness probe (does not touch the api) for Cloud Run / compose.
+app.get('/healthz', (_req, res) => res.status(200).send('ok'));
+
+// /api/* -> REST tier, with the bearer injected here (never in the browser).
+app.use(
+  '/api',
+  createProxyMiddleware({
+    target: API_TARGET,
+    changeOrigin: true,
+    onProxyReq: (proxyReq) => {
+      if (API_TOKEN) {
+        proxyReq.setHeader('authorization', `Bearer ${API_TOKEN}`);
+      }
+    },
+  })
+);
+
+// Static assets, then SPA fallback so client-side routes (react-router) resolve.
+app.use(express.static(DIST_DIR));
+app.get('*', (_req, res) => res.sendFile(path.join(DIST_DIR, 'index.html')));
+
+app.listen(PORT, () => {
+  const auth = API_TOKEN ? 'token injected' : 'no token (AUTH_DISABLED parity)';
+  console.log(`QuantUI serving ${DIST_DIR} on :${PORT} -> ${API_TARGET} (${auth})`);
+});


### PR DESCRIPTION
## Summary
First step of deploying QuantUI to Cloud Run behind IAP (plan: `docs/proposals/quantui-iap-plan.md`).

Adds the serving container for the React/Vite SPA:
- `frontend/server/server.mjs` — Express serves built `dist/` + reverse-proxies `/api/*` to `quantcore-api`, injecting the bearer **server-side** from `QUANTCORE_API_TOKEN` (never in the browser; same-origin, no CORS). Token omitted when unset (local `AUTH_DISABLED` parity).
- `Dockerfile.ui` — multi-stage (node build → slim runtime), build context `./frontend`, non-root.
- `frontend/.dockerignore` — keeps `node_modules`/`dist`/`.env*` out of the image.
- `docs/proposals/quantui-iap-plan.md` — full approved plan + checkpoint log.

## Verification (local)
- `docker build -f Dockerfile.ui ./frontend` ✅
- `/healthz` → 200 ✅
- static SPA + client-route fallback ✅
- `/api/health` round-trips through the proxy ✅
- token-injection mode logs "token injected" when `QUANTCORE_API_TOKEN` set ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
