### PR TITLE
Fix CI deploy race and local-stack Anthropic key quoting

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,15 @@ on:
     branches: [main]
   pull_request:
 
+# Serialize deploys per ref so back-to-back merges to main don't race on the same
+# Cloud Run services (concurrent `gcloud run deploy` on one service ABORTs with an
+# optimistic-lock "version was specified but current version is …" conflict). A new
+# run waits for the in-flight one to finish rather than cancelling it mid-rollout.
+# Keyed by ref, so PR gate runs (distinct refs) still run in parallel with main.
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   PROJECT_ID: quantcore-test-20260606
   REGION: us-central1

--- a/.github/workflows/prod-rollout.yml
+++ b/.github/workflows/prod-rollout.yml
@@ -44,6 +44,13 @@ on:
   release:
     types: [published]
 
+# Serialize prod rollouts so two dispatches/releases can't race on the same Cloud Run
+# services (concurrent `gcloud run deploy` ABORTs with an optimistic-lock conflict).
+# A new run waits for the in-flight one rather than cancelling a mid-rollout deploy.
+concurrency:
+  group: prod-rollout
+  cancel-in-progress: false
+
 env:
   TEST_PROJECT: quantcore-test-20260606
   PROD_PROJECT: quantcore-prod-20260606

--- a/scripts/restart_local_stack.sh
+++ b/scripts/restart_local_stack.sh
@@ -45,6 +45,9 @@ pkill -f "uvicorn api.main:app" 2>/dev/null
 sleep 2
 source .venv/bin/activate
 KEY="$(grep '^ANTHROPIC_API_KEY=' .env | cut -d= -f2- || true)"
+# .env may quote the value (ANTHROPIC_API_KEY="sk-ant-..."); strip surrounding
+# quotes so they don't end up INSIDE the key and cause a 401 invalid x-api-key.
+KEY="${KEY%\"}"; KEY="${KEY#\"}"; KEY="${KEY%\'}"; KEY="${KEY#\'}"
 ANTHROPIC_API_KEY="$KEY" nohup uvicorn api.main:app --host 127.0.0.1 --port 5001 \
     > "$REPO/api.log" 2>&1 &
 echo "  API starting (slow first boot is normal)..."


### PR DESCRIPTION
  deploy.yml/prod-rollout.yml: add concurrency guards so back-to-back
  merges (or dispatches) don't run concurrent `gcloud run deploy` on the
  same Cloud Run services. Two close merges to main previously raced and
  one aborted with an optimistic-lock conflict ("version was specified but
  current version is …"). deploy serializes per-ref (PR gates still run in
  parallel); prod-rollout serializes on a single fixed group.

  restart_local_stack.sh: strip surrounding quotes from ANTHROPIC_API_KEY
  when extracting it from .env. A quoted value (KEY="sk-ant-...") left the
  quotes inside the key passed to uvicorn, so the chat sidekick got 401
  invalid x-api-key.
