### PR TITLE
Arch v2: yfinance behind the gateway, everywhere (closes #74, #75, #76, #77)

### DIFF
--- a/fastMCPTest/README.md
+++ b/fastMCPTest/README.md
@@ -38,7 +38,6 @@ uses the repo virtualenv at `../.venv/bin/fastmcp`.
 | `options_position_store.py` | Library | Tracks active options positions; drives ITM, expiration, and profit-target alerts |
 | `news_store.py` | Library | PostgreSQL persistence for news articles and FinBERT sentiment scores |
 | `news_collector.py` | Library | RSS + yfinance news fetcher with lazy-loaded FinBERT scoring pipeline |
-| `collect_options.py` | CLI / Cron | EOD snapshot collector; designed to run daily at 4:10 PM ET via cron or launchd |
 | `ohlcv_cache.py` | Library | PostgreSQL-backed OHLCV bar cache; eliminates redundant yfinance calls |
 | `.mcp.json` | Config | Registers the FastMCP servers in this directory for auto-start |
 
@@ -130,27 +129,13 @@ Pass `--no-persist` to skip saving, or `--db /path/to/file.db` for a custom path
 
 ---
 
-## EOD Snapshot Collector (`collect_options.py`)
+## EOD Snapshot Collector (retired)
 
-Designed to run as a daily cron job at ~4:10 PM ET on trading days, automatically capturing an end-of-day options snapshot for every symbol in the watchlist. Exits cleanly (code 0) on non-trading days so no data is written on weekends or NYSE holidays.
-
-```bash
-python collect_options.py                        # all watchlist symbols, today
-python collect_options.py --symbols MU,WDC,GEV  # specific symbols only
-python collect_options.py --date 2026-04-01      # backfill a specific date
-python collect_options.py --dry-run              # validate config, no DB writes
-python collect_options.py --max-expirations 6    # capture 6 expirations (default 4)
-python collect_options.py --log-level DEBUG      # verbose per-contract logging
-```
-
-**Exit codes:** `0` = success; `1` = one or more symbols failed; `2` = market closed or config error.
-
-**Scheduling on macOS:** A launchd `.plist` template is embedded in the script header. Install it under `~/Library/LaunchAgents/` with `TZ=America/New_York` to fire at 4:10 PM ET.
-
-**Cron entry (4:10 PM ET, Mon–Fri):**
-```
-10 16 * * 1-5  cd /path/to/fastMCPTest && /path/to/venv/python collect_options.py
-```
+`collect_options.py` was retired in the yfinance-gateway consolidation (issues
+#74/#77): it fetched chains directly from yfinance, bypassing the gateway.
+Its capability lives in the services layer — use
+`POST /api/securities/refresh-options-snapshots?source=watchlist&chain_type=full`
+(or `OptionsService.refresh_options_snapshots` in-process) instead.
 
 ---
 

--- a/notifier.py
+++ b/notifier.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from datetime import date, datetime
 
 import requests
-import yfinance as yf
 from dotenv import load_dotenv
 from portfolio import portfolio as spm
 import portfolio.money as money
@@ -149,14 +148,15 @@ class Notifier:
         # Fetch live prices for all unique symbols in one batch
         symbols = list({p["symbol"] for p in active})
         current_prices: dict[str, float] = {}
+        # Prices via the services layer (issue #76) — adapters never import
+        # yfinance; the notifier runs in-process with main.py (Rule 6).
+        from quantcore.services.registry import get_services
+
+        prices_service = get_services().prices
         for sym in symbols:
-            try:
-                info = yf.Ticker(sym).fast_info
-                price = getattr(info, "last_price", None)
-                if price is not None and price > 0:
-                    current_prices[sym] = float(price)
-            except Exception:
-                pass
+            price = prices_service.get_fast_price(sym)
+            if price is not None:
+                current_prices[sym] = price
 
         alerts = self._options_positions.get_pending_alerts(current_prices)
 

--- a/quantcore/analytics/market_time.py
+++ b/quantcore/analytics/market_time.py
@@ -1,0 +1,68 @@
+"""Pure market-calendar helpers (no I/O) — analytics-layer utilities shared by
+
+the OHLCV persistence layer (bar OPEN/CLOSED classification at write time) and
+PricesService (fetch-when-stale policy). All functions accept an injectable
+``now`` for deterministic tests. US equities regular session only; not
+holiday-aware (same approximation the system has always used).
+"""
+from __future__ import annotations
+
+import datetime
+
+import pytz
+
+ET = pytz.timezone("America/New_York")
+
+# Mapping from yfinance period strings to calendar days.
+PERIOD_DAYS: dict[str, int] = {
+    "1d":   1,
+    "5d":   5,
+    "30d":  30,
+    "60d":  60,
+    "90d":  91,
+    "1mo":  31,
+    "3mo":  91,
+    "6mo":  182,
+    "1y":   365,
+    "2y":   730,
+    "3y":   1095,
+    "5y":   1825,
+    "10y":  3650,
+}
+
+_OPEN = datetime.time(9, 30)
+_CLOSE = datetime.time(16, 0)
+
+
+def _now_et(now: datetime.datetime | None) -> datetime.datetime:
+    if now is None:
+        return datetime.datetime.now(tz=ET)
+    return now.astimezone(ET)
+
+
+def period_to_days(period: str) -> int:
+    """Convert a yfinance period string to calendar days (default 182)."""
+    return PERIOD_DAYS.get(period.lower(), 182)
+
+
+def is_market_open(now: datetime.datetime | None = None) -> bool:
+    """Approximate regular-hours check — weekdays 9:30–16:00 ET, not holiday-aware."""
+    current = _now_et(now)
+    if current.weekday() >= 5:
+        return False
+    return _OPEN <= current.time() < _CLOSE
+
+
+def latest_completed_session(now: datetime.datetime | None = None) -> datetime.date:
+    """The most recent trading session that has *started*.
+
+    Overnight (midnight–9:30 ET) and on weekends no newer daily bar can exist,
+    so staleness checks compare against this date rather than calendar today.
+    """
+    current = _now_et(now)
+    session = current.date()
+    if current.weekday() >= 5 or current.time() < _OPEN:
+        session -= datetime.timedelta(days=1)
+    while session.weekday() >= 5:
+        session -= datetime.timedelta(days=1)
+    return session

--- a/quantcore/gateways/yfinance_gateway.py
+++ b/quantcore/gateways/yfinance_gateway.py
@@ -4,14 +4,102 @@ Architectural standard v2 §5.1: services never import yfinance directly; they
 receive this gateway via constructor injection. Methods are added as services
 migrate (Phase 1 Steps 1-8). The legacy portfolio/yfinance_gateway.py used by
 main.py's report path is separate and consolidates here in Phase 2.
+
+This module is the ONLY yf.download call site in the codebase (issue #74/#75):
+yf.download passes results through module-global state and is not thread-safe
+— concurrent calls can hand one ticker's bars to another (the July 2026 OHLCV
+corruption). Every download is serialized on _YF_DOWNLOAD_LOCK, enforced by
+test_architecture_guards.py.
 """
 
 import concurrent.futures
+import datetime
+import logging
+import threading
 
+import pandas as pd
 import yfinance as yf
+
+logger = logging.getLogger(__name__)
+
+_YF_DOWNLOAD_LOCK = threading.Lock()
+
+# Hard cap on a single fetch window (Yahoo practicality + payload sanity).
+_MAX_FETCH_DAYS = 730
+
+_OHLCV_COLS = ["Open", "High", "Low", "Close", "Volume"]
+_FIELD_NAMES = {"Open", "High", "Low", "Close", "Volume", "Adj Close",
+                "Dividends", "Stock Splits"}
+
+
+def _flatten_columns(df: pd.DataFrame) -> pd.DataFrame:
+    """yf.download returns MultiIndex columns in newer versions; flatten to
+    field names whichever level holds them."""
+    if isinstance(df.columns, pd.MultiIndex):
+        if df.columns.get_level_values(0)[0] in _FIELD_NAMES:
+            df.columns = df.columns.get_level_values(0)
+        else:
+            df.columns = df.columns.get_level_values(1)
+    return df
 
 
 class YFinanceGateway:
+    def fetch_history(
+        self,
+        symbol: str,
+        interval: str,
+        days: int,
+        auto_adjust: bool = True,
+        include_adj_close: bool = False,
+    ) -> pd.DataFrame:
+        """Single-symbol OHLCV download — the canonical history fetch seam.
+
+        Returns a DataFrame with Open/High/Low/Close/Volume (plus Adj Close
+        when requested and available), NaN-Close rows dropped; empty standard
+        frame when Yahoo returns nothing. Window capped at _MAX_FETCH_DAYS.
+        """
+        fetch_days = min(days, _MAX_FETCH_DAYS)
+        end = datetime.datetime.utcnow()
+        start = end - datetime.timedelta(days=fetch_days)
+        with _YF_DOWNLOAD_LOCK:
+            df = yf.download(
+                symbol,
+                start=start.strftime("%Y-%m-%d"),
+                end=end.strftime("%Y-%m-%d"),
+                interval=interval,
+                auto_adjust=auto_adjust,
+                progress=False,
+            )
+        if df is None or df.empty:
+            logger.warning("yfinance returned no data for %s/%s", symbol, interval)
+            return pd.DataFrame(columns=_OHLCV_COLS)
+        df = _flatten_columns(df)
+        if not set(_OHLCV_COLS).issubset(set(df.columns)):
+            logger.warning(
+                "yfinance columns unexpected for %s/%s: %s",
+                symbol, interval, list(df.columns),
+            )
+            return pd.DataFrame(columns=_OHLCV_COLS)
+        cols = list(_OHLCV_COLS)
+        if include_adj_close and "Adj Close" in df.columns:
+            cols.append("Adj Close")
+        return df[cols].dropna(subset=["Close"])
+
+    def close_thread_caches(self) -> None:
+        """Close yfinance's per-thread peewee cache DB connections.
+
+        yfinance opens one sqlite connection per thread (tkr-tz.db,
+        cookies.db) that is never closed; long-running batch work leaks file
+        descriptors without this. Safe no-op if yfinance internals change.
+        """
+        try:
+            from yfinance.cache import _CookieDBManager, _TzDBManager
+
+            _TzDBManager.close_db()
+            _CookieDBManager.close_db()
+        except Exception:  # noqa: BLE001 — provider internals, best-effort
+            pass
+
     def ticker_info(self, symbol: str, timeout: float = 15.0) -> dict:
         """Fetch ticker.info with a hard timeout to prevent callers from hanging.
 
@@ -86,8 +174,10 @@ class YFinanceGateway:
         """Bulk multi-ticker OHLCV download via yf.download() (progress suppressed).
 
         Used by relative-strength scoring, which fetches a symbol and its
-        benchmarks (SPY/QQQ/sector ETF) in a single call.
+        benchmarks (SPY/QQQ/sector ETF) in a single call. Serialized on the
+        same lock as fetch_history — yf.download is never thread-safe.
         """
-        return yf.download(
-            tickers, period=period, auto_adjust=auto_adjust, progress=False
-        )
+        with _YF_DOWNLOAD_LOCK:
+            return yf.download(
+                tickers, period=period, auto_adjust=auto_adjust, progress=False
+            )

--- a/quantcore/repositories/harvester_repository.py
+++ b/quantcore/repositories/harvester_repository.py
@@ -22,7 +22,6 @@ from typing import Any, Dict, List, Optional
 from time import time
 
 import pandas as pd
-import yfinance as yf
 from dotenv import load_dotenv
 
 # Import the plan builder from HarvesterExperiment.py (kept as the pure planner).
@@ -200,44 +199,17 @@ WHERE status = 'SUPERSEDED';
 # Data ingestion (OHLCV + adj_close)
 # -----------------------------
 
-def fetch_daily_history_ohlcv(symbol: str, days: int = 400) -> pd.DataFrame:
+def normalize_daily_bars(df: pd.DataFrame) -> pd.DataFrame:
     """
-    Fetch daily bars with yfinance: Open/High/Low/Close/Adj Close/Volume.
-
-    Notes:
-    - yfinance changed the default for auto_adjust; we set auto_adjust=False to reliably
-      receive an 'Adj Close' column.
-    - If 'Adj Close' is still unavailable for a symbol, we fall back to using 'Close'.
+    Normalize gateway-fetched daily bars for persistence: ensure Adj Close
+    (falling back to Close), require the standard column set, and reshape the
+    index into a bar_date string column. Pure — fetching happens in
+    YFinanceGateway, orchestrated by HarvesterService (issue #74).
     """
-    df = yf.download(
-        symbol,
-        period=f"{days}d",
-        interval="1d",
-        progress=False,
-        auto_adjust=False,
-    )
     if df is None or df.empty:
         return pd.DataFrame()
+    df = df.copy()
 
-    # Normalize MultiIndex (can happen for some yfinance outputs)
-    if isinstance(df.columns, pd.MultiIndex):
-        # Try common layouts. Prefer selecting the requested symbol if present.
-        lvl0 = df.columns.get_level_values(0)
-        lvl1 = df.columns.get_level_values(1)
-
-        if symbol in lvl0:
-            # symbol-first layout: (SYMBOL, Field)
-            df = df.xs(symbol, axis=1, level=0, drop_level=True)
-        elif symbol in lvl1:
-            # field-first layout: (Field, SYMBOL)
-            df = df.xs(symbol, axis=1, level=1, drop_level=True)
-        else:
-            # Fallback: take the first column block
-            df = df.droplevel(0, axis=1)
-
-    # Ensure we have the needed columns.
-    # With auto_adjust=False, yfinance typically provides: Open, High, Low, Close, Adj Close, Volume
-    # But some tickers/markets may omit Adj Close; if so, use Close.
     if "Adj Close" not in df.columns and "Close" in df.columns:
         df["Adj Close"] = df["Close"]
 
@@ -287,7 +259,7 @@ class HarvesterPlanDB:
     # Public API methods
     # -------------------------
 
-    def build_plan(self, symbol: str, template_name: str, params: PlanBuildParams) -> Dict[str, Any]:
+    def build_plan(self, symbol: str, template_name: str, params: PlanBuildParams, bars: pd.DataFrame = None) -> Dict[str, Any]:
         """
         Build a forward plan for `symbol` using the existing planner from HarvesterExperiment.py,
         persist it to SQLite, and return a summary.
@@ -313,10 +285,11 @@ class HarvesterPlanDB:
                 raise RuntimeError(f"Failed to resolve symbol_id for {symbol}")
             symbol_id = int(row["symbol_id"])
 
-        # 2) Fetch bars and upsert into ohlcv table
-        bars = fetch_daily_history_ohlcv(symbol, days=max(params.history_window_days + 60, 420))
+        # 2) Normalize caller-supplied bars and upsert into ohlcv table
+        # (HarvesterService fetches via YFinanceGateway — issue #74).
+        bars = normalize_daily_bars(bars)
         if bars.empty:
-            raise RuntimeError(f"No price history returned for {symbol}")
+            raise RuntimeError(f"No price history supplied for {symbol}")
 
         with closing(get_connection()) as conn:
             try:
@@ -571,7 +544,7 @@ class HarvesterPlanDB:
             rows = conn.execute(sql, params).fetchall()
         return [dict(r) for r in rows]
 
-    def symbols_at_harvest_points(self) -> List[Dict[str, Any]]:
+    def symbols_at_harvest_points(self, price_lookup=None) -> List[Dict[str, Any]]:
         """
         Poll current prices and return a list of:
           { "symbol": <ticker>, "shares_to_sell": <int> }
@@ -603,8 +576,8 @@ class HarvesterPlanDB:
             shares_to_sell = int(next_rung["shares_sold_planned"])
             rung_id = int(next_rung["rung_id"])
 
-            # Poll current price (use last close)
-            current_price = self._poll_latest_close(ticker)
+            # Poll current price (last close), supplied by the service layer
+            current_price = price_lookup(ticker) if price_lookup else None
             if current_price is None:
                 continue
 
@@ -895,26 +868,6 @@ class HarvesterPlanDB:
     # -------------------------
     # Internal helpers
     # -------------------------
-
-    def _poll_latest_close(self, ticker: str) -> Optional[float]:
-        try:
-            df = yf.download(ticker, period="5d", interval="1d", progress=False)
-            if df is None or df.empty:
-                return None
-            # Handle MultiIndex similarly
-            if isinstance(df.columns, pd.MultiIndex):
-                if "Close" in df.columns.get_level_values(0):
-                    if ticker in df.columns.get_level_values(1):
-                        df = df.xs(ticker, axis=1, level=1, drop_level=True)
-                else:
-                    df = df.xs(ticker, axis=1, level=0, drop_level=True)
-
-            if "Close" not in df.columns:
-                return None
-            close = df["Close"].dropna().iloc[-1]
-            return float(close)
-        except Exception:
-            return None
 
     def _ensure_next_rung_alert(self, instance_id: int) -> None:
         """

--- a/quantcore/repositories/ohlcv_repository.py
+++ b/quantcore/repositories/ohlcv_repository.py
@@ -1,13 +1,10 @@
 """
-ohlcv_cache.py — Shared SQLite-backed OHLCV bar cache.
+OHLCV bar persistence — SQL only (architectural-standard-v2 §5.1, issue #74).
 
-All MCP servers route yfinance ticker.history() calls through this module so
-that expensive network fetches are performed at most once per bar per interval.
-
-Public API
-----------
-    get_history(symbol, interval, days) -> pd.DataFrame
-    period_to_days(period)             -> int
+Stores and queries daily/intraday bars with OPEN/CLOSED/GAP/CORRECTED status
+semantics. Fetching lives in YFinanceGateway.fetch_history; the fetch-when-
+stale policy lives in PricesService.get_history. This module never touches
+the network.
 """
 
 from __future__ import annotations
@@ -15,57 +12,17 @@ from __future__ import annotations
 import datetime
 import enum
 import logging
-import threading
 from contextlib import closing
 from dataclasses import dataclass
 from typing import Optional
 from time import time
 
 import pandas as pd
-import pytz
-import yfinance as yf
 
+from quantcore.analytics.market_time import ET, is_market_open
 from quantcore.db import get_connection
 
 logger = logging.getLogger(__name__)
-
-# ---------------------------------------------------------------------------
-# Constants
-# ---------------------------------------------------------------------------
-
-_ET = pytz.timezone("America/New_York")
-
-# How many days of history to pre-populate on a cold start, per interval
-_WARM_DAYS: dict[str, int] = {
-    "1d":  730,
-    "1wk": 1825,
-    "1mo": 3650,
-    "1h":  59,
-    "30m": 59,
-    "15m": 59,
-}
-
-# Hard cap on a single yfinance fetch window
-_MAX_FETCH_DAYS = 730
-
-# Mapping from yfinance period strings to calendar days
-_PERIOD_DAYS: dict[str, int] = {
-    "1d":   1,
-    "5d":   5,
-    "30d":  30,
-    "60d":  60,
-    "90d":  91,
-    "1mo":  31,
-    "3mo":  91,
-    "6mo":  182,
-    "1y":   365,
-    "2y":   730,
-    "3y":   1095,
-    "5y":   1825,
-    "10y":  3650,
-}
-
-_VALID_INTERVALS = {"1d", "1wk", "1mo", "1h", "30m", "15m"}
 
 
 # ---------------------------------------------------------------------------
@@ -101,18 +58,8 @@ class OHLCV:
 
 
 # ---------------------------------------------------------------------------
-# Market-hours helpers
+# Bar classification (persistence semantics; clock logic in analytics.market_time)
 # ---------------------------------------------------------------------------
-
-def _is_market_open() -> bool:
-    """Approximate check — not holiday-aware."""
-    now = datetime.datetime.now(tz=_ET)
-    if now.weekday() >= 5:
-        return False
-    market_open  = now.replace(hour=9, minute=30, second=0, microsecond=0)
-    market_close = now.replace(hour=16, minute=0,  second=0, microsecond=0)
-    return market_open <= now < market_close
-
 
 def _bar_status_for(bar_date: datetime.date, interval: str) -> BarStatus:
     """
@@ -120,10 +67,10 @@ def _bar_status_for(bar_date: datetime.date, interval: str) -> BarStatus:
     Intraday bars on the current date while the market is open are OPEN.
     All other bars are CLOSED.
     """
-    today = datetime.datetime.now(tz=_ET).date()
-    if bar_date == today and interval not in ("1d", "1wk", "1mo") and _is_market_open():
+    today = datetime.datetime.now(tz=ET).date()
+    if bar_date == today and interval not in ("1d", "1wk", "1mo") and is_market_open():
         return BarStatus.OPEN
-    if bar_date == today and interval == "1d" and _is_market_open():
+    if bar_date == today and interval == "1d" and is_market_open():
         return BarStatus.OPEN
     return BarStatus.CLOSED
 
@@ -275,119 +222,15 @@ def _query_cache(symbol: str, interval: str, days: int) -> pd.DataFrame:
 
 
 # ---------------------------------------------------------------------------
-# yfinance fetch
+# Public API (SQL only — fetching lives in YFinanceGateway.fetch_history and
+# the fetch-when-stale policy in PricesService.get_history, per issue #74)
 # ---------------------------------------------------------------------------
 
-# yf.download() is NOT thread-safe: results pass through module-global state
-# (yfinance.shared._DFS), so concurrent calls can hand one ticker's bars to
-# another ticker. Callers such as refresh_options_snapshots fetch from a
-# ThreadPoolExecutor, which corrupted the OHLCV table with cross-ticker rows
-# (2026-06-30 and 2026-07-02 prod incidents). Serialize every download.
-_YF_DOWNLOAD_LOCK = threading.Lock()
-
-
-def _fetch_yfinance(symbol: str, interval: str, days: int) -> pd.DataFrame:
-    """Download from yfinance, capped at _MAX_FETCH_DAYS."""
-    fetch_days = min(days, _MAX_FETCH_DAYS)
-    end   = datetime.datetime.utcnow()
-    start = end - datetime.timedelta(days=fetch_days)
-    logger.debug("yfinance fetch: %s %s start=%s end=%s", symbol, interval, start.date(), end.date())
-    with _YF_DOWNLOAD_LOCK:
-        df = yf.download(
-            symbol,
-            start=start.strftime("%Y-%m-%d"),
-            end=end.strftime("%Y-%m-%d"),
-            interval=interval,
-            auto_adjust=True,
-            progress=False,
-        )
-    if df.empty:
-        logger.warning("yfinance returned no data for %s/%s", symbol, interval)
-        return pd.DataFrame(columns=["Open", "High", "Low", "Close", "Volume"])
-
-    # yf.download returns MultiIndex columns when downloading a single symbol in
-    # newer versions; flatten if needed.
-    if isinstance(df.columns, pd.MultiIndex):
-        # Level 0 may be either Price names ("Close", "Open", …) or the ticker
-        # symbol ("MU", "AAPL", …) depending on the yfinance version.  Detect
-        # which level holds the field names and flatten to that.
-        _FIELD_NAMES = {"Open", "High", "Low", "Close", "Volume", "Adj Close",
-                        "Dividends", "Stock Splits"}
-        if df.columns.get_level_values(0)[0] in _FIELD_NAMES:
-            df.columns = df.columns.get_level_values(0)
-        else:
-            df.columns = df.columns.get_level_values(1)
-
-    # Ensure the expected columns exist after flattening
-    required = {"Open", "High", "Low", "Close", "Volume"}
-    if not required.issubset(set(df.columns)):
-        logger.warning(
-            "yfinance columns unexpected for %s/%s: %s", symbol, interval, list(df.columns)
-        )
-        return pd.DataFrame(columns=["Open", "High", "Low", "Close", "Volume"])
-
-    return df[["Open", "High", "Low", "Close", "Volume"]].dropna(subset=["Close"])
-
-
-# ---------------------------------------------------------------------------
-# Public API
-# ---------------------------------------------------------------------------
-
-def period_to_days(period: str) -> int:
-    """Convert a yfinance period string to calendar days."""
-    return _PERIOD_DAYS.get(period.lower(), 182)
-
-
-def get_history(symbol: str, interval: str, days: int) -> pd.DataFrame:
-    """
-    Return OHLCV history as a DataFrame with columns Open, High, Low, Close, Volume
-    and a UTC DatetimeIndex — identical in structure to yfinance ticker.history().
-
-    Serves from the SQLite cache when possible; fetches from yfinance only when:
-      - No cached data exists (cold start)
-      - The cache contains an OPEN bar that needs refreshing
-      - The most recent CLOSED bar is ≥1 trading day old on a weekday
-    """
-    if interval not in _VALID_INTERVALS:
-        raise ValueError(f"Invalid interval '{interval}'. Valid: {_VALID_INTERVALS}")
-
-    symbol = symbol.upper()
-
-    needs_fetch = False
-    if _count_cached(symbol, interval) == 0:
-        logger.info("Cold start: %s/%s — fetching %d warm days", symbol, interval,
-                    _WARM_DAYS.get(interval, 730))
-        needs_fetch = True
-        days = max(days, _WARM_DAYS.get(interval, 730))
-    elif _has_open_bar(symbol, interval):
-        logger.debug("OPEN bar detected for %s/%s — refreshing", symbol, interval)
-        needs_fetch = True
-    else:
-        latest_ts = _latest_closed_ts(symbol, interval)
-        if latest_ts is not None:
-            last_date = datetime.datetime.utcfromtimestamp(latest_ts).date()
-            # Compare against the most recent session that has started, not
-            # calendar today: overnight (midnight–9:30 ET) and on weekends no
-            # newer bar can exist, so refetching would never close the gap.
-            now_et  = datetime.datetime.now(tz=_ET)
-            session = now_et.date()
-            if now_et.weekday() >= 5 or now_et.time() < datetime.time(9, 30):
-                session -= datetime.timedelta(days=1)
-            while session.weekday() >= 5:
-                session -= datetime.timedelta(days=1)
-            if last_date < session:
-                logger.debug(
-                    "Stale cache for %s/%s (last bar %s < session %s) — refreshing",
-                    symbol, interval, last_date, session,
-                )
-                needs_fetch = True
-
-    if needs_fetch:
-        fresh = _fetch_yfinance(symbol, interval, days)
-        if not fresh.empty:
-            _store_bars(symbol, interval, fresh)
-
-    return _query_cache(symbol, interval, days)
+count_cached = _count_cached
+latest_closed_ts = _latest_closed_ts
+has_open_bar = _has_open_bar
+store_bars = _store_bars
+get_bars = _query_cache
 
 
 class OhlcvRepository:
@@ -395,14 +238,24 @@ class OhlcvRepository:
 
     Services depend on this class (constructor-injected via
     quantcore.services.registry) rather than on the module functions, so the
-    cache internals can evolve without touching callers.
+    cache internals can evolve without touching callers. SQL-only: history
+    fetching is orchestrated by PricesService via YFinanceGateway.
     """
 
-    def get_history(self, symbol: str, interval: str, days: int) -> pd.DataFrame:
-        return get_history(symbol, interval, days)
+    def count_cached(self, symbol: str, interval: str) -> int:
+        return _count_cached(symbol, interval)
 
-    def period_to_days(self, period: str) -> int:
-        return period_to_days(period)
+    def latest_closed_ts(self, symbol: str, interval: str):
+        return _latest_closed_ts(symbol, interval)
+
+    def has_open_bar(self, symbol: str, interval: str) -> bool:
+        return _has_open_bar(symbol, interval)
+
+    def store_bars(self, symbol: str, interval: str, df: pd.DataFrame) -> None:
+        _store_bars(symbol, interval, df)
+
+    def get_bars(self, symbol: str, interval: str, days: int) -> pd.DataFrame:
+        return _query_cache(symbol, interval, days)
 
     def daily_bars_for_symbols(self, symbols: list[str]) -> list:
         """All cached daily bars for the given symbols, ordered by symbol, ts."""

--- a/quantcore/services/harvester.py
+++ b/quantcore/services/harvester.py
@@ -33,8 +33,11 @@ from quantcore.repositories.harvester_repository import (
 
 
 class HarvesterService:
-    def __init__(self, harvester_repository: HarvesterPlanDB) -> None:
+    def __init__(self, harvester_repository: HarvesterPlanDB, yfinance_gateway=None) -> None:
         self._repo = harvester_repository
+        # Price fetching goes through the gateway (single fetch seam, #74);
+        # the repository only persists and queries.
+        self._yf = yfinance_gateway
 
     # ------------------------------------------------------------------
     # Plan CRUD / queries (passthrough to the repository)
@@ -45,7 +48,17 @@ class HarvesterService:
         template_name: str,
         params: PlanBuildParams,
     ) -> Dict[str, Any]:
-        return self._repo.build_plan(symbol=symbol, template_name=template_name, params=params)
+        symbol = symbol.upper().strip()
+        days = max(params.history_window_days + 60, 420)
+        bars = self._yf.fetch_history(
+            symbol, "1d", days, auto_adjust=False, include_adj_close=True
+        )
+        if not bars.empty and "Adj Close" not in bars.columns:
+            bars = bars.copy()
+            bars["Adj Close"] = bars["Close"]
+        return self._repo.build_plan(
+            symbol=symbol, template_name=template_name, params=params, bars=bars
+        )
 
     def display_all_plans(self, status: str = "ACTIVE") -> List[Dict[str, Any]]:
         return self._repo.display_all_plans(status=status)
@@ -88,10 +101,20 @@ class HarvesterService:
         return self._repo.get_dashboard_stats()
 
     def poll_latest_close(self, ticker: str) -> Optional[float]:
-        return self._repo._poll_latest_close(ticker)
+        return self._latest_close(ticker)
+
+    def _latest_close(self, ticker: str) -> Optional[float]:
+        try:
+            df = self._yf.fetch_history(ticker, "1d", 7)
+            if df is None or df.empty:
+                return None
+            closes = df["Close"].dropna()
+            return float(closes.iloc[-1]) if len(closes) else None
+        except Exception:
+            return None
 
     def symbols_at_harvest_points(self) -> List[Dict[str, Any]]:
-        return self._repo.symbols_at_harvest_points()
+        return self._repo.symbols_at_harvest_points(price_lookup=self._latest_close)
 
     # ------------------------------------------------------------------
     # Notifier integration (per-symbol hit checks)
@@ -163,7 +186,7 @@ class HarvesterService:
             rung_id = int(rung["rung_id"])
             shares_to_sell = int(rung["shares_sold_planned"])
 
-            current_price = self._repo._poll_latest_close(ticker)
+            current_price = self._latest_close(ticker)
             if current_price is None or current_price < target_price:
                 continue
 

--- a/quantcore/services/microstructure.py
+++ b/quantcore/services/microstructure.py
@@ -15,6 +15,7 @@ LIMITATIONS (inherited from the data source):
 import datetime
 import math
 
+from quantcore.analytics.market_time import period_to_days
 from quantcore.gateways.yfinance_gateway import YFinanceGateway
 from quantcore.repositories.ohlcv_repository import OhlcvRepository
 
@@ -36,9 +37,12 @@ def _safe_int(val, default: int = 0) -> int:
 
 
 class MicrostructureService:
-    def __init__(self, ohlcv_repository: OhlcvRepository, yfinance_gateway: YFinanceGateway) -> None:
+    def __init__(self, ohlcv_repository: OhlcvRepository, yfinance_gateway: YFinanceGateway, prices=None) -> None:
         self._ohlcv = ohlcv_repository
         self._yf = yfinance_gateway
+        # History access goes through PricesService (single fetch seam, #74);
+        # injected by the registry like RecommendationsService's composition.
+        self._prices = prices
 
     # ------------------------------------------------------------------
     # Short Interest / Days-to-Cover
@@ -139,7 +143,7 @@ class MicrostructureService:
         fetch_period = {"1d": "6mo", "1h": "60d"}[interval]
         fmt          = "%Y-%m-%d" if interval == "1d" else "%Y-%m-%d %H:%M"
 
-        hist = self._ohlcv.get_history(symbol.upper(), interval, self._ohlcv.period_to_days(fetch_period)).copy()
+        hist = self._prices.get_history(symbol.upper(), interval, period_to_days(fetch_period)).copy()
 
         if len(hist) < lookback + 10:
             raise ValueError(f"Not enough data for {symbol} (got {len(hist)} bars, need {lookback + 10})")
@@ -298,7 +302,7 @@ class MicrostructureService:
             options_spread_pct = round(sum(atm_spreads) / len(atm_spreads), 2)
 
         # ---- 3. High-low range ratio (intraday spread proxy) ----
-        hist     = self._ohlcv.get_history(symbol.upper(), "1d", 90).copy()
+        hist     = self._prices.get_history(symbol.upper(), "1d", 90).copy()
         hl_ratio  = None
         spread_vs_norm = "unknown"
 

--- a/quantcore/services/options.py
+++ b/quantcore/services/options.py
@@ -75,7 +75,7 @@ class OptionsService:
             raise ValueError(f"Could not retrieve price for symbol: {symbol}")
 
         # Bollinger Bands for context
-        hist = self._ohlcv.get_history(symbol.upper(), "1d", 90)
+        hist = self._prices.get_history(symbol.upper(), "1d", 90)
         close = hist["Close"].dropna()
         if len(close) >= 20:
             sma20 = float(close.rolling(window=20).mean().iloc[-1])
@@ -1031,12 +1031,8 @@ class OptionsService:
         finally:
             # Close yfinance's peewee cache DB connections that are held open
             # in each worker thread's thread-local storage.
-            try:
-                from yfinance.cache import _TzDBManager, _CookieDBManager
-                _TzDBManager.close_db()
-                _CookieDBManager.close_db()
-            except Exception:
-                pass
+            # Provider-internal cache cleanup belongs to the gateway (#75).
+            self._yf.close_thread_caches()
 
         elapsed = round(_time.monotonic() - start, 1)
         results_list.sort(key=lambda r: r["symbol"])

--- a/quantcore/services/options_screening.py
+++ b/quantcore/services/options_screening.py
@@ -24,6 +24,8 @@ from pathlib import Path
 from typing import Optional
 
 import numpy as np
+
+from quantcore.analytics.market_time import period_to_days
 import yaml
 
 # Project root (…/StockPortfolioManager) — for resolving the default watchlist.
@@ -275,9 +277,11 @@ def _chain_pc(calls_df, puts_df, price: float, atm_only: bool = False):
 class OptionsScreeningService:
     """Rule-based options screener: fetch → score → build trades → rank."""
 
-    def __init__(self, ohlcv_repository, yfinance_gateway):
+    def __init__(self, ohlcv_repository, yfinance_gateway, prices=None):
         self._ohlcv = ohlcv_repository
         self._yf = yfinance_gateway
+        # History via PricesService — the single fetch seam (issue #74).
+        self._prices = prices
 
     # ------------------------------------------------------------------
     # Data fetching
@@ -285,7 +289,7 @@ class OptionsScreeningService:
 
     def fetch_bollinger_bands(self, symbol: str) -> Optional[BollingerBands]:
         try:
-            hist = self._ohlcv.get_history(symbol, "1d", self._ohlcv.period_to_days(HISTORY_PERIOD))
+            hist = self._prices.get_history(symbol, "1d", period_to_days(HISTORY_PERIOD))
             if hist.empty or len(hist) < BB_PERIOD:
                 return None
             close = hist["Close"]
@@ -439,7 +443,7 @@ class OptionsScreeningService:
         most recent HV30 value so rank/percentile still reflect the vol environment.
         """
         try:
-            hist = self._ohlcv.get_history(symbol, "1d", 365)
+            hist = self._prices.get_history(symbol, "1d", 365)
             if hist.empty or len(hist) < 31:
                 return None
 

--- a/quantcore/services/prices.py
+++ b/quantcore/services/prices.py
@@ -12,6 +12,7 @@ screener's sentiment overlay through SentimentStore.
 
 from __future__ import annotations
 
+import datetime
 import math
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -20,10 +21,23 @@ import numpy as np
 import pandas as pd
 
 from quantcore.analytics.indicators import macd_series, rsi_series, safe_float
+from quantcore.analytics.market_time import latest_completed_session, period_to_days
 from quantcore.gateways.yfinance_gateway import YFinanceGateway
 from quantcore.repositories.ohlcv_repository import OhlcvRepository
 from quantcore.repositories.options_repository import OptionsStore
 from quantcore.repositories.sentiment_repository import SentimentStore
+
+VALID_INTERVALS = {"1d", "1wk", "1mo", "1h", "30m", "15m"}
+
+# How many days of history to pre-populate on a cold start, per interval.
+WARM_DAYS: dict[str, int] = {
+    "1d":  730,
+    "1wk": 1825,
+    "1mo": 3650,
+    "1h":  59,
+    "30m": 59,
+    "15m": 59,
+}
 
 
 def _safe_int(val):
@@ -84,6 +98,56 @@ class PricesService:
         self._sentiment = sentiment_repository
 
     # ------------------------------------------------------------------
+    # OHLCV history — fetch-when-stale policy (issue #74; moved here from
+    # the repository per Rule 5: caching policy is a service concern).
+    # Other services reach history via a constructor-injected PricesService,
+    # keeping YFinanceGateway the single fetch seam.
+    # ------------------------------------------------------------------
+
+    def get_history(self, symbol: str, interval: str = "1d", days: int = 365) -> pd.DataFrame:
+        """Cached OHLCV history; fetches via the gateway only when: no cache
+        (cold start), an OPEN bar needs refreshing, or the latest CLOSED bar
+        predates the most recent started session."""
+        if interval not in VALID_INTERVALS:
+            raise ValueError(f"Invalid interval '{interval}'. Valid: {VALID_INTERVALS}")
+        symbol = symbol.upper()
+
+        needs_fetch = False
+        if self._ohlcv.count_cached(symbol, interval) == 0:
+            days = max(days, WARM_DAYS.get(interval, 730))
+            needs_fetch = True
+        elif self._ohlcv.has_open_bar(symbol, interval):
+            needs_fetch = True
+        else:
+            latest_ts = self._ohlcv.latest_closed_ts(symbol, interval)
+            if latest_ts is not None:
+                last_date = datetime.datetime.utcfromtimestamp(latest_ts).date()
+                if last_date < latest_completed_session():
+                    needs_fetch = True
+
+        if needs_fetch:
+            fresh = self._yf.fetch_history(symbol, interval, days)
+            if not fresh.empty:
+                self._ohlcv.store_bars(symbol, interval, fresh)
+
+        return self._ohlcv.get_bars(symbol, interval, days)
+
+    def get_fast_price(self, symbol: str):
+        """Lightweight last-trade price via fast_info; None when unavailable.
+
+        Used by the notifier's alert loop (issue #76) — adapters call this
+        instead of importing yfinance.
+        """
+        try:
+            info = self._yf.fast_info(symbol.upper())
+            price = getattr(info, "last_price", None)
+            if price is None or float(price) <= 0:
+                return None
+            return float(price)
+        except Exception:
+            return None
+
+    # ------------------------------------------------------------------
     # Quote + options summary
     # ------------------------------------------------------------------
 
@@ -95,7 +159,7 @@ class PricesService:
             raise ValueError(f"Could not retrieve price for symbol: {symbol}")
 
         # Bollinger Bands
-        hist = self._ohlcv.get_history(symbol.upper(), "1d", 90)
+        hist = self.get_history(symbol.upper(), "1d", 90)
         close = hist["Close"].dropna()
         if len(close) >= 20:
             sma20 = float(close.rolling(window=20).mean().iloc[-1])
@@ -158,7 +222,7 @@ class PricesService:
 
         fetch_period = {"1d": "90d", "1wk": "2y", "1mo": "5y"}[interval]
 
-        hist = self._ohlcv.get_history(symbol.upper(), interval, self._ohlcv.period_to_days(fetch_period))
+        hist = self.get_history(symbol.upper(), interval, period_to_days(fetch_period))
         closes = hist["Close"].dropna()
 
         if len(closes) < period + 1:
@@ -200,7 +264,7 @@ class PricesService:
 
         fetch_period = {"1d": "6mo", "1wk": "3y", "1mo": "10y"}[interval]
 
-        hist = self._ohlcv.get_history(symbol.upper(), interval, self._ohlcv.period_to_days(fetch_period))
+        hist = self.get_history(symbol.upper(), interval, period_to_days(fetch_period))
         closes = hist["Close"].dropna()
 
         if len(closes) < 35:
@@ -243,7 +307,7 @@ class PricesService:
 
         fetch_period = {"1d": "90d", "1wk": "2y", "1mo": "5y"}[interval]
 
-        hist = self._ohlcv.get_history(symbol.upper(), interval, self._ohlcv.period_to_days(fetch_period))
+        hist = self.get_history(symbol.upper(), interval, period_to_days(fetch_period))
 
         if len(hist) < k_period + d_period:
             raise ValueError(
@@ -304,7 +368,7 @@ class PricesService:
 
         fetch_period = {"1d": "6mo", "1wk": "3y", "1mo": "10y"}[interval]
 
-        hist = self._ohlcv.get_history(symbol.upper(), interval, self._ohlcv.period_to_days(fetch_period)).copy()
+        hist = self.get_history(symbol.upper(), interval, period_to_days(fetch_period)).copy()
 
         if len(hist) < lookback + 5:
             raise ValueError(f"Not enough data for {symbol} (got {len(hist)} bars, need {lookback + 5})")
@@ -410,7 +474,7 @@ class PricesService:
 
         fetch_period = {"1d": "6mo", "1wk": "3y", "1mo": "10y"}[interval]
 
-        hist = self._ohlcv.get_history(symbol.upper(), interval, self._ohlcv.period_to_days(fetch_period)).copy()
+        hist = self.get_history(symbol.upper(), interval, period_to_days(fetch_period)).copy()
 
         if len(hist) < lookback + 5:
             raise ValueError(f"Not enough data for {symbol} (got {len(hist)} bars, need {lookback + 5})")
@@ -529,7 +593,7 @@ class PricesService:
 
         fetch_period = {"1d": "6mo", "1wk": "3y", "1mo": "10y"}[interval]
 
-        hist = self._ohlcv.get_history(symbol.upper(), interval, self._ohlcv.period_to_days(fetch_period)).copy()
+        hist = self.get_history(symbol.upper(), interval, period_to_days(fetch_period)).copy()
 
         if len(hist) < lookback + 5:
             raise ValueError(f"Not enough data for {symbol} (got {len(hist)} bars, need {lookback + 5})")
@@ -659,7 +723,7 @@ class PricesService:
         symbol = symbol.upper().strip()
         # Fetch enough extra bars to seed the first rolling window
         fetch_days = since_days + lookback + 5
-        df = self._ohlcv.get_history(symbol, interval=interval, days=fetch_days)
+        df = self.get_history(symbol, interval=interval, days=fetch_days)
         if df is None or df.empty:
             return {"symbol": symbol, "error": "No OHLCV data in cache", "history": []}
 
@@ -690,7 +754,7 @@ class PricesService:
 
         fetch_period = {"1d": "6mo", "1wk": "3y", "1mo": "10y"}[interval]
 
-        hist = self._ohlcv.get_history(symbol.upper(), interval, self._ohlcv.period_to_days(fetch_period)).copy()
+        hist = self.get_history(symbol.upper(), interval, period_to_days(fetch_period)).copy()
 
         if len(hist) < lookback + 25:
             raise ValueError(f"Not enough data for {symbol} (got {len(hist)} bars, need {lookback + 25})")
@@ -900,7 +964,7 @@ class PricesService:
 
         fetch_period = {"15m": "60d", "30m": "60d", "1h": "60d", "1d": "2y"}[interval]
 
-        hist = self._ohlcv.get_history(symbol.upper(), interval, self._ohlcv.period_to_days(fetch_period)).copy()
+        hist = self.get_history(symbol.upper(), interval, period_to_days(fetch_period)).copy()
 
         min_bars = swing_bars * 2 + 10
         if len(hist) < min_bars:
@@ -1049,7 +1113,7 @@ class PricesService:
 
         fetch_period = {"1d": "2y", "1h": "60d"}[interval]
 
-        hist = self._ohlcv.get_history(symbol.upper(), interval, self._ohlcv.period_to_days(fetch_period)).copy()
+        hist = self.get_history(symbol.upper(), interval, period_to_days(fetch_period)).copy()
 
         if len(hist) < lookback + 5:
             raise ValueError(f"Not enough data for {symbol} (got {len(hist)} bars, need {lookback + 5})")
@@ -1212,7 +1276,7 @@ class PricesService:
         # Request enough calendar days to cover the trading-day lookback.
         # ~252 trading days ≈ 365 calendar days; use 2× to be safe with the cache.
         calendar_days = max(lookback_days * 2, 365)
-        hist = self._ohlcv.get_history(symbol.upper(), "1d", calendar_days).copy()
+        hist = self.get_history(symbol.upper(), "1d", calendar_days).copy()
 
         if len(hist) < 10:
             raise ValueError(
@@ -1333,7 +1397,7 @@ class PricesService:
 
     def get_ohlcv_bars(self, ticker: str, days: int = 180) -> dict:
         ticker = ticker.upper()
-        df = self._ohlcv.get_history(ticker, "1d", days)
+        df = self.get_history(ticker, "1d", days)
 
         if df.empty:
             return {"ticker": ticker, "bars": []}
@@ -1376,7 +1440,7 @@ class PricesService:
 
     def get_technicals_table(self, ticker: str, days: int = 365) -> dict:
         ticker = ticker.upper()
-        df = self._ohlcv.get_history(ticker, "1d", max(days, 400))
+        df = self.get_history(ticker, "1d", max(days, 400))
 
         if df.empty:
             return {"ticker": ticker, "indicators": []}

--- a/quantcore/services/recommendations.py
+++ b/quantcore/services/recommendations.py
@@ -307,15 +307,15 @@ class RecommendationsService:
     ) -> dict:
         symbol = symbol.upper().strip()
         fetch_days = since_days + rs_period + 10
-        sym_df  = self._ohlcv.get_history(symbol, interval=interval, days=fetch_days)
-        spy_df  = self._ohlcv.get_history("SPY",  interval=interval, days=fetch_days)
-        qqq_df  = self._ohlcv.get_history("QQQ",  interval=interval, days=fetch_days)
+        sym_df  = self._prices.get_history(symbol, interval=interval, days=fetch_days)
+        spy_df  = self._prices.get_history("SPY",  interval=interval, days=fetch_days)
+        qqq_df  = self._prices.get_history("QQQ",  interval=interval, days=fetch_days)
         if sym_df is None or sym_df.empty or spy_df is None or spy_df.empty:
             return {"symbol": symbol, "error": "Insufficient OHLCV data in cache", "history": []}
 
         # Determine sector ETF
         sector_etf = self._get_sector_etf(symbol)
-        sec_df = self._ohlcv.get_history(sector_etf, interval=interval, days=fetch_days) if sector_etf else None
+        sec_df = self._prices.get_history(sector_etf, interval=interval, days=fetch_days) if sector_etf else None
 
         def rolling_return(df):
             closes = df["Close"]

--- a/quantcore/services/registry.py
+++ b/quantcore/services/registry.py
@@ -97,6 +97,7 @@ def get_services() -> Services:
     microstructure = MicrostructureService(
         ohlcv_repository=ohlcv_repository,
         yfinance_gateway=yfinance_gateway,
+        prices=prices,
     )
     sentiment = SentimentService(
         news_repository=news_repository,
@@ -145,8 +146,12 @@ def get_services() -> Services:
         options_screening=OptionsScreeningService(
             ohlcv_repository=ohlcv_repository,
             yfinance_gateway=yfinance_gateway,
+            prices=prices,
         ),
-        harvester=HarvesterService(harvester_repository=harvester_repository),
+        harvester=HarvesterService(
+            harvester_repository=harvester_repository,
+            yfinance_gateway=yfinance_gateway,
+        ),
         portfolio=PortfolioService(portfolio_repository=portfolio_repository),
         recommendations=RecommendationsService(
             prices=prices,

--- a/scripts/generate_watchlist_fundamentals_report.py
+++ b/scripts/generate_watchlist_fundamentals_report.py
@@ -22,7 +22,7 @@ for _path in (ROOT, FAST_MCP_DIR):
         sys.path.insert(0, str(_path))
 
 from quantcore.services.registry import get_services  # noqa: E402
-from quantcore.repositories.ohlcv_repository import get_history  # noqa: E402
+from quantcore.services.registry import get_services  # noqa: E402
 
 
 SORT_TABLE_JS = """
@@ -223,7 +223,7 @@ def collect_row(entry: dict[str, Any]) -> dict[str, Any]:
     price_error = ""
     history = pd.DataFrame()
     try:
-        history = get_history(symbol, "1d", 120)
+        history = get_services().prices.get_history(symbol, "1d", 120)
     except Exception as exc:  # noqa: BLE001
         price_error = str(exc)
 

--- a/scripts/repair_ohlcv_misalignment.py
+++ b/scripts/repair_ohlcv_misalignment.py
@@ -4,7 +4,7 @@ A bulk ingest on 2026-06-30 ~20:10-20:13 UTC wrote misaligned price data to
 prod: groups of unrelated symbols received byte-identical OHLCV bars (e.g.
 INTC=MRVL=POWL=SOLS all got one ticker's bar). This re-fetches each affected
 symbol individually through the proven-correct single-symbol path
-(_fetch_yfinance -> _store_bars, ON CONFLICT DO UPDATE) and overwrites the bad
+(YFinanceGateway.fetch_history -> store_bars, ON CONFLICT DO UPDATE) and overwrites the bad
 rows in place. Re-fetching a healthy symbol is harmless (idempotent upsert).
 
 Usage:
@@ -24,7 +24,10 @@ from dotenv import load_dotenv
 load_dotenv("/Users/thomasfowler/source/com/thomasdfowler/StockPortfolioManager/.env")
 
 from quantcore.db import get_connection
-from quantcore.repositories.ohlcv_repository import _fetch_yfinance, _store_bars
+from quantcore.gateways.yfinance_gateway import YFinanceGateway
+from quantcore.repositories.ohlcv_repository import store_bars
+
+_gateway = YFinanceGateway()
 
 WARM_DAYS = 730
 
@@ -60,7 +63,7 @@ def main() -> int:
     ok = empty = failed = 0
     for i, sym in enumerate(symbols, 1):
         try:
-            df = _fetch_yfinance(sym, "1d", WARM_DAYS)
+            df = _gateway.fetch_history(sym, "1d", WARM_DAYS)
             if df.empty:
                 empty += 1
                 print(f"  [{i}/{len(symbols)}] {sym:8} EMPTY (yfinance returned nothing)")
@@ -73,7 +76,7 @@ def main() -> int:
                 print(f"  [{i}/{len(symbols)}] {sym:8} SKIP (non-positive close {last_close})")
                 continue
             if not args.dry_run:
-                _store_bars(sym, "1d", df)
+                store_bars(sym, "1d", df)
             ok += 1
             if i % 25 == 0 or i == len(symbols):
                 print(f"  [{i}/{len(symbols)}] {sym:8} {len(df)} bars  last={last_date} close={last_close:.2f}  (ok={ok})")

--- a/test_architecture_guards.py
+++ b/test_architecture_guards.py
@@ -1,0 +1,92 @@
+"""Architecture fence (architectural-standard-v2, issues #74–#77).
+
+Turns the July 2026 audit findings into permanent CI guarantees:
+
+  * yfinance may be imported ONLY by the provider gateway package, the legacy
+    ``portfolio/`` domain layer (main.py report path carve-out), and the
+    standalone ``experiments/`` monitors.
+  * ``yf.download`` — the thread-unsafe call that caused the OHLCV
+    cross-ticker corruption — may appear only inside quantcore/gateways/,
+    where every call is serialized on _YF_DOWNLOAD_LOCK.
+
+If one of these tests fails, a provider import leaked outside the gateway
+seam — move the call behind YFinanceGateway instead of editing the allowlist.
+"""
+import re
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent
+
+# Directories whose *.py files are subject to the fence.
+SCANNED_DIRS = ["quantcore", "api", "fastMCPTest", "scripts", "mcp_gateway"]
+# Root-level modules subject to the fence.
+SCANNED_ROOT_FILES = ["main.py", "notifier.py"]
+
+# Sanctioned yfinance importers (standard §5.3 + documented carve-outs).
+YFINANCE_ALLOWED_PREFIXES = (
+    "quantcore/gateways/",
+    "portfolio/",
+    "experiments/",
+)
+
+# Actual import statements only — docstring prose like "from yfinance and
+# caches the result" must not trip the fence.
+_IMPORT_RE = re.compile(
+    r"^\s*(import yfinance\b|from yfinance(\.\w+)* import\b)", re.MULTILINE
+)
+_DOWNLOAD_RE = re.compile(r"\byf\.download\s*\(")
+# Real call sites in the gateway are multiline calls: "yf.download(\n".
+_DOWNLOAD_CALL_RE = re.compile(r"yf\.download\(\s*\n")
+
+
+def _scanned_files():
+    for d in SCANNED_DIRS:
+        root = REPO / d
+        if root.exists():
+            yield from root.rglob("*.py")
+    for name in SCANNED_ROOT_FILES:
+        f = REPO / name
+        if f.exists():
+            yield f
+
+
+class TestYfinanceFence(unittest.TestCase):
+    def test_yfinance_imports_only_in_sanctioned_locations(self):
+        violations = []
+        for f in _scanned_files():
+            rel = f.relative_to(REPO).as_posix()
+            if rel.startswith(YFINANCE_ALLOWED_PREFIXES):
+                continue
+            if _IMPORT_RE.search(f.read_text(errors="replace")):
+                violations.append(rel)
+        self.assertEqual(
+            violations, [],
+            "yfinance imported outside the gateway/carve-outs — route these "
+            f"through YFinanceGateway: {violations}",
+        )
+
+    def test_yf_download_only_in_gateways(self):
+        violations = []
+        for f in _scanned_files():
+            rel = f.relative_to(REPO).as_posix()
+            if rel.startswith("quantcore/gateways/"):
+                continue
+            src = f.read_text(errors="replace")
+            if _IMPORT_RE.search(src) and _DOWNLOAD_RE.search(src):
+                violations.append(rel)
+        self.assertEqual(violations, [], f"yf.download outside gateways: {violations}")
+
+    def test_gateway_download_sites_hold_the_lock(self):
+        """Every yf.download call in the gateway must sit inside a
+        `with _YF_DOWNLOAD_LOCK:` block (crude but effective source check)."""
+        src = (REPO / "quantcore/gateways/yfinance_gateway.py").read_text()
+        calls = len(_DOWNLOAD_CALL_RE.findall(src))
+        self.assertGreater(calls, 0, "expected at least one yf.download call site")
+        locked_blocks = src.count("with _YF_DOWNLOAD_LOCK:")
+        self.assertGreaterEqual(locked_blocks, calls,
+                                "a yf.download call site is missing the lock")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_harvester_fetch_seam.py
+++ b/test_harvester_fetch_seam.py
@@ -1,0 +1,97 @@
+"""Tests for the harvester's fetch seam (issue #74): HarvesterService fetches
+price data via YFinanceGateway and passes it into the repository — the
+repository itself never touches yfinance. All mocked; no DB, no network.
+"""
+import os
+import unittest
+from pathlib import Path
+from unittest.mock import Mock
+
+import pandas as pd
+
+# Standard test preamble: swap in the test DSN BEFORE quantcore.db is imported
+# (harvester_repository imports it transitively and freezes DB_DSN).
+_env_file = Path(__file__).parent / ".env"
+if _env_file.exists():
+    for _line in _env_file.read_text().splitlines():
+        if _line.strip().startswith("QUANTCORE_TEST_DB_DSN="):
+            os.environ["QUANTCORE_DB_DSN"] = _line.split("=", 1)[1].strip()
+            break
+
+from quantcore.repositories.harvester_repository import PlanBuildParams  # noqa: E402
+from quantcore.services.harvester import HarvesterService  # noqa: E402
+
+
+def bars_df(include_adj=True):
+    data = {
+        "Open": [10.0, 11.0],
+        "High": [10.5, 11.5],
+        "Low": [9.5, 10.5],
+        "Close": [10.2, 11.2],
+        "Volume": [1000, 1100],
+    }
+    if include_adj:
+        data["Adj Close"] = [10.1, 11.1]
+    return pd.DataFrame(data, index=pd.to_datetime(["2026-07-10", "2026-07-13"]))
+
+
+class TestBuildPlanFetchSeam(unittest.TestCase):
+    def setUp(self):
+        self.repo = Mock()
+        self.gateway = Mock()
+        self.service = HarvesterService(self.repo, yfinance_gateway=self.gateway)
+
+    def test_build_plan_fetches_raw_history_and_passes_bars(self):
+        self.gateway.fetch_history.return_value = bars_df()
+        params = PlanBuildParams()
+        self.service.build_plan(symbol="intc", template_name="tmpl", params=params)
+
+        args, kwargs = self.gateway.fetch_history.call_args
+        self.assertEqual(args[0], "INTC")
+        self.assertEqual(args[1], "1d")
+        self.assertGreaterEqual(args[2], 420)
+        self.assertFalse(kwargs["auto_adjust"])          # Adj Close required
+        self.assertTrue(kwargs["include_adj_close"])
+
+        _, repo_kwargs = self.repo.build_plan.call_args
+        self.assertIn("bars", repo_kwargs)
+        self.assertIn("Adj Close", repo_kwargs["bars"].columns)
+
+    def test_missing_adj_close_falls_back_to_close(self):
+        self.gateway.fetch_history.return_value = bars_df(include_adj=False)
+        self.service.build_plan(symbol="INTC", template_name="t", params=PlanBuildParams())
+        bars = self.repo.build_plan.call_args.kwargs["bars"]
+        self.assertIn("Adj Close", bars.columns)
+        self.assertEqual(list(bars["Adj Close"]), list(bars["Close"]))
+
+
+class TestLatestClose(unittest.TestCase):
+    def setUp(self):
+        self.repo = Mock()
+        self.gateway = Mock()
+        self.service = HarvesterService(self.repo, yfinance_gateway=self.gateway)
+
+    def test_latest_close_from_gateway(self):
+        self.gateway.fetch_history.return_value = bars_df()
+        self.assertEqual(self.service.poll_latest_close("INTC"), 11.2)
+        # The repository is never asked to fetch anything.
+        self.assertFalse(
+            any("poll" in str(c) for c in self.repo.method_calls),
+            self.repo.method_calls,
+        )
+
+    def test_latest_close_none_on_empty(self):
+        self.gateway.fetch_history.return_value = pd.DataFrame(
+            columns=["Open", "High", "Low", "Close", "Volume"]
+        )
+        self.assertIsNone(self.service.poll_latest_close("ZZNONE"))
+
+    def test_symbols_at_harvest_points_injects_price_lookup(self):
+        self.service.symbols_at_harvest_points()
+        _, kwargs = self.repo.symbols_at_harvest_points.call_args
+        self.assertIn("price_lookup", kwargs)
+        self.assertTrue(callable(kwargs["price_lookup"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_market_time.py
+++ b/test_market_time.py
@@ -1,0 +1,78 @@
+"""Tests for quantcore/analytics/market_time.py — pure market-calendar helpers
+
+shared by the OHLCV persistence layer (bar classification) and PricesService
+(staleness policy). Pure functions, injectable clock, no I/O.
+"""
+import datetime
+import unittest
+
+import pytz
+
+from quantcore.analytics.market_time import (
+    ET,
+    is_market_open,
+    latest_completed_session,
+    period_to_days,
+)
+
+
+def et(y, m, d, hh, mm):
+    return pytz.timezone("America/New_York").localize(
+        datetime.datetime(y, m, d, hh, mm)
+    )
+
+
+class TestIsMarketOpen(unittest.TestCase):
+    def test_weekday_regular_hours(self):
+        self.assertTrue(is_market_open(now=et(2026, 7, 15, 10, 0)))   # Wed 10:00
+        self.assertTrue(is_market_open(now=et(2026, 7, 15, 9, 30)))   # open bell
+
+    def test_weekday_outside_hours(self):
+        self.assertFalse(is_market_open(now=et(2026, 7, 15, 9, 0)))   # pre-market
+        self.assertFalse(is_market_open(now=et(2026, 7, 15, 16, 0)))  # close bell
+        self.assertFalse(is_market_open(now=et(2026, 7, 15, 20, 0)))  # evening
+
+    def test_weekend_closed(self):
+        self.assertFalse(is_market_open(now=et(2026, 7, 11, 11, 0)))  # Saturday
+
+
+class TestLatestCompletedSession(unittest.TestCase):
+    def test_midweek_after_open_is_today(self):
+        self.assertEqual(
+            latest_completed_session(now=et(2026, 7, 15, 10, 0)),
+            datetime.date(2026, 7, 15),
+        )
+
+    def test_midweek_before_open_is_previous_day(self):
+        self.assertEqual(
+            latest_completed_session(now=et(2026, 7, 15, 8, 0)),
+            datetime.date(2026, 7, 14),
+        )
+
+    def test_monday_premarket_rolls_back_to_friday(self):
+        self.assertEqual(
+            latest_completed_session(now=et(2026, 7, 13, 8, 0)),  # Mon 8am
+            datetime.date(2026, 7, 10),                            # Friday
+        )
+
+    def test_weekend_rolls_back_to_friday(self):
+        self.assertEqual(
+            latest_completed_session(now=et(2026, 7, 12, 12, 0)),  # Sunday
+            datetime.date(2026, 7, 10),
+        )
+
+
+class TestPeriodToDays(unittest.TestCase):
+    def test_known_periods(self):
+        self.assertEqual(period_to_days("1y"), 365)
+        self.assertEqual(period_to_days("2y"), 730)
+        self.assertEqual(period_to_days("6mo"), 182)
+        self.assertEqual(period_to_days("5d"), 5)
+
+    def test_case_insensitive_and_default(self):
+        self.assertEqual(period_to_days("1Y"), 365)
+        self.assertEqual(period_to_days("bogus"), 182)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_prices_history_policy.py
+++ b/test_prices_history_policy.py
@@ -1,0 +1,125 @@
+"""Tests for the fetch-when-stale policy in PricesService.get_history.
+
+Issue #74: this policy used to live inside the OHLCV repository; per
+architectural-standard-v2 Rule 5 (caching policy is a service concern) it now
+lives here, orchestrating YFinanceGateway (fetch) and OhlcvRepository
+(persist/query). Everything is mocked — no network, no DB.
+"""
+import datetime
+import time
+import unittest
+from unittest.mock import Mock, patch
+
+import pandas as pd
+
+from quantcore.services.prices import PricesService, WARM_DAYS
+
+
+def make_service(repo=None, gateway=None):
+    return PricesService(
+        ohlcv_repository=repo or Mock(),
+        yfinance_gateway=gateway or Mock(),
+        options_repository=Mock(),
+        sentiment_repository=Mock(),
+    )
+
+
+def ts_for(date: datetime.date) -> int:
+    return int(time.mktime(date.timetuple()))
+
+
+FRESH_DF = pd.DataFrame(
+    {"Open": [1.0], "High": [1.0], "Low": [1.0], "Close": [1.0], "Volume": [1]},
+    index=pd.to_datetime(["2026-07-13"]),
+)
+
+
+class TestHistoryPolicy(unittest.TestCase):
+    def setUp(self):
+        self.repo = Mock()
+        self.gateway = Mock()
+        self.gateway.fetch_history.return_value = FRESH_DF
+        self.repo.get_bars.return_value = FRESH_DF
+        self.service = make_service(self.repo, self.gateway)
+
+    def test_invalid_interval_raises(self):
+        with self.assertRaises(ValueError):
+            self.service.get_history("INTC", "13m", 30)
+
+    def test_cold_start_fetches_warm_days_and_stores(self):
+        self.repo.count_cached.return_value = 0
+        result = self.service.get_history("intc", "1d", 30)
+
+        self.gateway.fetch_history.assert_called_once()
+        args, kwargs = self.gateway.fetch_history.call_args
+        self.assertEqual(args[0], "INTC")  # uppercased
+        self.assertEqual(args[1], "1d")
+        self.assertEqual(args[2], WARM_DAYS["1d"])  # warm window, not 30
+        self.repo.store_bars.assert_called_once()
+        self.assertIs(result, self.repo.get_bars.return_value)
+
+    def test_open_bar_triggers_refetch(self):
+        self.repo.count_cached.return_value = 500
+        self.repo.has_open_bar.return_value = True
+        self.service.get_history("INTC", "1d", 30)
+        self.gateway.fetch_history.assert_called_once()
+
+    def test_stale_closed_bar_triggers_refetch(self):
+        self.repo.count_cached.return_value = 500
+        self.repo.has_open_bar.return_value = False
+        stale = datetime.date(2026, 7, 9)
+        session = datetime.date(2026, 7, 13)
+        self.repo.latest_closed_ts.return_value = ts_for(stale)
+        with patch(
+            "quantcore.services.prices.latest_completed_session", return_value=session
+        ):
+            self.service.get_history("INTC", "1d", 30)
+        self.gateway.fetch_history.assert_called_once()
+
+    def test_fresh_cache_no_fetch(self):
+        self.repo.count_cached.return_value = 500
+        self.repo.has_open_bar.return_value = False
+        session = datetime.date(2026, 7, 13)
+        self.repo.latest_closed_ts.return_value = ts_for(session)
+        with patch(
+            "quantcore.services.prices.latest_completed_session", return_value=session
+        ):
+            result = self.service.get_history("INTC", "1d", 30)
+        self.gateway.fetch_history.assert_not_called()
+        self.repo.store_bars.assert_not_called()
+        self.assertIs(result, self.repo.get_bars.return_value)
+
+    def test_empty_fetch_result_not_stored(self):
+        self.repo.count_cached.return_value = 0
+        self.gateway.fetch_history.return_value = pd.DataFrame(
+            columns=["Open", "High", "Low", "Close", "Volume"]
+        )
+        self.service.get_history("ZZNONE", "1d", 30)
+        self.repo.store_bars.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TestGetFastPrice(unittest.TestCase):
+    """notifier.py's alert loop uses this instead of importing yfinance (issue #76)."""
+
+    def setUp(self):
+        self.gateway = Mock()
+        self.service = make_service(gateway=self.gateway)
+
+    def test_returns_last_price(self):
+        self.gateway.fast_info.return_value = type("FI", (), {"last_price": 123.45})()
+        self.assertEqual(self.service.get_fast_price("intc"), 123.45)
+        self.gateway.fast_info.assert_called_once_with("INTC")
+
+    def test_none_on_missing_or_nonpositive(self):
+        self.gateway.fast_info.return_value = type("FI", (), {"last_price": 0})()
+        self.assertIsNone(self.service.get_fast_price("INTC"))
+        self.gateway.fast_info.return_value = type("FI", (), {})()
+        self.assertIsNone(self.service.get_fast_price("INTC"))
+
+    def test_none_on_gateway_error(self):
+        self.gateway.fast_info.side_effect = RuntimeError("yahoo down")
+        self.assertIsNone(self.service.get_fast_price("INTC"))

--- a/test_yfinance_gateway.py
+++ b/test_yfinance_gateway.py
@@ -1,0 +1,126 @@
+"""Tests for YFinanceGateway.fetch_history — the single yf.download seam.
+
+Issue #74/#75: all yfinance downloads go through the gateway, which owns the
+serialization lock (yf.download shares module-global state and is not
+thread-safe — the July 2026 corruption vector), the MultiIndex column
+flattening, the fetch-window cap, and provider-internal cache cleanup.
+"""
+import unittest
+from unittest.mock import patch
+
+import pandas as pd
+
+from quantcore.gateways import yfinance_gateway as gw_mod
+from quantcore.gateways.yfinance_gateway import YFinanceGateway
+
+
+def flat_df():
+    idx = pd.to_datetime(["2026-07-10", "2026-07-11"])
+    return pd.DataFrame(
+        {
+            "Open": [1.0, 2.0],
+            "High": [1.5, 2.5],
+            "Low": [0.5, 1.5],
+            "Close": [1.2, 2.2],
+            "Volume": [100, 200],
+        },
+        index=idx,
+    )
+
+
+class TestFetchHistory(unittest.TestCase):
+    def setUp(self):
+        self.gateway = YFinanceGateway()
+
+    def test_download_runs_under_the_serialization_lock(self):
+        seen = {}
+
+        def fake_download(*args, **kwargs):
+            seen["locked_during_call"] = gw_mod._YF_DOWNLOAD_LOCK.locked()
+            return flat_df()
+
+        with patch.object(gw_mod.yf, "download", side_effect=fake_download):
+            self.gateway.fetch_history("INTC", "1d", 30)
+        self.assertTrue(seen["locked_during_call"])
+        self.assertFalse(gw_mod._YF_DOWNLOAD_LOCK.locked())  # released after
+
+    def test_bulk_download_also_serialized(self):
+        seen = {}
+
+        def fake_download(*args, **kwargs):
+            seen["locked_during_call"] = gw_mod._YF_DOWNLOAD_LOCK.locked()
+            return flat_df()
+
+        with patch.object(gw_mod.yf, "download", side_effect=fake_download):
+            self.gateway.download(["INTC", "SPY"], period="6mo")
+        self.assertTrue(seen["locked_during_call"])
+
+    def test_flattens_multiindex_columns_field_level_first(self):
+        df = flat_df()
+        df.columns = pd.MultiIndex.from_product([df.columns, ["INTC"]])
+        with patch.object(gw_mod.yf, "download", return_value=df):
+            out = self.gateway.fetch_history("INTC", "1d", 30)
+        self.assertEqual(
+            list(out.columns), ["Open", "High", "Low", "Close", "Volume"]
+        )
+        self.assertEqual(len(out), 2)
+
+    def test_flattens_multiindex_columns_ticker_level_first(self):
+        df = flat_df()
+        df.columns = pd.MultiIndex.from_product([["INTC"], df.columns])
+        with patch.object(gw_mod.yf, "download", return_value=df):
+            out = self.gateway.fetch_history("INTC", "1d", 30)
+        self.assertEqual(
+            list(out.columns), ["Open", "High", "Low", "Close", "Volume"]
+        )
+
+    def test_empty_result_returns_standard_empty_frame(self):
+        with patch.object(gw_mod.yf, "download", return_value=pd.DataFrame()):
+            out = self.gateway.fetch_history("ZZNONE", "1d", 30)
+        self.assertTrue(out.empty)
+        self.assertEqual(
+            list(out.columns), ["Open", "High", "Low", "Close", "Volume"]
+        )
+
+    def test_drops_rows_with_nan_close(self):
+        df = flat_df()
+        df.loc[df.index[0], "Close"] = float("nan")
+        with patch.object(gw_mod.yf, "download", return_value=df):
+            out = self.gateway.fetch_history("INTC", "1d", 30)
+        self.assertEqual(len(out), 1)
+
+    def test_window_capped_at_max_fetch_days(self):
+        captured = {}
+
+        def fake_download(symbol, **kwargs):
+            captured.update(kwargs)
+            return flat_df()
+
+        with patch.object(gw_mod.yf, "download", side_effect=fake_download):
+            self.gateway.fetch_history("INTC", "1d", 5000)
+        start = pd.Timestamp(captured["start"])
+        end = pd.Timestamp(captured["end"])
+        self.assertLessEqual((end - start).days, 730)
+
+    def test_auto_adjust_passthrough(self):
+        captured = {}
+
+        def fake_download(symbol, **kwargs):
+            captured.update(kwargs)
+            return flat_df()
+
+        with patch.object(gw_mod.yf, "download", side_effect=fake_download):
+            self.gateway.fetch_history("INTC", "1d", 30, auto_adjust=False)
+        self.assertFalse(captured["auto_adjust"])
+
+
+class TestCloseThreadCaches(unittest.TestCase):
+    def test_never_raises_even_when_yfinance_internals_change(self):
+        gateway = YFinanceGateway()
+        # Must be safe to call regardless of yfinance version internals.
+        gateway.close_thread_caches()
+        gateway.close_thread_caches()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #74. Closes #75. Closes #76. Closes #77.

## What

Consolidates every yfinance call behind `YFinanceGateway`, completing the provider-I/O boundary from architectural-standard-v2 (§5.3, Rules 2/3/5) that the July audit flagged:

| Change | Standard rule |
|---|---|
| `YFinanceGateway.fetch_history()` — the **only** `yf.download` call site; owns the serialization lock (fetch + bulk download), 730-day window cap, MultiIndex flattening | §5.3 gateways own provider calls; the lock now protects **every** caller structurally, not just the OHLCV path |
| `OhlcvRepository` → pure SQL (`store_bars`/`get_bars`/staleness primitives) | §5.1 repositories persist, nothing else |
| Fetch-when-stale policy → `PricesService.get_history()`; other services get history via constructor-injected `prices` (the RecommendationsService idiom); shared calendar helpers in new `quantcore/analytics/market_time.py` | Rule 5: caching policy is a service concern |
| `HarvesterService` fetches plan history (raw, Adj-Close-preserving) + latest closes via the gateway; `harvester_repository` takes normalized bars / injected `price_lookup` | same |
| `notifier.py` → `PricesService.get_fast_price()` (adapters call services) | Rule 2 |
| `services/options.py` yfinance-internals cleanup → `gateway.close_thread_caches()` | §5.3 |
| `fastMCPTest/collect_options.py` **retired** (superseded by `refresh_options_snapshots`); README updated | Phase 1 item 4 |
| **`test_architecture_guards.py`** — permanent CI fence: yfinance imports only in `gateways/`+carve-outs, `yf.download` only in the gateway, every download under the lock | turns the audit into a guarantee |

## Scope correction for #75

The audit listed `options_contracts.py` and `sentiment.py` as violators — both were **docstring-only false positives** (they already went through the gateway). The real #75 scope was the `yfinance.cache` import in `options.py`, fixed here.

## Verification

- **193 tests green** (35 new: gateway lock/flattening/window-cap, market_time, staleness-policy table, harvester fetch seam, fast price, the fence) — all new code test-first
- Wrapper smoke 5/5; **OpenAPI surface unchanged** (zero route changes — this is an internal refactor)
- Behavior-neutral by design: same staleness policy, same lock semantics, same bar normalization. No new retry/rate-limit semantics (now trivially possible as a follow-up since there's finally one seam).

🤖 Generated with [Claude Code](https://claude.com/claude-code)