### PR TITLE
Docs: make prod the system of record + prod MCP token how-to

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,39 @@ Positions are DB-backed with multi-owner support (`positions` table, `owner` col
 
 **Refactor status:** Phase 1 of architectural-standard-v2 (services-layer extraction) is **complete** — see [`docs/proposals/phase1-migration-plan.md`](docs/proposals/phase1-migration-plan.md) for the checkpoint log. Phase 2 (FastAPI/Pydantic REST tier) is **complete** — the Flask app (`api/app.py`) has been retired and rebuilt on FastAPI (app factory `api/main.py`, route groups under `api/routers/*`, Pydantic request/response schemas under `api/schemas/*`), preserving every route path and JSON shape so the React front end runs unmodified; OpenAPI docs are served at `/docs` and the spec at `/openapi.json`. See [`docs/proposals/phase2-fastapi-plan.md`](docs/proposals/phase2-fastapi-plan.md) for the checkpoint log. Run it with `uvicorn api.main:app --host 127.0.0.1 --port 5001` (or `python -m api.main`). Phase 3 (AI gateway + GCP deployment) is **complete on the test project** — see [`docs/proposals/phase3-gateway-plan.md`](docs/proposals/phase3-gateway-plan.md): the five MCP servers (`fastMCPTest/*_server.py`, `options_analysis.py`) were inverted into thin **HTTP gateway wrappers** that call the REST tier through the single seam `mcp_gateway/rest_client.py` (Rule 6 — `AI Agent → MCP wrapper → REST tier → Service`); `api/auth.py` adds JWT verification (inert until a key is configured, so local/compose stay open); everything is containerized (`Dockerfile.{api,mcp,report}`, `docker-compose.yml` local stack) and deployed to **GCP Cloud Run** — `quantcore-api` (JWT-enforced) + 5 wrapper services + `main.py` as a daily Cloud Run **Job** on Cloud Scheduler (in-process services, never HTTP). CI/CD is `.github/workflows/deploy.yml` (tests + wrapper smoke + OpenAPI surface diff, then build/roll-out; push/PR triggers are gated by a `preflight` job that skips the deploy when the test-WIF secrets are absent — wire them with `scripts/setup_test_wif.sh`). **Production rollout is COMPLETE** — see [`docs/proposals/prod-rollout-plan.md`](docs/proposals/prod-rollout-plan.md): rather than a test-service DSN flip, the same stack was stood up in a **dedicated prod project** `quantcore-prod-20260606` (project # `127961694257`, `us-central1`) reaching its own prod Cloud SQL — `quantcore-api` (JWT-enforced) + 5 wrapper services + the report Cloud Run Job on Cloud Scheduler, on images **copied by digest** test→prod (api `ac5cd17f…`, mcp `1b7da905…`, report `65d70659…`). Gated prod CI/CD is `.github/workflows/prod-rollout.yml` (`workflow_dispatch`/`release`, `prod` GitHub Environment with required reviewers, separate prod WIF). `.mcp.json` points AI clients at the prod wrapper `/mcp` URLs (`https://quantcore-<svc>-127961694257.us-central1.run.app`, bearer `${QUANTCORE_MCP_TOKEN}`); the 5 `*-local` entries remain for the docker-compose stack. The deferred `portfolio/yfinance_gateway.py` `get_latest_prices` fragility is now **hardened** (retry/back-off + graceful all-None degrade so a flaky Yahoo response no longer crashes the daily report); rebuilding/redeploying the prod report image with this fix is a pending user/CI step.
 
+### QuantUI front end on Cloud Run (behind IAP)
+
+The React SPA (`frontend/`) is deployed as the **QuantUI** Cloud Run service in both projects,
+gated by **Identity-Aware Proxy (IAP)** so the team reaches the real UI from anywhere with no auth
+code in the app — see [`docs/proposals/quantui-iap-plan.md`](docs/proposals/quantui-iap-plan.md)
+(status: **COMPLETE, Steps 1–8**). Live URLs:
+
+- **Test:** `https://quantui-uikpdb55ea-uc.a.run.app` (`quantcore-test-20260606`)
+- **Prod:** `https://quantui-swgixldxzq-uc.a.run.app` (`quantcore-prod-20260606`)
+
+**Serving model:** `Dockerfile.ui` builds `frontend/dist/` and runs a tiny Express server
+(`frontend/server/server.mjs`) that serves the static bundle (SPA fallback) and **reverse-proxies
+`/api/*` to `quantcore-api`, injecting the app JWT server-side** from the `quantui-api-token` Secret
+Manager secret. The browser stays same-origin (no CORS) and never sees the bearer — the production
+equivalent of the Vite dev proxy. IAP gates *who can load the UI*; the app JWT authenticates the
+UI→API hop. Each project has its own `quantui-api-token` (signed with that project's
+`QUANTCORE_JWT_SECRET`) and its own custom OAuth client (standalone projects can't auto-provision
+one; attach via `scripts/attach_quantui_iap_oauth.sh`).
+
+**Deploy workflow for a UI change:** edit `frontend/` → PR → merge to `main`. `deploy.yml` (no path
+filters) builds `quantcore-ui` (`build-ui` step in `cloudbuild.yaml`) and image-only-rolls it onto
+the **test** `quantui` service automatically (IAP/secret/env config preserved). Verify on the test
+URL, then promote to **prod** by manually dispatching `prod-rollout.yml` (`workflow_dispatch`) with
+the commit's 7-char SHA — it copies the image **by digest** test→prod and image-only-deploys prod
+`quantui`. Prod is never auto-deployed.
+
+**Granting a new user:** while the OAuth consent screen is in "Testing", an account must be on BOTH
+(1) the consent screen **Audience** test-user list and (2) hold `roles/iap.httpsResourceAccessor`
+on `quantui`. Add the email to the `USERS=( … )` array in `scripts/grant_quantui_iap_access.sh` and
+run it per project (`./scripts/grant_quantui_iap_access.sh` for test;
+`./scripts/grant_quantui_iap_access.sh quantcore-prod-20260606` for prod), plus add them to the
+Audience tab in Console. Both are required — only one results in a blocked login.
+
 ## Configuration
 
 - **`.env`** — `QUANTCORE_DB_DSN` is the PostgreSQL connection string for the unified database (e.g. `postgresql://<user>:<password>@<host>:<port>/<database>`); `QUANTCORE_TEST_DB_DSN` optionally points the same code at an isolated database for testing; `DISCORD_WEBHOOK_URL` for notifications; `BUCKET_NAME`/`BUCKET_KEY` for optional S3 upload.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,23 @@ run it per project (`./scripts/grant_quantui_iap_access.sh` for test;
 `./scripts/grant_quantui_iap_access.sh quantcore-prod-20260606` for prod), plus add them to the
 Audience tab in Console. Both are required — only one results in a blocked login.
 
+### Environments (prod is the system of record)
+
+**Prod (`quantcore-prod-20260606`) is the system of record for all analysis for all users; test
+(`quantcore-test-20260606`) is for development and CI only.** This supersedes the earlier "do
+analysis on test, treat prod as read-only" operating rule — now that changes ship through CI/CD
+(`deploy.yml` → test, `prod-rollout.yml` → prod), prod is the live system everyone reads from. The
+deployed `quantui` UI and the `.mcp.json` AI-client remotes both already target prod.
+
+The 5 remote MCP servers in `.mcp.json` send `Authorization: Bearer ${QUANTCORE_MCP_TOKEN}`, which
+the wrappers forward unchanged to `quantcore-api` (identity passthrough → HS256 JWT in
+`api/auth.py`). So real analysis requires `QUANTCORE_MCP_TOKEN` to be a valid prod JWT in the
+environment Claude Code launches from; if it's unset, every data tool returns `401: … Not enough
+segments` (the wrapper-local `mcp_health_check` still passes, which is misleading). Each user mints
+their own 3-month token with `scripts/mint_prod_jwt.py --output export --expires-hours 2160 --sub
+<you>` (see readme "Connecting AI clients to prod"). **When onboarding a user, remind them the token
+expires after 90 days and recommend quarterly rotation** (and a per-user `--sub`).
+
 ## Configuration
 
 - **`.env`** — `QUANTCORE_DB_DSN` is the PostgreSQL connection string for the unified database (e.g. `postgresql://<user>:<password>@<host>:<port>/<database>`); `QUANTCORE_TEST_DB_DSN` optionally points the same code at an isolated database for testing; `DISCORD_WEBHOOK_URL` for notifications; `BUCKET_NAME`/`BUCKET_KEY` for optional S3 upload.

--- a/readme.md
+++ b/readme.md
@@ -200,6 +200,85 @@ npm run build      # output goes to frontend/dist/
 
 ---
 
+## QuantUI on Cloud Run (behind IAP)
+
+The same React app is deployed as a hosted service (**QuantUI**) so the team can reach the real UI
+from anywhere, gated by their Google accounts via **Identity-Aware Proxy (IAP)** — no auth code in
+the app. It runs in both projects:
+
+| Environment | URL | Project | Auto-deploy? |
+|-------------|-----|---------|--------------|
+| **Test** | https://quantui-uikpdb55ea-uc.a.run.app | `quantcore-test-20260606` | **Yes** — every push to `main` |
+| **Prod** | https://quantui-swgixldxzq-uc.a.run.app | `quantcore-prod-20260606` | **No** — manual promotion only |
+
+### How it's served
+
+The SPA is *not* served by Vite in production. `Dockerfile.ui` builds `frontend/dist/` and runs a
+tiny Express server (`frontend/server/server.mjs`) that:
+
+- serves the static `dist/` bundle (with SPA `index.html` fallback), and
+- reverse-proxies `/api/*` to `quantcore-api`, injecting the app JWT **server-side** from Secret
+  Manager (`quantui-api-token`).
+
+So the browser stays same-origin (no CORS) and the bearer token **never reaches the client** — the
+production equivalent of the Vite dev proxy. IAP gates *who can load the UI*; the app JWT
+authenticates the UI→API hop. Each project has its own `quantui-api-token` secret (signed with that
+project's `QUANTCORE_JWT_SECRET`) and its own custom OAuth client.
+
+### Workflow for a UI change
+
+1. **Edit** under `frontend/` and open a PR against `main`.
+2. **Merge to `main`.** This triggers `.github/workflows/deploy.yml` (no path filters, so any push to
+   `main` qualifies). The `gate` job runs tests + smoke; then `cloudbuild.yaml`'s `build-ui` step
+   builds `quantcore-ui:<sha>` and the **Deploy quantui** step image-only-rolls it onto the **test**
+   service (IAP + secret + `QUANTCORE_REST_URL` config is preserved across redeploys).
+3. **Verify on test** — open the test URL above in the browser, confirm the data grids populate.
+4. **Promote to prod** — run the **`prod-rollout`** GitHub Action (`workflow_dispatch`) with that
+   commit's 7-char SHA as `image_tag`. It copies the validated image **by digest** test→prod and
+   image-only-deploys the prod `quantui` service. Prod is **never** auto-deployed; it requires this
+   manual, reviewer-gated dispatch.
+
+> Note: because `deploy.yml` has no path filters, *any* push to `main` (not just `frontend/` changes)
+> rebuilds and redeploys all services, including a fresh `quantui` revision. Harmless, just expect the
+> revision counter to climb on every merge.
+
+### Granting a new user access
+
+While the OAuth consent screen is in **Testing** status, an account needs to be on **two** lists for
+login to succeed:
+
+1. **OAuth consent test user** — Console → APIs & Services → OAuth consent screen → **Audience** →
+   *Add users* (add the account in the relevant project).
+2. **IAP accessor role** — `roles/iap.httpsResourceAccessor` on the `quantui` service.
+
+Add the email to the `USERS=( … )` array in `scripts/grant_quantui_iap_access.sh`, then run it per
+project (defaults to test; pass the prod project to grant there):
+
+```bash
+./scripts/grant_quantui_iap_access.sh                          # test
+./scripts/grant_quantui_iap_access.sh quantcore-prod-20260606  # prod
+```
+
+Both the Audience entry **and** the IAM grant must be present — having only one results in a blocked
+login. (One-time per project: attaching the custom OAuth client is done with
+`scripts/attach_quantui_iap_oauth.sh`.)
+
+### Running the serving container locally
+
+```bash
+docker build -f Dockerfile.ui -t quantui:dev .
+docker run --rm -p 8080:8080 \
+  -e QUANTCORE_REST_URL=http://host.docker.internal:5001 \
+  -e PORT=8080 \
+  quantui:dev
+# → UI at http://localhost:8080, proxying /api/* to a local uvicorn api.main:app
+```
+
+The `docker-compose.yml` stack also includes a `quantui` service for full local parity (no token,
+since the compose api runs `AUTH_DISABLED=1`).
+
+---
+
 ## Starting Both Servers Together (Mac)
 
 `runUI-MAC.sh` is a convenience script that launches both the API and frontend servers in the background from a single command.

--- a/readme.md
+++ b/readme.md
@@ -101,6 +101,21 @@ The application uses a unified **PostgreSQL** database (codename **QuantCore**, 
 python scripts/migrate_sqlite_to_postgres.py --sqlite data/quantcore.sqlite --dsn "$QUANTCORE_DB_DSN"
 ```
 
+### Environments (prod vs test)
+
+There are two GCP environments, and the rule is simple:
+
+| Environment | Project | Role |
+|-------------|---------|------|
+| **Prod** | `quantcore-prod-20260606` | **System of record.** All users and all analysis run against prod. |
+| **Test** | `quantcore-test-20260606` | **Development and CI only** — never the place to do real analysis. |
+
+Now that changes ship through a CI/CD pipeline (`deploy.yml` → test, `prod-rollout.yml` → prod),
+prod is the live system everyone reads from. The deployed `quantui` UI and the `.mcp.json` AI-client
+remotes both already target prod; connecting an AI client just needs a prod token (see
+[Connecting AI clients to prod](#connecting-ai-clients-to-prod-mcp-token)). Reserve test for
+developing and validating changes before they're promoted.
+
 ## Usage
 
 ### Basic Portfolio Analysis
@@ -263,6 +278,12 @@ Both the Audience entry **and** the IAM grant must be present — having only on
 login. (One-time per project: attaching the custom OAuth client is done with
 `scripts/attach_quantui_iap_oauth.sh`.)
 
+> **Full onboarding is now two things:** (a) **UI access** via the IAP grant above, **and** (b) an
+> AI-client **prod MCP token** so their Claude/agent can call the analysis tools — have them mint
+> their own as described in
+> [Connecting AI clients to prod](#connecting-ai-clients-to-prod-mcp-token). Remind them the token
+> expires after **90 days** and should be rotated quarterly (re-run the mint command).
+
 ### Running the serving container locally
 
 ```bash
@@ -370,6 +391,39 @@ at `http://localhost:5001` (the published api port) and it runs unchanged.
 ## MCP Intelligence Layer (`fastMCPTest/`)
 
 A suite of **FastMCP servers** that expose real-time market analysis as tools consumable by AI agents (Claude Code, custom agents, or any MCP-compatible client). The servers provide the analytical backbone for the `get_trade_recommendation` tool described below.
+
+### Connecting AI clients to prod (MCP token)
+
+The repo's `.mcp.json` already points the five remote servers at the **prod** wrapper URLs
+(`https://quantcore-<svc>-swgixldxzq-uc.a.run.app/mcp`), each sending
+`Authorization: Bearer ${QUANTCORE_MCP_TOKEN}`. The wrappers do **identity passthrough** — they
+forward that bearer to `quantcore-api`, which enforces an HS256 JWT (`api/auth.py`). So the only
+thing each team member supplies is their own prod token in `QUANTCORE_MCP_TOKEN`; without it every
+data tool returns `401: … Not enough segments`.
+
+**Prereq:** `gcloud auth login` with an account that can read the `quantcore-jwt-secret` secret in
+`quantcore-prod-20260606` (the mint script fetches the signing secret from Secret Manager and never
+prints it).
+
+Mint a **3-month** prod JWT for yourself and load it into the shell environment Claude Code launches
+from (the token is a live bearer — it's redirected straight to a file in `$HOME`, never printed to
+the terminal):
+
+```bash
+# --sub is your owner partition (use your name; defaults to john). 2160h = 90 days.
+python scripts/mint_prod_jwt.py --output export --expires-hours 2160 --sub <you> > ~/.quantcore_mcp.env
+chmod 600 ~/.quantcore_mcp.env
+echo 'source ~/.quantcore_mcp.env' >> ~/.zshrc   # so every new shell inherits it
+```
+
+Then **restart Claude Code from a fresh shell** — `.mcp.json` reads `${QUANTCORE_MCP_TOKEN}` from
+the process environment at startup, so a var exported in a child shell won't reach an
+already-running client. Verify by running any prod data tool (e.g. `get_short_interest AAPL`); you
+should get data, not a 401.
+
+> **Token lifetime:** this token expires after **90 days** — re-run the mint command to rotate it.
+> `~/.quantcore_mcp.env` is outside the repo and must **never** be committed. Each team member mints
+> their own with their own `--sub`; don't share tokens.
 
 ### Servers
 


### PR DESCRIPTION
Documents prod (quantcore-prod-20260606) as the system of record for all analysis, supersedes the test-only operating rule, and
  adds the prod MCP token minting/rotation how-to. Verified: newly minted prod JWT authenticates against the prod MCP servers (live data call
  succeeds).