### PR TITLE
QuantUI/IAP: trim API token to survive trailing newline

### DIFF
--- a/frontend/server/server.mjs
+++ b/frontend/server/server.mjs
@@ -26,7 +26,10 @@ const DIST_DIR = process.env.DIST_DIR || path.resolve(__dirname, '..', 'dist');
 
 const PORT = Number(process.env.PORT) || 8080;
 const API_TARGET = process.env.QUANTCORE_REST_URL || 'http://127.0.0.1:5001';
-const API_TOKEN = process.env.QUANTCORE_API_TOKEN || '';
+// .trim() guards against a stray trailing newline in the secret value (e.g. when a
+// token is piped into `gcloud secrets versions add --data-file=-`): an Authorization
+// header with a newline throws ERR_INVALID_CHAR and would crash the proxy.
+const API_TOKEN = (process.env.QUANTCORE_API_TOKEN || '').trim();
 
 const app = express();
 

--- a/scripts/attach_quantui_iap_oauth.sh
+++ b/scripts/attach_quantui_iap_oauth.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Attach a custom OAuth client (ID + secret) to the quantui Cloud Run service's
+# IAP. Required for IAP login in a standalone (non-org) project, where the --iap
+# deploy cannot auto-provision an OAuth client (symptom: 502 "Empty Google
+# Account OAuth client ID(s)/secret(s)").
+#
+# Prereq: create the OAuth client first (Console -> APIs & Services -> Clients,
+# type "Web application") and add the redirect URI
+#   https://iap.googleapis.com/v1/oauth/clientIds/CLIENT_ID:handleRedirect
+#
+# The client secret is read interactively (hidden) and written only to a
+# temp YAML that is deleted on exit -- it never touches shell history.
+#
+# Usage:  ./scripts/attach_quantui_iap_oauth.sh
+#
+set -euo pipefail
+
+PROJECT="quantcore-test-20260606"
+REGION="us-central1"
+SERVICE="quantui"
+
+read -r -p "OAuth Client ID: " CLIENT_ID
+read -r -s -p "OAuth Client secret (hidden): " CLIENT_SECRET
+echo
+
+if [[ -z "${CLIENT_ID}" || -z "${CLIENT_SECRET}" ]]; then
+  echo "ERROR: client id and secret are both required." >&2
+  exit 1
+fi
+
+TMP_YAML="$(mktemp -t iap_settings.XXXXXX.yaml)"
+cleanup() { rm -f "${TMP_YAML}"; }
+trap cleanup EXIT
+
+cat > "${TMP_YAML}" <<YAML
+access_settings:
+  oauth_settings:
+    client_id: ${CLIENT_ID}
+    client_secret: ${CLIENT_SECRET}
+YAML
+
+echo "==> Applying IAP OAuth settings to ${SERVICE} (${PROJECT}/${REGION})"
+gcloud iap settings set "${TMP_YAML}" \
+  --resource-type=cloud-run \
+  --service="${SERVICE}" \
+  --region="${REGION}" \
+  --project="${PROJECT}"
+
+echo "Done. (temp YAML shredded)"

--- a/scripts/grant_quantui_iap_access.sh
+++ b/scripts/grant_quantui_iap_access.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Grant the dev team roles/iap.httpsResourceAccessor on the quantui Cloud Run
+# service (direct IAP integration) so they can log in through IAP.
+#
+# Each account ALSO needs to be a test user on the OAuth consent screen
+# (Console -> APIs & Services -> OAuth consent screen -> Audience -> Add users)
+# while the app is in "Testing" status. Both must match for login to succeed.
+#
+# Usage:  ./scripts/grant_quantui_iap_access.sh
+#
+set -euo pipefail
+
+PROJECT="quantcore-test-20260606"
+REGION="us-central1"
+SERVICE="quantui"
+ROLE="roles/iap.httpsResourceAccessor"
+
+USERS=(
+  "funkjohn@gmail.com"
+  "jlsager@csuchico.edu"
+  "john@johnfunk.com"
+  "musicalmacdonald@gmail.com"
+  "superdavidabrown@gmail.com"
+)
+
+for u in "${USERS[@]}"; do
+  echo "==> Granting ${ROLE} to ${u} on ${SERVICE} (${PROJECT}/${REGION})"
+  gcloud iap web add-iam-policy-binding \
+    --resource-type=cloud-run \
+    --service="${SERVICE}" \
+    --region="${REGION}" \
+    --project="${PROJECT}" \
+    --member="user:${u}" \
+    --role="${ROLE}"
+done
+
+echo
+echo "Done. Current IAP IAM policy for ${SERVICE}:"
+gcloud iap web get-iam-policy \
+  --resource-type=cloud-run \
+  --service="${SERVICE}" \
+  --region="${REGION}" \
+  --project="${PROJECT}"


### PR DESCRIPTION
Hardens the Express proxy so a stray newline in the QUANTCORE_API_TOKEN secret can't crash the process (ERR_INVALID_CHAR →
  503 storm). Trims the token at read time; protects prod too.