### PR TITLE
QuantUI/IAP: fix .gcloudignore so Cloud Build can build the UI image

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -19,9 +19,14 @@ __pycache__/
 venv/
 env/
 
-# --- Node / frontend (separate app; no backend image serves it) ---
+# --- Node deps (heavy; reinstalled in-image, never uploaded) ---
 node_modules/
-frontend/
+
+# --- Frontend: the SOURCE tree IS needed for the quantcore-ui build (Dockerfile.ui,
+#     build context = frontend/), so don't exclude the whole tree — only its build
+#     output. node_modules/ and .env* are already excluded by the rules above/below. ---
+frontend/dist/
+*.tsbuildinfo
 
 # --- Local data / databases / logs (containers use Cloud SQL via the connector) ---
 *.sqlite


### PR DESCRIPTION
## Summary
Follow-up fix to PR #58 (QuantUI Steps 1–3). The post-merge `deploy` run failed at `build-ui` with:

```
unable to prepare context: path "frontend" not found
```

`gcloud builds submit` filters its upload by `.gcloudignore`, which had a blanket `frontend/` exclusion — so Cloud Build received no `frontend/` directory for `Dockerfile.ui` (whose build context is `frontend/`). It built fine locally because local `docker build` reads the directory directly, not from the filtered tarball.

## Fix
Replace the blanket `frontend/` exclusion in `.gcloudignore` with `frontend/dist/` + `*.tsbuildinfo`. `node_modules/` and `.env*` remain globally excluded, so the heavy deps and the `.env.local` token still never upload. `frontend/` holds only TS/TSX source (no `*.png` assets), so the existing `*.png` rule is harmless.

## Effect
The next `deploy` run on main will build all 4 images successfully; the guarded `Deploy quantui` step still skips cleanly until the one-time `--iap` deploy creates the service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
