### PR TITLE
Fix OHLCV corruption: serialize yf.download (not thread-safe)

### DIFF
--- a/quantcore/repositories/ohlcv_repository.py
+++ b/quantcore/repositories/ohlcv_repository.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import datetime
 import enum
 import logging
+import threading
 from contextlib import closing
 from dataclasses import dataclass
 from typing import Optional
@@ -277,20 +278,29 @@ def _query_cache(symbol: str, interval: str, days: int) -> pd.DataFrame:
 # yfinance fetch
 # ---------------------------------------------------------------------------
 
+# yf.download() is NOT thread-safe: results pass through module-global state
+# (yfinance.shared._DFS), so concurrent calls can hand one ticker's bars to
+# another ticker. Callers such as refresh_options_snapshots fetch from a
+# ThreadPoolExecutor, which corrupted the OHLCV table with cross-ticker rows
+# (2026-06-30 and 2026-07-02 prod incidents). Serialize every download.
+_YF_DOWNLOAD_LOCK = threading.Lock()
+
+
 def _fetch_yfinance(symbol: str, interval: str, days: int) -> pd.DataFrame:
     """Download from yfinance, capped at _MAX_FETCH_DAYS."""
     fetch_days = min(days, _MAX_FETCH_DAYS)
     end   = datetime.datetime.utcnow()
     start = end - datetime.timedelta(days=fetch_days)
     logger.debug("yfinance fetch: %s %s start=%s end=%s", symbol, interval, start.date(), end.date())
-    df = yf.download(
-        symbol,
-        start=start.strftime("%Y-%m-%d"),
-        end=end.strftime("%Y-%m-%d"),
-        interval=interval,
-        auto_adjust=True,
-        progress=False,
-    )
+    with _YF_DOWNLOAD_LOCK:
+        df = yf.download(
+            symbol,
+            start=start.strftime("%Y-%m-%d"),
+            end=end.strftime("%Y-%m-%d"),
+            interval=interval,
+            auto_adjust=True,
+            progress=False,
+        )
     if df.empty:
         logger.warning("yfinance returned no data for %s/%s", symbol, interval)
         return pd.DataFrame(columns=["Open", "High", "Low", "Close", "Volume"])

