### PR TITLE
QuantUI/IAP Step 8: prod-rollout wiring + parameterized IAP scripts

### DIFF
--- a/.github/workflows/prod-rollout.yml
+++ b/.github/workflows/prod-rollout.yml
@@ -111,7 +111,7 @@ jobs:
           gcloud auth configure-docker "$REGION-docker.pkg.dev" --quiet
           TAG="${{ github.event.inputs.image_tag || github.event.release.tag_name }}"
           echo "Promoting tag '$TAG' from $TEST_PROJECT -> $PROD_PROJECT"
-          for img in quantcore-api quantcore-mcp quantcore-report; do
+          for img in quantcore-api quantcore-mcp quantcore-report quantcore-ui; do
             SRC_TAGGED="$REGION-docker.pkg.dev/$TEST_PROJECT/$AR_REPO/$img:$TAG"
             # Resolve the immutable source-manifest digest so the copy + deploy reference
             # exact bytes.
@@ -150,3 +150,12 @@ jobs:
         run: |
           gcloud run jobs update quantcore-report --project "$PROD_PROJECT" --region "$REGION" \
             --image "$REGION-docker.pkg.dev/$PROD_PROJECT/$AR_REPO/quantcore-report@$QUANTCORE_REPORT_DIGEST"
+
+      - name: Deploy quantui (prod, image-only)
+        # First prod deploy of quantui is MANUAL with full config (--iap,
+        # --no-allow-unauthenticated, QUANTCORE_REST_URL, quantui-api-token secret) — see
+        # quantui-iap-plan.md Step 8. This image-only redeploy preserves that config, like
+        # the api/wrappers above; it only runs once the service already exists.
+        run: |
+          gcloud run deploy quantui --project "$PROD_PROJECT" --region "$REGION" \
+            --image "$REGION-docker.pkg.dev/$PROD_PROJECT/$AR_REPO/quantcore-ui@$QUANTCORE_UI_DIGEST"

--- a/scripts/attach_quantui_iap_oauth.sh
+++ b/scripts/attach_quantui_iap_oauth.sh
@@ -12,13 +12,16 @@
 # The client secret is read interactively (hidden) and written only to a
 # temp YAML that is deleted on exit -- it never touches shell history.
 #
-# Usage:  ./scripts/attach_quantui_iap_oauth.sh
+# Usage:  ./scripts/attach_quantui_iap_oauth.sh [PROJECT [REGION [SERVICE]]]
+#   Defaults to the TEST project; pass quantcore-prod-20260606 to attach in prod
+#   (each project needs its OWN custom OAuth client).
+#   e.g.  ./scripts/attach_quantui_iap_oauth.sh quantcore-prod-20260606
 #
 set -euo pipefail
 
-PROJECT="quantcore-test-20260606"
-REGION="us-central1"
-SERVICE="quantui"
+PROJECT="${1:-quantcore-test-20260606}"
+REGION="${2:-us-central1}"
+SERVICE="${3:-quantui}"
 
 read -r -p "OAuth Client ID: " CLIENT_ID
 read -r -s -p "OAuth Client secret (hidden): " CLIENT_SECRET

--- a/scripts/grant_quantui_iap_access.sh
+++ b/scripts/grant_quantui_iap_access.sh
@@ -7,13 +7,15 @@
 # (Console -> APIs & Services -> OAuth consent screen -> Audience -> Add users)
 # while the app is in "Testing" status. Both must match for login to succeed.
 #
-# Usage:  ./scripts/grant_quantui_iap_access.sh
+# Usage:  ./scripts/grant_quantui_iap_access.sh [PROJECT [REGION [SERVICE]]]
+#   Defaults to the TEST project; pass quantcore-prod-20260606 to grant in prod.
+#   e.g.  ./scripts/grant_quantui_iap_access.sh quantcore-prod-20260606
 #
 set -euo pipefail
 
-PROJECT="quantcore-test-20260606"
-REGION="us-central1"
-SERVICE="quantui"
+PROJECT="${1:-quantcore-test-20260606}"
+REGION="${2:-us-central1}"
+SERVICE="${3:-quantui}"
 ROLE="roles/iap.httpsResourceAccessor"
 
 USERS=(


### PR DESCRIPTION
Parameterizes the two IAP helper scripts to take a PROJECT arg (default test) and adds quantcore-ui to prod-rollout.yml
  (promote-by-digest + image-only deploy). Groundwork for promoting QuantUI into quantcore-prod-20260606; the first prod deploy stays
  manual with full IAP/secret config.