### PR TITLE
Arch v2: extract AnthropicChatClient into quantcore/gateways (closes #78)

### DIFF
--- a/quantcore/gateways/anthropic_gateway.py
+++ b/quantcore/gateways/anthropic_gateway.py
@@ -1,0 +1,48 @@
+"""Anthropic provider gateway — streams chat-sidekick model turns.
+
+Architectural-standard-v2 §5.3: external-system adapters (API calls, streaming,
+error surfaces) live here, never in services. ChatService depends on the
+ChatClient protocol (quantcore/services/chat.py) and receives this class via
+its default client factory; tests and CHAT_FAKE inject substitutes.
+
+IMPORTANT — lazy SDK import, deliberate deviation from eager registry
+construction: requirements-base images (the 5 MCP wrappers, the report job,
+and CI) do not ship the ``anthropic`` package — only the API image installs
+requirements-ml.txt. This module must therefore import cleanly without the
+SDK, and the SDK loads only when a client is actually constructed (i.e. on
+the first real /api/chat turn). Guarded by test_anthropic_gateway.py.
+"""
+from __future__ import annotations
+
+
+class AnthropicChatClient:
+    """Real client: streams one model turn via the Anthropic SDK."""
+
+    def __init__(self, model: str, effort: str, max_tokens: int = 8192):
+        import anthropic  # lazy — see module docstring
+
+        self._client = anthropic.Anthropic()
+        self._model = model
+        self._effort = effort
+        self._max_tokens = max_tokens
+
+    def stream_turn(self, *, system, tools, messages):
+        # claude-fable-5: omit `thinking` entirely (always on); no sampling
+        # params. Refusal fallbacks are opt-in — include them by default.
+        with self._client.beta.messages.stream(
+            model=self._model,
+            max_tokens=self._max_tokens,
+            system=system,
+            tools=tools,
+            messages=messages,
+            output_config={"effort": self._effort},
+            betas=["server-side-fallback-2026-06-01"],
+            fallbacks=[{"model": "claude-opus-4-8"}],
+        ) as stream:
+            for event in stream:
+                if (
+                    event.type == "content_block_delta"
+                    and getattr(event.delta, "type", "") == "text_delta"
+                ):
+                    yield ("delta", event.delta.text)
+            yield ("final", stream.get_final_message())

--- a/quantcore/services/chat.py
+++ b/quantcore/services/chat.py
@@ -4,9 +4,11 @@ Design notes:
   * The service depends on a minimal ChatClient protocol (``stream_turn``)
     rather than the Anthropic SDK directly, so unit tests drive the loop with
     scripted clients and CHAT_FAKE=1 swaps in FakeChatClient (chat_fake.py).
-  * IMPORTANT: never import ``anthropic`` at module top — this module is
-    reachable from quantcore.services.registry, which MCP stdio servers import
-    at startup. The SDK is lazy-imported inside AnthropicChatClient only.
+  * The real provider adapter (AnthropicChatClient) lives in
+    quantcore/gateways/anthropic_gateway.py per architectural-standard-v2
+    §5.3; it is loaded lazily via _default_client_factory so this module —
+    and the registry that imports it — never touches the SDK at import time
+    (MCP stdio servers and requirements-base images depend on that).
   * Model default is claude-fable-5: thinking is always on (the ``thinking``
     parameter must be omitted entirely), sampling params are not accepted, and
     depth is controlled via ``output_config.effort``. Server-side refusal
@@ -88,7 +90,8 @@ ChatEvent = TextDelta | ToolStatus | Directive | ErrorEvent | Done
 
 
 # ---------------------------------------------------------------------------
-# Client protocol + real Anthropic adapter
+# Client protocol (the provider adapter itself lives in
+# quantcore/gateways/anthropic_gateway.py per architectural-standard-v2 §5.3)
 # ---------------------------------------------------------------------------
 
 class ChatClient(Protocol):
@@ -99,37 +102,13 @@ class ChatClient(Protocol):
         ...
 
 
-class AnthropicChatClient:
-    """Real client: streams one model turn via the Anthropic SDK."""
+def _default_client_factory(model: str, effort: str) -> ChatClient:
+    # Late import + attribute lookup: keeps this module (and the registry that
+    # imports it) free of the SDK for requirements-base images, and lets tests
+    # patch quantcore.gateways.anthropic_gateway.AnthropicChatClient.
+    from quantcore.gateways import anthropic_gateway
 
-    def __init__(self, model: str, effort: str, max_tokens: int = 8192):
-        import anthropic  # lazy — see module docstring
-
-        self._client = anthropic.Anthropic()
-        self._model = model
-        self._effort = effort
-        self._max_tokens = max_tokens
-
-    def stream_turn(self, *, system, tools, messages):
-        # claude-fable-5: omit `thinking` entirely (always on); no sampling
-        # params. Refusal fallbacks are opt-in — include them by default.
-        with self._client.beta.messages.stream(
-            model=self._model,
-            max_tokens=self._max_tokens,
-            system=system,
-            tools=tools,
-            messages=messages,
-            output_config={"effort": self._effort},
-            betas=["server-side-fallback-2026-06-01"],
-            fallbacks=[{"model": "claude-opus-4-8"}],
-        ) as stream:
-            for event in stream:
-                if (
-                    event.type == "content_block_delta"
-                    and getattr(event.delta, "type", "") == "text_delta"
-                ):
-                    yield ("delta", event.delta.text)
-            yield ("final", stream.get_final_message())
+    return anthropic_gateway.AnthropicChatClient(model, effort)
 
 
 def _sanitize(value):
@@ -179,7 +158,7 @@ class ChatService:
         self._effort = effort
         self._max_iterations = max_iterations
         self._client_factory = client_factory or (
-            lambda: AnthropicChatClient(self._model, self._effort)
+            lambda: _default_client_factory(self._model, self._effort)
         )
         # Tool name -> bound dispatch. Positional args mirror the service
         # signatures so tests can assert exact calls.

--- a/test_anthropic_gateway.py
+++ b/test_anthropic_gateway.py
@@ -1,0 +1,75 @@
+"""Architecture-guard tests for the Anthropic provider gateway (issue #78).
+
+Per architectural-standard-v2 §5.3, external-provider adapters live in
+quantcore/gateways/. These tests pin three properties of the extraction:
+
+  1. The gateway module imports WITHOUT pulling in the anthropic SDK
+     (requirements-base images — MCP wrappers, report job, CI — don't ship it;
+     the SDK must load lazily on first client construction only).
+  2. The gateway exposes the ChatClient protocol surface (stream_turn).
+  3. quantcore/services/chat.py no longer contains any provider adapter code —
+     services hold business logic only.
+
+No test here constructs the real client (that would require the SDK + a key);
+the ChatService->gateway wiring is covered behaviorally in test_chat_service.
+"""
+import re
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent
+
+
+class TestAnthropicGatewayExtraction(unittest.TestCase):
+    def test_gateway_module_imports_without_anthropic_sdk(self):
+        code = (
+            "import sys; "
+            "import quantcore.gateways.anthropic_gateway; "
+            "assert 'anthropic' not in sys.modules, 'anthropic imported eagerly'; "
+            "print('lazy-ok')"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            cwd=REPO,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("lazy-ok", result.stdout)
+
+    def test_gateway_exposes_chat_client_protocol(self):
+        from quantcore.gateways.anthropic_gateway import AnthropicChatClient
+
+        self.assertTrue(callable(getattr(AnthropicChatClient, "stream_turn", None)))
+
+    def test_services_chat_contains_no_provider_adapter(self):
+        src = (REPO / "quantcore" / "services" / "chat.py").read_text()
+        # SDK import specifically ("import anthropic" / "from anthropic import ...");
+        # importing the gateway MODULE (anthropic_gateway) is the intended seam.
+        sdk_import = re.search(r"^\s*(import anthropic\b(?!_)|from anthropic\b(?!_))", src, re.M)
+        self.assertIsNone(sdk_import, f"SDK import found in services/chat.py: {sdk_import}")
+        self.assertNotIn("class AnthropicChatClient", src)
+
+    def test_registry_module_still_imports_lazily(self):
+        # The registry is imported by MCP stdio servers at startup; the gateway
+        # move must not make it (transitively) import the SDK.
+        code = (
+            "import sys; "
+            "import quantcore.services.registry; "
+            "assert 'anthropic' not in sys.modules, 'registry pulls anthropic'; "
+            "print('registry-ok')"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            cwd=REPO,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("registry-ok", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_chat_service.py
+++ b/test_chat_service.py
@@ -316,6 +316,28 @@ class TestFailureModes(ChatServiceTestBase):
         self.assertIsInstance(events[-1], ErrorEvent)
         self.assertFalse(any(isinstance(e, Done) for e in events))
 
+    def test_default_factory_builds_gateway_client_with_model_and_effort(self):
+        """Without an injected factory, ChatService must construct the provider
+        client from quantcore.gateways.anthropic_gateway (issue #78 wiring)."""
+        from unittest.mock import patch
+
+        with patch("quantcore.gateways.anthropic_gateway.AnthropicChatClient") as gateway_cls:
+            gateway_cls.return_value.stream_turn.return_value = iter(
+                [("final", final("end_turn", text_block("hi")))]
+            )
+            service = ChatService(
+                prices=Mock(),
+                fundamentals=Mock(),
+                sentiment=Mock(),
+                options=Mock(),
+                model="model-x",
+                effort="low",
+            )
+            events = list(service.stream_chat([{"role": "user", "content": "hey"}]))
+
+        gateway_cls.assert_called_once_with("model-x", "low")
+        self.assertIsInstance(events[-1], Done)
+
     def test_iteration_cap_terminates_with_error(self):
         looping_turn = {
             "final": final("tool_use", tool_use("tu_x", "get_rsi", {"symbol": "AMD"}))


### PR DESCRIPTION
Closes #78.

**What:** moves the Anthropic provider adapter out of `quantcore/services/chat.py` into `quantcore/gateways/anthropic_gateway.py`, per architectural-standard-v2 §5.3 (external-system adapters live in gateways; services hold business logic only). `ChatService` now depends solely on the `ChatClient` protocol plus a lazy `_default_client_factory`.

**Deliberate deviation, documented in the module docstring:** the gateway is *not* eagerly constructed in the registry (unlike `YFinanceGateway`) because `requirements-base` images — the 5 MCP wrappers, the report job, and CI — don't ship the `anthropic` SDK. The SDK loads only on first real chat-client construction. Two subprocess-based tests pin this: importing the gateway module and importing the registry must both leave `anthropic` out of `sys.modules`.

**Tests (written first):** new `test_anthropic_gateway.py` (4 architecture guards) + a behavioral wiring test in `test_chat_service.py` (default factory builds the gateway client with model/effort — patched at the gateway seam, no SDK needed). Full suite: **163 green**. Behavior-neutral: no route, protocol, or frontend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)