--- a/scripts/repair_ohlcv_misalignment.py
+++ b/scripts/repair_ohlcv_misalignment.py
@@ -1,0 +1,90 @@
+"""One-off repair for the 2026-06-30 OHLCV symbol-misalignment corruption.
+
+A bulk ingest on 2026-06-30 ~20:10-20:13 UTC wrote misaligned price data to
+prod: groups of unrelated symbols received byte-identical OHLCV bars (e.g.
+INTC=MRVL=POWL=SOLS all got one ticker's bar). This re-fetches each affected
+symbol individually through the proven-correct single-symbol path
+(_fetch_yfinance -> _store_bars, ON CONFLICT DO UPDATE) and overwrites the bad
+rows in place. Re-fetching a healthy symbol is harmless (idempotent upsert).
+
+Usage:
+    .venv/bin/python scripts/repair_ohlcv_misalignment.py            # repair
+    .venv/bin/python scripts/repair_ohlcv_misalignment.py --dry-run  # report only
+
+Targets whatever QUANTCORE_DB_DSN points at (prod via the :5433 proxy here).
+"""
+import argparse
+import datetime as dt
+import sys
+import time
+from contextlib import closing
+
+from dotenv import load_dotenv
+
+load_dotenv("/Users/thomasfowler/source/com/thomasdfowler/StockPortfolioManager/.env")
+
+from quantcore.db import get_connection
+from quantcore.repositories.ohlcv_repository import _fetch_yfinance, _store_bars
+
+WARM_DAYS = 730
+
+
+def affected_symbols() -> list[str]:
+    """Symbols with at least one daily bar ingested on a corruption date.
+
+    2026-06-30: original incident (UI Refresh All -> threaded chain refresh).
+    2026-07-02: recurrence before the yf.download lock landed.
+    """
+    with closing(get_connection()) as conn:
+        rows = conn.execute(
+            """
+            SELECT DISTINCT symbol
+            FROM ohlcv
+            WHERE interval = '1d'
+              AND to_timestamp(ingested_at)::date IN (DATE '2026-06-30', DATE '2026-07-02')
+            ORDER BY symbol
+            """
+        ).fetchall()
+    return [r[0] for r in rows]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dry-run", action="store_true", help="List targets, fetch, but do not write")
+    ap.add_argument("--sleep", type=float, default=0.4, help="Seconds between symbols (rate-limit guard)")
+    args = ap.parse_args()
+
+    symbols = affected_symbols()
+    print(f"[{dt.datetime.now():%H:%M:%S}] affected symbols: {len(symbols)}  dry_run={args.dry_run}")
+
+    ok = empty = failed = 0
+    for i, sym in enumerate(symbols, 1):
+        try:
+            df = _fetch_yfinance(sym, "1d", WARM_DAYS)
+            if df.empty:
+                empty += 1
+                print(f"  [{i}/{len(symbols)}] {sym:8} EMPTY (yfinance returned nothing)")
+                continue
+            last_close = float(df["Close"].iloc[-1])
+            last_date = df.index[-1].date()
+            # Sanity guard: a non-positive close is never valid.
+            if last_close <= 0:
+                failed += 1
+                print(f"  [{i}/{len(symbols)}] {sym:8} SKIP (non-positive close {last_close})")
+                continue
+            if not args.dry_run:
+                _store_bars(sym, "1d", df)
+            ok += 1
+            if i % 25 == 0 or i == len(symbols):
+                print(f"  [{i}/{len(symbols)}] {sym:8} {len(df)} bars  last={last_date} close={last_close:.2f}  (ok={ok})")
+        except Exception as exc:  # noqa: BLE001 - one-off repair, keep going
+            failed += 1
+            print(f"  [{i}/{len(symbols)}] {sym:8} FAILED: {type(exc).__name__}: {exc}")
+        time.sleep(args.sleep)
+
+    print(f"[{dt.datetime.now():%H:%M:%S}] DONE  repaired={ok}  empty={empty}  failed={failed}")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Incident
Prod OHLCV was corrupted twice (2026-06-30 ~20:10 UTC, 2026-07-02): 200+ symbols' daily bars rewritten with **other tickers' data**, in byte-identical groups of exactly 4 (e.g. `INTC=MRVL=POWL=SOLS`, `GOOG=MSFT=MU=PATH` — full OHLCV+volume identical). Symptom in the UI: wrong/blank prices in the Securities view; screener returned nonsense (`MSFT last_close=10.68`).

## Root cause
`refresh_options_snapshots` (wired to the UI **Refresh All** button) fetches chains from a `ThreadPoolExecutor(max_workers=4)`. Each fetch computes Bollinger bands → `get_history` → on a stale cache, `_fetch_yfinance` runs `yf.download` **concurrently in 4 threads**. `yf.download` is not thread-safe — results pass through module-global state (`yfinance.shared._DFS`), so concurrent calls read each other's frames. `_store_bars` then upserts the wrong ticker's history. `max_workers=4` ⇒ corrupted rows in groups of 4. Caught live on 2026-07-02: `CORRECTED bar detected: AMZN cached=240.14 new=26.57` with NET receiving the same closes.

## Fix
Module-level `threading.Lock` in `_fetch_yfinance` serializing every `yf.download` call, regardless of caller. Chain fetching stays parallel; only the OHLCV download is serialized.

## Repair
`scripts/repair_ohlcv_misalignment.py` re-fetches every symbol with bars ingested on the two corruption dates through the (now-serialized) single-symbol path — idempotent `ON CONFLICT DO UPDATE`, non-positive-close guard, `--dry-run` supported. Run once against prod after merge (or from a local checkout via the :5433 proxy).

## Deploy urgency
The deployed prod `quantcore-api` image predates this fix — **any Refresh All click in QuantUI re-corrupts prod OHLCV** until this ships (`deploy.yml` → test, then `prod-rollout.yml`). Re-run the repair after the fixed image is live if the button may have been used in between.

🤖 Generated with [Claude Code](https://claude.com/claude-code)