### PR TITLE
Sidekick: interaction backchannel — component clicks flow back into the conversation

### DIFF
--- a/api/routers/chat.py
+++ b/api/routers/chat.py
@@ -24,7 +24,8 @@ _SSE_HEADERS = {
 @router.post("")
 def chat(body: ChatRequest) -> StreamingResponse:
     events = services().chat.stream_chat(
-        [{"role": m.role, "content": m.content} for m in body.messages]
+        [{"role": m.role, "content": m.content} for m in body.messages],
+        interactions=[i.model_dump(exclude_none=True) for i in body.interactions],
     )
     return StreamingResponse(
         event_stream(events),

--- a/api/schemas/chat.py
+++ b/api/schemas/chat.py
@@ -11,5 +11,18 @@ class ChatMessage(BaseModel):
     content: str = Field(min_length=1, max_length=32_000)
 
 
+class ChatInteraction(BaseModel):
+    """One UI interaction (click inside a rendered component) — the
+    backchannel. Vocabulary is validated in the service against
+    BACKEND_INTERACTION_REGISTRY; this layer only enforces shape."""
+
+    component_id: str = Field(min_length=1, max_length=64)
+    component: str = Field(min_length=1, max_length=64)
+    action: str = Field(min_length=1, max_length=64)
+    payload: dict = Field(default_factory=dict)
+    props: dict | None = None
+
+
 class ChatRequest(BaseModel):
     messages: list[ChatMessage] = Field(min_length=1, max_length=200)
+    interactions: list[ChatInteraction] = Field(default_factory=list, max_length=20)

--- a/frontend/e2e/chat-sidekick.spec.ts
+++ b/frontend/e2e/chat-sidekick.spec.ts
@@ -69,6 +69,77 @@ test('fullscreen expand hides page content and still chats; collapse restores la
   await expect(page.getByTestId('page-content')).toBeVisible();
 });
 
+test('backchannel: chart click queues an interaction that rides the next message', async ({
+  page,
+}) => {
+  // The spread card fetches real pricing over REST; the test DB has no
+  // contracts, so fulfill that one route with a fixture — everything else
+  // (SSE stream, agent loop, interaction validation) is the real backend.
+  await page.route('**/options/vertical-spread*', (route) =>
+    route.fulfill({
+      json: {
+        symbol: 'WMT',
+        expiration: '2099-12-19',
+        kind: 'call',
+        debit: 2.1,
+        mid_debit: 2.0,
+        max_profit: 3.0,
+        max_loss: 2.0,
+        breakeven: 122.0,
+        risk_reward: 1.5,
+        warnings: [],
+        legs: {
+          long: { strike: 120, mid: 6.0, iv: 0.3 },
+          short: { strike: 125, mid: 4.0, iv: 0.28 },
+        },
+      },
+    }),
+  );
+
+  await page.getByTestId('chat-toggle').click();
+  const input = page.getByTestId('chat-input').locator('textarea').first();
+  await input.fill('Price a WMT 120/125 call spread');
+  await input.press('Enter');
+
+  // The spread_payoff directive rendered an interactive risk graph.
+  await expect(page.getByTestId('directive-spread_payoff')).toBeVisible({ timeout: 15_000 });
+  const chart = page.getByTestId('spread-payoff-chart');
+  await expect(chart).toBeVisible();
+  await expect(page.getByTestId('chat-message-assistant').last()).toContainText(
+    'risk graph below is live',
+    { timeout: 15_000 },
+  );
+
+  // Click the chart: a strike is selected, the composer chip and the
+  // message-mode reprice affordances appear.
+  await chart.click({ position: { x: 200, y: 120 } });
+  await expect(page.getByTestId('pending-interaction')).toBeVisible();
+  await expect(page.getByTestId('pending-interaction')).toContainText('select strike');
+  await expect(page.getByTestId('reprice-long')).toBeVisible();
+
+  // The next typed message carries the interaction in the POST body.
+  const chatRequest = page.waitForRequest(
+    (r) => r.url().includes('/api/chat') && r.method() === 'POST',
+  );
+  await input.fill('What about this strike?');
+  await input.press('Enter');
+  const body = (await chatRequest).postDataJSON() as {
+    interactions?: { component: string; action: string; payload: { strike: number } }[];
+  };
+  expect(body.interactions).toHaveLength(1);
+  expect(body.interactions![0].component).toBe('spread_payoff');
+  expect(body.interactions![0].action).toBe('select_strike');
+  expect(Number.isFinite(body.interactions![0].payload.strike)).toBe(true);
+
+  // Round trip: the REAL backend validated the interaction and the fake
+  // acknowledged it; the one-shot chip is gone.
+  await expect(page.getByTestId('chat-message-assistant').last()).toContainText(
+    'Noted your selection',
+    { timeout: 15_000 },
+  );
+  await expect(page.getByTestId('pending-interaction')).toHaveCount(0);
+});
+
 test('conversation persists across navigation and reload', async ({ page }) => {
   await page.getByTestId('chat-toggle').click();
   const input = page.getByTestId('chat-input').locator('textarea').first();

--- a/frontend/src/api/chatStream.test.ts
+++ b/frontend/src/api/chatStream.test.ts
@@ -51,6 +51,27 @@ describe('parseSSEChunk', () => {
     expect(events[1]).toEqual({ type: 'text', delta: 'ok' });
   });
 
+  it('surfaces the directive component_id as componentId when present', () => {
+    const { events } = parseSSEChunk(
+      '',
+      frame('directive', {
+        component: 'spread_payoff',
+        props: { ticker: 'WMT' },
+        component_id: 'abc123',
+      }),
+    );
+    expect(events).toEqual([
+      {
+        type: 'directive',
+        directive: {
+          component: 'spread_payoff',
+          props: { ticker: 'WMT' },
+          componentId: 'abc123',
+        },
+      },
+    ]);
+  });
+
   it('maps all wire event types', () => {
     const chunk =
       frame('text', { delta: 't' }) +
@@ -111,6 +132,27 @@ describe('streamChat', () => {
     expect(JSON.parse(init.body).messages).toEqual([{ role: 'user', content: 'hi' }]);
 
     expect(events.map((e) => e.type)).toEqual(['text', 'directive', 'done']);
+  });
+
+  it('includes interactions in the POST body only when non-empty', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockImplementation(async () =>
+        sseResponse([frame('done', { stop_reason: 'end_turn' })]),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const interaction = {
+      component_id: 'abc123',
+      component: 'spread_payoff',
+      action: 'select_strike',
+      payload: { strike: 120 },
+    };
+    await streamChat([{ role: 'user', content: 'hi' }], () => {}, undefined, [interaction]);
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body).interactions).toEqual([interaction]);
+
+    await streamChat([{ role: 'user', content: 'hi' }], () => {}, undefined, []);
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).not.toHaveProperty('interactions');
   });
 
   it('rejects with status on non-2xx', async () => {

--- a/frontend/src/api/chatStream.ts
+++ b/frontend/src/api/chatStream.ts
@@ -6,7 +6,7 @@
  * reads the body incrementally via ReadableStream.
  */
 import { ApiError } from './client';
-import type { ApiChatMessage, ChatStreamEvent } from '../chat/types';
+import type { ApiChatMessage, ChatInteraction, ChatStreamEvent } from '../chat/types';
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL || '';
 const API_TOKEN = import.meta.env.VITE_API_TOKEN || '';
@@ -60,6 +60,8 @@ export function parseSSEChunk(
           directive: {
             component: String(data.component ?? ''),
             props: (data.props as Record<string, unknown>) ?? {},
+            // Only surface the instance id when the wire frame carries one.
+            ...(data.component_id ? { componentId: String(data.component_id) } : {}),
           },
         });
         break;
@@ -79,6 +81,7 @@ export async function streamChat(
   messages: ApiChatMessage[],
   onEvent: (event: ChatStreamEvent) => void,
   signal?: AbortSignal,
+  interactions?: ChatInteraction[],
 ): Promise<void> {
   const response = await fetch(`${API_BASE}/api/chat`, {
     method: 'POST',
@@ -86,7 +89,10 @@ export async function streamChat(
       'Content-Type': 'application/json',
       ...(API_TOKEN ? { Authorization: `Bearer ${API_TOKEN}` } : {}),
     },
-    body: JSON.stringify({ messages }),
+    body: JSON.stringify({
+      messages,
+      ...(interactions && interactions.length > 0 ? { interactions } : {}),
+    }),
     signal,
   });
 

--- a/frontend/src/chat/ChatContext.tsx
+++ b/frontend/src/chat/ChatContext.tsx
@@ -215,6 +215,28 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         });
       };
 
+      // If the stream dies without a terminal frame (server restart, network
+      // drop), tool chips stuck in 'running' would spin forever — flip any
+      // survivors to 'error' once the stream is over, however it ended.
+      const finalizeInterruptedTools = () => {
+        setMessages((prev) => {
+          const next = [...prev];
+          const last = next[next.length - 1];
+          if (last?.role !== 'assistant') return prev;
+          let changed = false;
+          const segments = last.segments.map((segment) => {
+            if (segment.type === 'tool_status' && segment.state === 'running') {
+              changed = true;
+              return { ...segment, state: 'error' as const };
+            }
+            return segment;
+          });
+          if (!changed) return prev;
+          next[next.length - 1] = { ...last, segments };
+          return next;
+        });
+      };
+
       try {
         await streamChat(
           history,
@@ -235,6 +257,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
           setError((exc as Error).message || 'Chat request failed.');
         }
       } finally {
+        finalizeInterruptedTools();
         setIsStreaming(false);
         abortRef.current = null;
       }

--- a/frontend/src/chat/ChatContext.tsx
+++ b/frontend/src/chat/ChatContext.tsx
@@ -26,6 +26,7 @@ const MESSAGES_KEY = 'hl-chat-messages';
 const OPEN_KEY = 'hl-chat-open';
 const EXPANDED_KEY = 'hl-chat-expanded';
 const PENDING_KEY = 'hl-chat-pending-interactions';
+const CONSUMED_KEY = 'hl-chat-consumed-interactions';
 
 /** Assistant segments -> the plain-text turn the model sees next time. */
 export function serializeForApi(messages: ChatMessage[]): ApiChatMessage[] {
@@ -96,6 +97,12 @@ interface ChatContextValue {
   pendingInteractions: ChatInteraction[];
   queueInteraction: (interaction: ChatInteraction) => void;
   removeInteraction: (index: number) => void;
+  /**
+   * Gestures already sent to the model, keyed by component_id. Once an
+   * instance appears here it is part of the conversational record — the
+   * rendered card locks and its mark becomes immutable.
+   */
+  consumedInteractions: Record<string, ChatInteraction[]>;
 }
 
 const ChatContext = createContext<ChatContextValue | null>(null);
@@ -122,6 +129,9 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   const [pendingInteractions, setPendingInteractions] = useState<ChatInteraction[]>(() =>
     loadStored<ChatInteraction[]>(PENDING_KEY, []),
   );
+  const [consumedInteractions, setConsumedInteractions] = useState<
+    Record<string, ChatInteraction[]>
+  >(() => loadStored<Record<string, ChatInteraction[]>>(CONSUMED_KEY, {}));
   const [isStreaming, setIsStreaming] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
@@ -141,6 +151,14 @@ export function ChatProvider({ children }: { children: ReactNode }) {
       /* ignore */
     }
   }, [pendingInteractions]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(CONSUMED_KEY, JSON.stringify(consumedInteractions));
+    } catch {
+      /* ignore */
+    }
+  }, [consumedInteractions]);
 
   const queueInteraction = useCallback((interaction: ChatInteraction) => {
     setPendingInteractions((prev) => {
@@ -179,6 +197,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
     abortRef.current?.abort();
     setMessages([]);
     setPendingInteractions([]);
+    setConsumedInteractions({});
     setError(null);
     setIsStreaming(false);
   }, []);
@@ -192,6 +211,19 @@ export function ChatProvider({ children }: { children: ReactNode }) {
       // then clear the queue — interactions are one-shot context.
       const interactions = [...pendingInteractions, ...(extraInteractions ?? [])];
       setPendingInteractions([]);
+      // Sent gestures become part of the record: lock their card instances.
+      if (interactions.length > 0) {
+        setConsumedInteractions((prev) => {
+          const next = { ...prev };
+          for (const interaction of interactions) {
+            next[interaction.component_id] = [
+              ...(next[interaction.component_id] ?? []),
+              interaction,
+            ];
+          }
+          return next;
+        });
+      }
 
       const userMessage: ChatMessage = {
         role: 'user',
@@ -280,6 +312,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         pendingInteractions,
         queueInteraction,
         removeInteraction,
+        consumedInteractions,
       }}
     >
       {children}

--- a/frontend/src/chat/ChatContext.tsx
+++ b/frontend/src/chat/ChatContext.tsx
@@ -14,11 +14,18 @@ import {
   type ReactNode,
 } from 'react';
 import { streamChat } from '../api/chatStream';
-import type { ApiChatMessage, ChatMessage, ChatStreamEvent, Segment } from './types';
+import type {
+  ApiChatMessage,
+  ChatInteraction,
+  ChatMessage,
+  ChatStreamEvent,
+  Segment,
+} from './types';
 
 const MESSAGES_KEY = 'hl-chat-messages';
 const OPEN_KEY = 'hl-chat-open';
 const EXPANDED_KEY = 'hl-chat-expanded';
+const PENDING_KEY = 'hl-chat-pending-interactions';
 
 /** Assistant segments -> the plain-text turn the model sees next time. */
 export function serializeForApi(messages: ChatMessage[]): ApiChatMessage[] {
@@ -83,8 +90,12 @@ interface ChatContextValue {
   setRailOpen: (open: boolean) => void;
   expanded: boolean;
   setExpanded: (expanded: boolean) => void;
-  sendMessage: (text: string) => Promise<void>;
+  sendMessage: (text: string, extraInteractions?: ChatInteraction[]) => Promise<void>;
   clearConversation: () => void;
+  /** Context-mode gestures waiting to ride along with the next message. */
+  pendingInteractions: ChatInteraction[];
+  queueInteraction: (interaction: ChatInteraction) => void;
+  removeInteraction: (index: number) => void;
 }
 
 const ChatContext = createContext<ChatContextValue | null>(null);
@@ -108,6 +119,9 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   const [expanded, setExpandedState] = useState<boolean>(() =>
     loadStored<boolean>(EXPANDED_KEY, false),
   );
+  const [pendingInteractions, setPendingInteractions] = useState<ChatInteraction[]>(() =>
+    loadStored<ChatInteraction[]>(PENDING_KEY, []),
+  );
   const [isStreaming, setIsStreaming] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
@@ -119,6 +133,29 @@ export function ChatProvider({ children }: { children: ReactNode }) {
       /* storage full/unavailable — history simply won't persist */
     }
   }, [messages]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(PENDING_KEY, JSON.stringify(pendingInteractions));
+    } catch {
+      /* ignore */
+    }
+  }, [pendingInteractions]);
+
+  const queueInteraction = useCallback((interaction: ChatInteraction) => {
+    setPendingInteractions((prev) => {
+      // One pending gesture per (instance, action): re-clicking replaces.
+      const rest = prev.filter(
+        (p) =>
+          !(p.component_id === interaction.component_id && p.action === interaction.action),
+      );
+      return [...rest, interaction];
+    });
+  }, []);
+
+  const removeInteraction = useCallback((index: number) => {
+    setPendingInteractions((prev) => prev.filter((_, i) => i !== index));
+  }, []);
 
   const setRailOpen = useCallback((open: boolean) => {
     setRailOpenState(open);
@@ -141,15 +178,20 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   const clearConversation = useCallback(() => {
     abortRef.current?.abort();
     setMessages([]);
+    setPendingInteractions([]);
     setError(null);
     setIsStreaming(false);
   }, []);
 
   const sendMessage = useCallback(
-    async (text: string) => {
+    async (text: string, extraInteractions?: ChatInteraction[]) => {
       const trimmed = text.trim();
       if (!trimmed || isStreaming) return;
       setError(null);
+      // Attach queued context-mode gestures plus any message-mode gesture,
+      // then clear the queue — interactions are one-shot context.
+      const interactions = [...pendingInteractions, ...(extraInteractions ?? [])];
+      setPendingInteractions([]);
 
       const userMessage: ChatMessage = {
         role: 'user',
@@ -186,6 +228,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
             }
           },
           controller.signal,
+          interactions,
         );
       } catch (exc) {
         if ((exc as Error).name !== 'AbortError') {
@@ -196,7 +239,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         abortRef.current = null;
       }
     },
-    [messages, isStreaming],
+    [messages, isStreaming, pendingInteractions],
   );
 
   return (
@@ -211,6 +254,9 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         setExpanded,
         sendMessage,
         clearConversation,
+        pendingInteractions,
+        queueInteraction,
+        removeInteraction,
       }}
     >
       {children}
@@ -222,4 +268,10 @@ export function useChat(): ChatContextValue {
   const value = useContext(ChatContext);
   if (!value) throw new Error('useChat must be used inside <ChatProvider>');
   return value;
+}
+
+/** Like useChat, but safe outside <ChatProvider> — returns null instead of
+ * throwing, so directive components stay renderable in isolation/tests. */
+export function useChatOptional(): ChatContextValue | null {
+  return useContext(ChatContext);
 }

--- a/frontend/src/chat/DirectiveInteractions.tsx
+++ b/frontend/src/chat/DirectiveInteractions.tsx
@@ -1,0 +1,74 @@
+/**
+ * The bridge between a rendered directive component and the chat backchannel.
+ *
+ * DirectiveRenderer wraps each rendered component in a provider carrying that
+ * instance's identity (componentId, component name, validated props). Cards
+ * call `interact(action, payload, text?)`:
+ *
+ *   - 'context'-mode actions queue onto the composer (they ride along with
+ *     the user's next typed message);
+ *   - 'message'-mode actions submit `text` immediately with the interaction
+ *     attached.
+ *
+ * The mode comes from INTERACTION_REGISTRY, payloads are validated before
+ * anything leaves the component, and everything is inert (enabled: false)
+ * when there is no chat context, no instance id, or no vocabulary for the
+ * component — so cards render safely anywhere.
+ */
+import { createContext, useContext, useMemo, type ReactNode } from 'react';
+import { useChatOptional } from './ChatContext';
+import { INTERACTION_REGISTRY, validateInteractionPayload } from './componentRegistry';
+import type { ChatDirective } from './types';
+
+export interface DirectiveInteractionApi {
+  /** True when gestures from this instance can reach the conversation. */
+  enabled: boolean;
+  interact: (action: string, payload: Record<string, unknown>, text?: string) => void;
+}
+
+const INERT: DirectiveInteractionApi = { enabled: false, interact: () => undefined };
+
+const Ctx = createContext<DirectiveInteractionApi>(INERT);
+
+export function useDirectiveInteractions(): DirectiveInteractionApi {
+  return useContext(Ctx);
+}
+
+interface ProviderProps {
+  directive: ChatDirective;
+  /** Normalized props actually passed to the component (ticker uppercased). */
+  props: Record<string, unknown>;
+  children: ReactNode;
+}
+
+export function DirectiveInteractionProvider({ directive, props, children }: ProviderProps) {
+  const chat = useChatOptional();
+  const { component, componentId } = directive;
+
+  const api = useMemo<DirectiveInteractionApi>(() => {
+    const actions = INTERACTION_REGISTRY[component];
+    if (!chat || !componentId || !actions) return INERT;
+    return {
+      enabled: true,
+      interact: (action, payload, text) => {
+        const spec = actions[action];
+        if (!spec) return;
+        if (!validateInteractionPayload(component, action, payload).ok) return;
+        const interaction = {
+          component_id: componentId,
+          component,
+          action,
+          payload,
+          props,
+        };
+        if (spec.mode === 'message' && text) {
+          void chat.sendMessage(text, [interaction]);
+        } else {
+          chat.queueInteraction(interaction);
+        }
+      },
+    };
+  }, [chat, component, componentId, props]);
+
+  return <Ctx.Provider value={api}>{children}</Ctx.Provider>;
+}

--- a/frontend/src/chat/DirectiveInteractions.tsx
+++ b/frontend/src/chat/DirectiveInteractions.tsx
@@ -14,19 +14,33 @@
  * anything leaves the component, and everything is inert (enabled: false)
  * when there is no chat context, no instance id, or no vocabulary for the
  * component — so cards render safely anywhere.
+ *
+ * Once a gesture from an instance has been SENT, the instance is `locked`:
+ * it is part of the conversational record the model already answered, so its
+ * mark and affordances must never change again. Locked cards receive the
+ * `consumed` gestures to render their frozen state from.
  */
 import { createContext, useContext, useMemo, type ReactNode } from 'react';
 import { useChatOptional } from './ChatContext';
 import { INTERACTION_REGISTRY, validateInteractionPayload } from './componentRegistry';
-import type { ChatDirective } from './types';
+import type { ChatDirective, ChatInteraction } from './types';
 
 export interface DirectiveInteractionApi {
   /** True when gestures from this instance can reach the conversation. */
   enabled: boolean;
+  /** True once a gesture from this instance has been sent — immutable now. */
+  locked: boolean;
+  /** The gestures that were sent, oldest first — locked cards render these. */
+  consumed: ChatInteraction[];
   interact: (action: string, payload: Record<string, unknown>, text?: string) => void;
 }
 
-const INERT: DirectiveInteractionApi = { enabled: false, interact: () => undefined };
+const INERT: DirectiveInteractionApi = {
+  enabled: false,
+  locked: false,
+  consumed: [],
+  interact: () => undefined,
+};
 
 const Ctx = createContext<DirectiveInteractionApi>(INERT);
 
@@ -44,12 +58,19 @@ interface ProviderProps {
 export function DirectiveInteractionProvider({ directive, props, children }: ProviderProps) {
   const chat = useChatOptional();
   const { component, componentId } = directive;
+  const consumed: ChatInteraction[] =
+    (componentId && chat?.consumedInteractions?.[componentId]) || [];
 
   const api = useMemo<DirectiveInteractionApi>(() => {
     const actions = INTERACTION_REGISTRY[component];
     if (!chat || !componentId || !actions) return INERT;
+    if (consumed.length > 0) {
+      return { enabled: false, locked: true, consumed, interact: () => undefined };
+    }
     return {
       enabled: true,
+      locked: false,
+      consumed: [],
       interact: (action, payload, text) => {
         const spec = actions[action];
         if (!spec) return;
@@ -68,7 +89,7 @@ export function DirectiveInteractionProvider({ directive, props, children }: Pro
         }
       },
     };
-  }, [chat, component, componentId, props]);
+  }, [chat, component, componentId, props, consumed]);
 
   return <Ctx.Provider value={api}>{children}</Ctx.Provider>;
 }

--- a/frontend/src/chat/componentRegistry.test.ts
+++ b/frontend/src/chat/componentRegistry.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { COMPONENT_REGISTRY, validateDirective } from './componentRegistry';
+import {
+  COMPONENT_REGISTRY,
+  INTERACTION_REGISTRY,
+  validateDirective,
+  validateInteractionPayload,
+} from './componentRegistry';
 
 // Keep this case table aligned with test_chat_protocol.py::TestValidateDirective —
 // the frontend re-validates independently of the backend.
@@ -8,6 +13,65 @@ describe('COMPONENT_REGISTRY', () => {
     for (const name of ['signals', 'live_price', 'price_chart', 'spread_payoff']) {
       expect(COMPONENT_REGISTRY[name]?.component, name).toBeTypeOf('function');
     }
+  });
+});
+
+// Keep aligned with test_chat_protocol.py::TestValidateInteraction — the
+// interaction vocabulary is dual-validated exactly like directive props.
+describe('INTERACTION_REGISTRY', () => {
+  it('declares gestures only for registered components', () => {
+    for (const name of Object.keys(INTERACTION_REGISTRY)) {
+      expect(COMPONENT_REGISTRY[name], name).toBeDefined();
+    }
+  });
+
+  it('declares the v1 vocabulary with modes', () => {
+    expect(INTERACTION_REGISTRY.spread_payoff.select_strike.mode).toBe('context');
+    expect(INTERACTION_REGISTRY.spread_payoff.reprice_leg.mode).toBe('message');
+    expect(INTERACTION_REGISTRY.price_chart.select_point.mode).toBe('context');
+  });
+});
+
+describe('validateInteractionPayload', () => {
+  it('accepts a valid select_strike payload', () => {
+    expect(
+      validateInteractionPayload('spread_payoff', 'select_strike', { strike: 120 }).ok,
+    ).toBe(true);
+  });
+
+  it('accepts a valid reprice_leg payload', () => {
+    expect(
+      validateInteractionPayload('spread_payoff', 'reprice_leg', {
+        leg: 'short',
+        strike: 122.5,
+      }).ok,
+    ).toBe(true);
+  });
+
+  it('rejects unknown actions and unknown components', () => {
+    expect(validateInteractionPayload('spread_payoff', 'explode', {}).ok).toBe(false);
+    expect(validateInteractionPayload('signals', 'select_strike', { strike: 1 }).ok).toBe(
+      false,
+    );
+  });
+
+  it('rejects missing, extra, non-finite and wrong-typed fields', () => {
+    expect(validateInteractionPayload('spread_payoff', 'select_strike', {}).ok).toBe(false);
+    expect(
+      validateInteractionPayload('spread_payoff', 'select_strike', {
+        strike: 120,
+        evil: 'x',
+      }).ok,
+    ).toBe(false);
+    expect(
+      validateInteractionPayload('spread_payoff', 'select_strike', { strike: NaN }).ok,
+    ).toBe(false);
+    expect(
+      validateInteractionPayload('spread_payoff', 'select_strike', { strike: '120' }).ok,
+    ).toBe(false);
+    expect(
+      validateInteractionPayload('price_chart', 'select_point', { date: ' ', price: 5 }).ok,
+    ).toBe(false);
   });
 });
 

--- a/frontend/src/chat/componentRegistry.tsx
+++ b/frontend/src/chat/componentRegistry.tsx
@@ -44,7 +44,57 @@ export const COMPONENT_REGISTRY: Record<string, RegistryEntry> = {
   },
 };
 
+/**
+ * The interaction vocabulary — which user gestures each component may send
+ * back into the conversation. Mirrors BACKEND_INTERACTION_REGISTRY in
+ * quantcore/services/chat_tools.py (both sides validate, like directives).
+ *
+ * mode 'context': the gesture attaches to the NEXT typed message.
+ * mode 'message': the gesture submits a structured turn immediately.
+ */
+export interface InteractionSpec {
+  payload: Record<string, PropKind>;
+  mode: 'context' | 'message';
+}
+
+export const INTERACTION_REGISTRY: Record<string, Record<string, InteractionSpec>> = {
+  spread_payoff: {
+    select_strike: { payload: { strike: 'number' }, mode: 'context' },
+    reprice_leg: { payload: { leg: 'string', strike: 'number' }, mode: 'message' },
+  },
+  price_chart: {
+    select_point: { payload: { date: 'string', price: 'number' }, mode: 'context' },
+  },
+};
+
 export type ValidationResult = { ok: true } | { ok: false; reason: string };
+
+export function validateInteractionPayload(
+  component: string,
+  action: string,
+  payload: Record<string, unknown>,
+  registry: Record<string, Record<string, InteractionSpec>> = INTERACTION_REGISTRY,
+): ValidationResult {
+  const spec = registry[component]?.[action];
+  if (!spec) {
+    return { ok: false, reason: `No interaction '${action}' on '${component}'` };
+  }
+  const extra = Object.keys(payload).filter((k) => !(k in spec.payload));
+  if (extra.length > 0) {
+    return { ok: false, reason: `Unexpected payload fields: ${extra.join(', ')}` };
+  }
+  for (const [name, kind] of Object.entries(spec.payload)) {
+    const value = payload[name];
+    if (kind === 'string') {
+      if (typeof value !== 'string' || value.trim().length === 0) {
+        return { ok: false, reason: `Payload '${name}' must be a non-empty string` };
+      }
+    } else if (typeof value !== 'number' || !Number.isFinite(value)) {
+      return { ok: false, reason: `Payload '${name}' must be a finite number` };
+    }
+  }
+  return { ok: true };
+}
 
 export function validateDirective(
   directive: ChatDirective,

--- a/frontend/src/chat/types.ts
+++ b/frontend/src/chat/types.ts
@@ -3,6 +3,22 @@
 export interface ChatDirective {
   component: string;
   props: Record<string, unknown>;
+  /** Server-assigned instance id — interactions reference exactly this render. */
+  componentId?: string;
+}
+
+/**
+ * One user interaction inside a rendered component (the UI->model
+ * backchannel). Field names are the wire shape of POST /api/chat's
+ * `interactions` array (api/schemas/chat.py) — snake_case on purpose.
+ */
+export interface ChatInteraction {
+  component_id: string;
+  component: string;
+  action: string;
+  payload: Record<string, unknown>;
+  /** Props snapshot of the touched instance, so the envelope is self-describing. */
+  props?: Record<string, unknown>;
 }
 
 /** One decoded SSE event from POST /api/chat. */

--- a/frontend/src/components/chat/ChatRail.test.tsx
+++ b/frontend/src/components/chat/ChatRail.test.tsx
@@ -238,6 +238,11 @@ describe('ChatRail', () => {
       expect(streamChatMock.mock.calls[0][3]).toEqual([PENDING]);
       // One-shot context: the chip is gone after the send.
       expect(screen.queryByTestId('pending-interaction')).toBeNull();
+      // The instance is now on the consumed record — its card locks.
+      const consumed = JSON.parse(
+        localStorage.getItem('hl-chat-consumed-interactions') ?? '{}',
+      );
+      expect(consumed['inst-1']).toEqual([PENDING]);
       finishStream();
     });
 

--- a/frontend/src/components/chat/ChatRail.test.tsx
+++ b/frontend/src/components/chat/ChatRail.test.tsx
@@ -199,6 +199,25 @@ describe('ChatRail', () => {
     expect(history[history.length - 1]).toEqual({ role: 'user', content: 'And AMD?' });
   });
 
+  it('flips running tool chips to error when the stream dies without a terminal frame', async () => {
+    renderRail();
+    await sendPrompt('Price an MSTR spread');
+    emit({ type: 'text', delta: 'Pricing…' });
+    emit({
+      type: 'tool_status',
+      tool: 'price_vertical_spread',
+      args: { symbol: 'MSTR' },
+      state: 'running',
+    });
+    expect(screen.getByTestId('tool-chip-price_vertical_spread').dataset.state).toBe('running');
+
+    // Server restarted mid-call: the stream just ends — no done, no error frame.
+    finishStream();
+    await waitFor(() =>
+      expect(screen.getByTestId('tool-chip-price_vertical_spread').dataset.state).toBe('error'),
+    );
+  });
+
   describe('pending interactions (backchannel composer chips)', () => {
     const PENDING = {
       component_id: 'inst-1',

--- a/frontend/src/components/chat/ChatRail.test.tsx
+++ b/frontend/src/components/chat/ChatRail.test.tsx
@@ -8,7 +8,12 @@ import type { ChatStreamEvent } from '../../chat/types';
 let currentOnEvent: ((e: ChatStreamEvent) => void) | null = null;
 let resolveStream: (() => void) | null = null;
 const streamChatMock = vi.fn(
-  (_msgs: unknown, onEvent: (e: ChatStreamEvent) => void) =>
+  (
+    _msgs: unknown,
+    onEvent: (e: ChatStreamEvent) => void,
+    _signal?: unknown,
+    _interactions?: unknown,
+  ) =>
     new Promise<void>((resolve) => {
       currentOnEvent = onEvent;
       resolveStream = resolve;
@@ -192,5 +197,42 @@ describe('ChatRail', () => {
     expect(assistantTurn?.content).toContain('Here.');
     expect(assistantTurn?.content).toContain('[shown: signals INTC]');
     expect(history[history.length - 1]).toEqual({ role: 'user', content: 'And AMD?' });
+  });
+
+  describe('pending interactions (backchannel composer chips)', () => {
+    const PENDING = {
+      component_id: 'inst-1',
+      component: 'spread_payoff',
+      action: 'select_strike',
+      payload: { strike: 120 },
+    };
+
+    it('shows a chip for a queued interaction and sends it with the next message', async () => {
+      localStorage.setItem('hl-chat-pending-interactions', JSON.stringify([PENDING]));
+      renderRail();
+
+      const chip = screen.getByTestId('pending-interaction');
+      expect(chip.textContent).toContain('select strike');
+      expect(chip.textContent).toContain('120');
+
+      await sendPrompt('What about this one?');
+      expect(streamChatMock.mock.calls[0][3]).toEqual([PENDING]);
+      // One-shot context: the chip is gone after the send.
+      expect(screen.queryByTestId('pending-interaction')).toBeNull();
+      finishStream();
+    });
+
+    it('chip delete discards the pending interaction without sending', async () => {
+      localStorage.setItem('hl-chat-pending-interactions', JSON.stringify([PENDING]));
+      renderRail();
+
+      const chip = screen.getByTestId('pending-interaction');
+      await userEvent.click(chip.querySelector('.MuiChip-deleteIcon')!);
+      expect(screen.queryByTestId('pending-interaction')).toBeNull();
+
+      await sendPrompt('plain question');
+      expect(streamChatMock.mock.calls[0][3]).toEqual([]);
+      finishStream();
+    });
   });
 });

--- a/frontend/src/components/chat/ChatRail.tsx
+++ b/frontend/src/components/chat/ChatRail.tsx
@@ -88,9 +88,26 @@ function MessageView({ message }: { message: ChatMessage }) {
   );
 }
 
+/** "select_strike: strike 120" — compact composer-chip label for a gesture. */
+function interactionLabel(action: string, payload: Record<string, unknown>): string {
+  const detail = Object.entries(payload)
+    .map(([k, v]) => `${k} ${v}`)
+    .join(', ');
+  return `${action.replace(/_/g, ' ')}: ${detail}`;
+}
+
 export default function ChatRail() {
-  const { messages, isStreaming, error, expanded, setExpanded, sendMessage, clearConversation } =
-    useChat();
+  const {
+    messages,
+    isStreaming,
+    error,
+    expanded,
+    setExpanded,
+    sendMessage,
+    clearConversation,
+    pendingInteractions,
+    removeInteraction,
+  } = useChat();
   const [draft, setDraft] = useState('');
   const scrollRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
@@ -167,6 +184,29 @@ export default function ChatRail() {
         <Alert severity="error" data-testid="chat-error" sx={{ mx: 1.5, mb: 1, ...centered }}>
           {error}
         </Alert>
+      )}
+
+      {pendingInteractions.length > 0 && (
+        <Stack
+          direction="row"
+          spacing={0.5}
+          flexWrap="wrap"
+          useFlexGap
+          sx={{ px: 1.5, pb: 0.5, ...centered }}
+        >
+          {pendingInteractions.map((interaction, i) => (
+            <Chip
+              key={`${interaction.component_id}-${interaction.action}-${i}`}
+              size="small"
+              color="info"
+              variant="outlined"
+              data-testid="pending-interaction"
+              label={interactionLabel(interaction.action, interaction.payload)}
+              onDelete={() => removeInteraction(i)}
+              sx={{ fontSize: 11 }}
+            />
+          ))}
+        </Stack>
       )}
 
       <Stack direction="row" spacing={1} sx={{ p: 1.5, pt: 0.5, ...centered }}>

--- a/frontend/src/components/chat/DirectiveRenderer.tsx
+++ b/frontend/src/components/chat/DirectiveRenderer.tsx
@@ -12,6 +12,7 @@ import {
   validateDirective,
   type RegistryEntry,
 } from '../../chat/componentRegistry';
+import { DirectiveInteractionProvider } from '../../chat/DirectiveInteractions';
 import type { ChatDirective } from '../../chat/types';
 
 class DirectiveErrorBoundary extends Component<{ children: ReactNode }, { failed: boolean }> {
@@ -74,7 +75,9 @@ export default function DirectiveRenderer({ directive, registry = COMPONENT_REGI
         {entry.titled && typeof passProps.ticker === 'string' && (
           <DirectiveTitle ticker={passProps.ticker} />
         )}
-        <Registered {...passProps} />
+        <DirectiveInteractionProvider directive={directive} props={passProps}>
+          <Registered {...passProps} />
+        </DirectiveInteractionProvider>
       </Box>
     </DirectiveErrorBoundary>
   );

--- a/frontend/src/components/chat/PriceChartCard.tsx
+++ b/frontend/src/components/chat/PriceChartCard.tsx
@@ -5,9 +5,11 @@
 import { Alert, Box, CircularProgress, Typography } from '@mui/material';
 import PriceChart from '../securities/charts/PriceChart';
 import { useTechnicals } from '../../hooks/useSecurities';
+import { useDirectiveInteractions } from '../../chat/DirectiveInteractions';
 
 export default function PriceChartCard({ ticker }: { ticker: string }) {
   const { data, isLoading, error } = useTechnicals(ticker, 365);
+  const interactions = useDirectiveInteractions();
 
   if (isLoading) {
     return (
@@ -31,7 +33,20 @@ export default function PriceChartCard({ ticker }: { ticker: string }) {
       <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
         {ticker} — price &amp; moving averages
       </Typography>
-      <PriceChart data={indicators} height={220} />
+      <PriceChart
+        data={indicators}
+        height={220}
+        onPointClick={
+          interactions.enabled
+            ? (point) => interactions.interact('select_point', { ...point })
+            : undefined
+        }
+      />
+      {interactions.enabled && (
+        <Typography variant="caption" color="text.secondary">
+          Click the chart to attach a date/price to your next question
+        </Typography>
+      )}
     </Box>
   );
 }

--- a/frontend/src/components/chat/SpreadPayoffCard.test.tsx
+++ b/frontend/src/components/chat/SpreadPayoffCard.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 
 const useVerticalSpreadMock = vi.fn();
 const usePricePollingMock = vi.fn();
@@ -10,7 +10,18 @@ vi.mock('../../hooks/useSymbols', () => ({
   usePricePolling: (...args: unknown[]) => usePricePollingMock(...args),
 }));
 
+// Fake chat context so DirectiveInteractionProvider is live without ChatProvider.
+const queueInteractionMock = vi.fn();
+const sendMessageMock = vi.fn();
+vi.mock('../../chat/ChatContext', () => ({
+  useChatOptional: () => ({
+    queueInteraction: queueInteractionMock,
+    sendMessage: sendMessageMock,
+  }),
+}));
+
 import SpreadPayoffCard from './SpreadPayoffCard';
+import { DirectiveInteractionProvider } from '../../chat/DirectiveInteractions';
 
 const SPREAD_RESPONSE = {
   symbol: 'INTC',
@@ -41,6 +52,8 @@ afterEach(() => {
   cleanup();
   useVerticalSpreadMock.mockReset();
   usePricePollingMock.mockReset();
+  queueInteractionMock.mockReset();
+  sendMessageMock.mockReset();
 });
 
 describe('SpreadPayoffCard', () => {
@@ -80,6 +93,19 @@ describe('SpreadPayoffCard', () => {
     expect(screen.getByTestId('spread-payoff-error')).toBeInTheDocument();
   });
 
+  it('is display-only without an interaction provider', () => {
+    useVerticalSpreadMock.mockReturnValue({
+      data: { ...SPREAD_RESPONSE, expiration: PROPS.expiration },
+      isLoading: false,
+      error: null,
+    });
+    usePricePollingMock.mockReturnValue({ data: { ticker: 'INTC', price: 150 } });
+    render(<SpreadPayoffCard {...PROPS} />);
+    fireEvent.click(screen.getByTestId('spread-payoff-chart'), { clientX: 120 });
+    expect(queueInteractionMock).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('reprice-long')).toBeNull();
+  });
+
   it('surfaces liquidity warnings from the service', () => {
     useVerticalSpreadMock.mockReturnValue({
       data: {
@@ -93,5 +119,64 @@ describe('SpreadPayoffCard', () => {
     usePricePollingMock.mockReturnValue({ data: { ticker: 'INTC', price: 150 } });
     render(<SpreadPayoffCard {...PROPS} />);
     expect(screen.getByTestId('spread-payoff-warning').textContent).toContain('wide bid/ask');
+  });
+});
+
+describe('SpreadPayoffCard interactions (backchannel)', () => {
+  const DIRECTIVE = {
+    component: 'spread_payoff',
+    componentId: 'inst-1',
+    props: PROPS as unknown as Record<string, unknown>,
+  };
+
+  function renderInteractive() {
+    useVerticalSpreadMock.mockReturnValue({
+      data: { ...SPREAD_RESPONSE, expiration: PROPS.expiration },
+      isLoading: false,
+      error: null,
+    });
+    usePricePollingMock.mockReturnValue({ data: { ticker: 'INTC', price: 150 } });
+    return render(
+      <DirectiveInteractionProvider directive={DIRECTIVE} props={DIRECTIVE.props}>
+        <SpreadPayoffCard {...PROPS} />
+      </DirectiveInteractionProvider>,
+    );
+  }
+
+  it('clicking the chart queues a select_strike with the instance identity', () => {
+    renderInteractive();
+    fireEvent.click(screen.getByTestId('spread-payoff-chart'), { clientX: 120 });
+    expect(queueInteractionMock).toHaveBeenCalledTimes(1);
+    const queued = queueInteractionMock.mock.calls[0][0];
+    expect(queued.component).toBe('spread_payoff');
+    expect(queued.component_id).toBe('inst-1');
+    expect(queued.action).toBe('select_strike');
+    expect(Number.isFinite(queued.payload.strike)).toBe(true);
+    expect(queued.props).toEqual(DIRECTIVE.props);
+  });
+
+  it('selecting a strike reveals reprice chips; clicking one sends a message-mode turn', () => {
+    renderInteractive();
+    expect(screen.queryByTestId('reprice-long')).toBeNull();
+    fireEvent.click(screen.getByTestId('spread-payoff-chart'), { clientX: 120 });
+
+    fireEvent.click(screen.getByTestId('reprice-long'));
+    expect(sendMessageMock).toHaveBeenCalledTimes(1);
+    const [text, extras] = sendMessageMock.mock.calls[0];
+    expect(text).toContain('long leg');
+    expect(text).toContain('INTC');
+    expect(extras).toHaveLength(1);
+    expect(extras[0].action).toBe('reprice_leg');
+    expect(extras[0].payload.leg).toBe('long');
+    expect(Number.isFinite(extras[0].payload.strike)).toBe(true);
+    // Message-mode gestures never touch the context queue.
+    expect(queueInteractionMock).toHaveBeenCalledTimes(1); // only the select
+  });
+
+  it('mentions chart clickability in the caption when interactive', () => {
+    renderInteractive();
+    expect(screen.getByTestId('spread-payoff-card').textContent).toContain(
+      'Click the chart to select a strike',
+    );
   });
 });

--- a/frontend/src/components/chat/SpreadPayoffCard.test.tsx
+++ b/frontend/src/components/chat/SpreadPayoffCard.test.tsx
@@ -13,11 +13,17 @@ vi.mock('../../hooks/useSymbols', () => ({
 // Fake chat context so DirectiveInteractionProvider is live without ChatProvider.
 const queueInteractionMock = vi.fn();
 const sendMessageMock = vi.fn();
+const chatState: {
+  queueInteraction: typeof queueInteractionMock;
+  sendMessage: typeof sendMessageMock;
+  consumedInteractions: Record<string, unknown[]>;
+} = {
+  queueInteraction: queueInteractionMock,
+  sendMessage: sendMessageMock,
+  consumedInteractions: {},
+};
 vi.mock('../../chat/ChatContext', () => ({
-  useChatOptional: () => ({
-    queueInteraction: queueInteractionMock,
-    sendMessage: sendMessageMock,
-  }),
+  useChatOptional: () => chatState,
 }));
 
 import SpreadPayoffCard from './SpreadPayoffCard';
@@ -54,6 +60,7 @@ afterEach(() => {
   usePricePollingMock.mockReset();
   queueInteractionMock.mockReset();
   sendMessageMock.mockReset();
+  chatState.consumedInteractions = {};
 });
 
 describe('SpreadPayoffCard', () => {
@@ -171,6 +178,39 @@ describe('SpreadPayoffCard interactions (backchannel)', () => {
     expect(Number.isFinite(extras[0].payload.strike)).toBe(true);
     // Message-mode gestures never touch the context queue.
     expect(queueInteractionMock).toHaveBeenCalledTimes(1); // only the select
+  });
+
+  it('locks the card once its gesture has been sent: frozen mark, no clicks, no chips', () => {
+    chatState.consumedInteractions = {
+      'inst-1': [
+        {
+          component_id: 'inst-1',
+          component: 'spread_payoff',
+          action: 'select_strike',
+          payload: { strike: 150 },
+        },
+      ],
+    };
+    renderInteractive();
+
+    // The answered selection renders as an immutable mark.
+    const chart = screen.getByTestId('spread-payoff-chart');
+    expect(chart.textContent).toContain('sel 150');
+    expect(screen.getByTestId('spread-payoff-card').textContent).toContain(
+      'Selection locked',
+    );
+
+    // Clicking neither queues a new gesture nor moves the mark.
+    fireEvent.click(chart, { clientX: 300 });
+    expect(queueInteractionMock).not.toHaveBeenCalled();
+    expect(chart.textContent).toContain('sel 150');
+
+    // No live affordances on a historical card.
+    expect(screen.queryByTestId('reprice-long')).toBeNull();
+    expect(screen.queryByTestId('reprice-short')).toBeNull();
+    expect(screen.getByTestId('spread-payoff-card').textContent).not.toContain(
+      'Click the chart to select a strike',
+    );
   });
 
   it('mentions chart clickability in the caption when interactive', () => {

--- a/frontend/src/components/chat/SpreadPayoffCard.tsx
+++ b/frontend/src/components/chat/SpreadPayoffCard.tsx
@@ -10,6 +10,7 @@ import { Alert, Box, Chip, CircularProgress, Stack, Typography } from '@mui/mate
 import { useVerticalSpread } from '../../hooks/useSecurities';
 import { usePricePolling } from '../../hooks/useSymbols';
 import { buildCurves, type SpreadInput } from '../../chat/spreadMath';
+import { useDirectiveInteractions } from '../../chat/DirectiveInteractions';
 
 const HEIGHT = 240;
 const MARGIN = { top: 12, right: 16, bottom: 28, left: 56 };
@@ -46,6 +47,8 @@ export default function SpreadPayoffCard({
   const spot = priceData?.price ?? 0;
   const svgRef = useRef<SVGSVGElement>(null);
   const [containerWidth, setContainerWidth] = useState(0);
+  const interactions = useDirectiveInteractions();
+  const [selectedStrike, setSelectedStrike] = useState<number | null>(null);
 
   // Track the container's real width (bubble sizing settles after first
   // paint, and expand/collapse changes it) so the chart always fills it.
@@ -184,7 +187,20 @@ export default function SpreadPayoffCard({
     marker(data.legs.short.strike, '#f59e0b', `S ${data.legs.short.strike}`);
     marker(data.breakeven, '#a78bfa', `BE ${data.breakeven}`);
     if (spot > 0) marker(spot, '#ff2d78', `spot ${spot.toFixed(2)}`, '1,0');
-  }, [data, spot, expiration, containerWidth]);
+    if (selectedStrike != null) marker(selectedStrike, '#22d3ee', `sel ${selectedStrike}`, '6,3');
+
+    // Backchannel: click a price on the chart to select a strike — snapped to
+    // $0.50 — and attach it to the next message (context mode).
+    if (interactions.enabled) {
+      svg.style('cursor', 'crosshair').on('click', (event) => {
+        const [mx] = d3.pointer(event);
+        if (mx < MARGIN.left || mx > width - MARGIN.right) return;
+        const strike = Math.round(x.invert(mx) * 2) / 2;
+        setSelectedStrike(strike);
+        interactions.interact('select_strike', { strike });
+      });
+    }
+  }, [data, spot, expiration, containerWidth, interactions, selectedStrike]);
 
   if (isLoading) {
     return (
@@ -237,7 +253,30 @@ export default function SpreadPayoffCard({
       </Box>
       <Typography variant="caption" color="text.secondary">
         Solid: P/L at expiration · Dashed: value today (BS, per-leg IV) · per contract (×100)
+        {interactions.enabled && ' · Click the chart to select a strike'}
       </Typography>
+      {interactions.enabled && selectedStrike != null && (
+        <Stack direction="row" spacing={0.5} sx={{ mt: 0.5 }}>
+          {(['long', 'short'] as const).map((leg) => (
+            <Chip
+              key={leg}
+              size="small"
+              color="primary"
+              variant="outlined"
+              data-testid={`reprice-${leg}`}
+              label={`Move ${leg} leg → $${selectedStrike}`}
+              onClick={() =>
+                interactions.interact(
+                  'reprice_leg',
+                  { leg, strike: selectedStrike },
+                  `Reprice the ${ticker} ${expiration} ${kind} spread with the ${leg} leg moved to $${selectedStrike} (other leg unchanged), and compare it to the current ${long_strike}/${short_strike}.`,
+                )
+              }
+              sx={{ fontSize: 11 }}
+            />
+          ))}
+        </Stack>
+      )}
     </Box>
   );
 }

--- a/frontend/src/components/chat/SpreadPayoffCard.tsx
+++ b/frontend/src/components/chat/SpreadPayoffCard.tsx
@@ -49,6 +49,16 @@ export default function SpreadPayoffCard({
   const [containerWidth, setContainerWidth] = useState(0);
   const interactions = useDirectiveInteractions();
   const [selectedStrike, setSelectedStrike] = useState<number | null>(null);
+  // Once this instance's gesture has been sent, the mark is part of the
+  // answered conversation: render it from the consumed record, immutably.
+  const lockedStrike = (() => {
+    for (let i = interactions.consumed.length - 1; i >= 0; i--) {
+      const strike = interactions.consumed[i].payload.strike;
+      if (typeof strike === 'number') return strike;
+    }
+    return null;
+  })();
+  const shownStrike = interactions.locked ? lockedStrike : selectedStrike;
 
   // Track the container's real width (bubble sizing settles after first
   // paint, and expand/collapse changes it) so the chart always fills it.
@@ -187,7 +197,7 @@ export default function SpreadPayoffCard({
     marker(data.legs.short.strike, '#f59e0b', `S ${data.legs.short.strike}`);
     marker(data.breakeven, '#a78bfa', `BE ${data.breakeven}`);
     if (spot > 0) marker(spot, '#ff2d78', `spot ${spot.toFixed(2)}`, '1,0');
-    if (selectedStrike != null) marker(selectedStrike, '#22d3ee', `sel ${selectedStrike}`, '6,3');
+    if (shownStrike != null) marker(shownStrike, '#22d3ee', `sel ${shownStrike}`, '6,3');
 
     // Backchannel: click a price on the chart to select a strike — snapped to
     // $0.50 — and attach it to the next message (context mode).
@@ -200,7 +210,7 @@ export default function SpreadPayoffCard({
         interactions.interact('select_strike', { strike });
       });
     }
-  }, [data, spot, expiration, containerWidth, interactions, selectedStrike]);
+  }, [data, spot, expiration, containerWidth, interactions, shownStrike]);
 
   if (isLoading) {
     return (
@@ -254,6 +264,7 @@ export default function SpreadPayoffCard({
       <Typography variant="caption" color="text.secondary">
         Solid: P/L at expiration · Dashed: value today (BS, per-leg IV) · per contract (×100)
         {interactions.enabled && ' · Click the chart to select a strike'}
+        {interactions.locked && shownStrike != null && ' · Selection locked (answered)'}
       </Typography>
       {interactions.enabled && selectedStrike != null && (
         <Stack direction="row" spacing={0.5} sx={{ mt: 0.5 }}>

--- a/frontend/src/components/securities/charts/PriceChart.tsx
+++ b/frontend/src/components/securities/charts/PriceChart.tsx
@@ -13,6 +13,8 @@ interface Props {
   showBB?: boolean;
   height?: number;
   earningsDates?: string[]; // YYYY-MM-DD strings to mark on chart
+  /** Optional: click the chart to select the nearest bar (chat backchannel). */
+  onPointClick?: (point: { date: string; price: number }) => void;
 }
 
 const MARGIN = { top: 16, right: 16, bottom: 32, left: 60 };
@@ -29,6 +31,7 @@ export default function PriceChart({
   showBB = true,
   height = 300,
   earningsDates = [],
+  onPointClick,
 }: Props) {
   const ref = useRef<SVGSVGElement>(null);
 
@@ -201,6 +204,14 @@ export default function PriceChart({
       .attr('width', W).attr('height', H)
       .attr('fill', 'none')
       .attr('pointer-events', 'all')
+      .style('cursor', onPointClick ? 'crosshair' : 'default')
+      .on('click', (event) => {
+        if (!onPointClick) return;
+        const [mx] = d3.pointer(event);
+        const i = bisect(valid, xScale.invert(mx), 1);
+        const d = valid[Math.min(i, valid.length - 1)];
+        if (d?.close != null) onPointClick({ date: d.date, price: d.close });
+      })
       .on('mousemove', function (event) {
         const [mx] = d3.pointer(event);
         const x0 = xScale.invert(mx);
@@ -226,7 +237,7 @@ export default function PriceChart({
         focus.style('display', 'none');
         tooltip.style('display', 'none');
       });
-  }, [data, showMAs, showBB, height, earningsDates]);
+  }, [data, showMAs, showBB, height, earningsDates, onPointClick]);
 
   const latest = data[data.length - 1];
   const first  = data[0];

--- a/quantcore/services/chat.py
+++ b/quantcore/services/chat.py
@@ -21,10 +21,15 @@ import json
 import logging
 import math
 import os
+import uuid
 from dataclasses import dataclass, field
 from typing import Callable, Iterator, Protocol
 
-from quantcore.services.chat_tools import TOOL_SCHEMAS, validate_directive
+from quantcore.services.chat_tools import (
+    TOOL_SCHEMAS,
+    validate_directive,
+    validate_interaction,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +49,13 @@ short_strike, kind}) using the exact same parameters. After discussing a
 ticker, prefer showing the relevant component so the user sees live data —
 the component fetches its own data; never restate numbers the component will
 display.
+
+Rendered components are interactive: when the user clicks inside one (a
+strike on a spread_payoff chart, a point on a price_chart), their message
+arrives with [UI_INTERACTION] lines — JSON naming the component instance, the
+action, its payload, and the props of that instance. Treat these as precise
+context from the user ("this strike" means the payload strike). Answer about
+the selected element directly; never echo the raw JSON back.
 
 Numbers you state in prose must come from tool results in this conversation,
 never from memory. Be concise; this is a side rail, not a report."""
@@ -69,9 +81,14 @@ class ToolStatus:
 
 @dataclass(frozen=True)
 class Directive:
-    """A validated show_component call — render this registry component."""
+    """A validated show_component call — render this registry component.
+
+    ``component_id`` identifies the rendered instance so UI interactions can
+    reference exactly which chart the user touched (the backchannel).
+    """
     component: str
     props: dict = field(default_factory=dict)
+    component_id: str = ""
 
 
 @dataclass(frozen=True)
@@ -120,6 +137,28 @@ def _sanitize(value):
     if isinstance(value, (list, tuple)):
         return [_sanitize(v) for v in value]
     return value
+
+
+def _fold_interactions(convo: list[dict], interactions: list[dict]) -> None:
+    """Append [UI_INTERACTION] envelope lines to the final user turn (adding
+    one if the conversation doesn't end on a user turn). Interactions are
+    current-turn context only — future turns rely on the assistant's reply,
+    exactly like MCP Apps' update-model-context semantics."""
+    lines = []
+    for it in interactions:
+        body = {
+            k: it[k]
+            for k in ("component", "component_id", "action", "payload", "props")
+            if it.get(k) is not None
+        }
+        lines.append(
+            "[UI_INTERACTION] " + json.dumps(_sanitize(body), sort_keys=True)
+        )
+    block = "\n".join(lines)
+    if convo and convo[-1]["role"] == "user" and isinstance(convo[-1]["content"], str):
+        convo[-1]["content"] = f"{convo[-1]['content']}\n\n{block}"
+    else:
+        convo.append({"role": "user", "content": block})
 
 
 def _tool_result(tool_use_id: str, payload, is_error: bool = False) -> dict:
@@ -187,8 +226,17 @@ class ChatService:
             ),
         }
 
-    def stream_chat(self, messages: list[dict]) -> Iterator[ChatEvent]:
+    def stream_chat(
+        self, messages: list[dict], interactions: list[dict] | None = None
+    ) -> Iterator[ChatEvent]:
         convo = [{"role": m["role"], "content": m["content"]} for m in messages]
+        if interactions:
+            for it in interactions:
+                ok, reason = validate_interaction(it)
+                if not ok:
+                    yield ErrorEvent(message=f"Invalid interaction: {reason}")
+                    return
+            _fold_interactions(convo, interactions)
         try:
             client = self._client_factory()
             for _ in range(self._max_iterations):
@@ -224,7 +272,11 @@ class ChatService:
                         props = args.get("props")
                         ok, reason = validate_directive(component, props)
                         if ok:
-                            yield Directive(component=component, props=props)
+                            yield Directive(
+                                component=component,
+                                props=props,
+                                component_id=uuid.uuid4().hex[:12],
+                            )
                             results.append(_tool_result(tu.id, {"rendered": True}))
                         else:
                             results.append(_tool_result(tu.id, reason, is_error=True))

--- a/quantcore/services/chat_fake.py
+++ b/quantcore/services/chat_fake.py
@@ -5,10 +5,17 @@ canned two-turn INTC script through the REAL agent loop and REAL directive
 validation, so route-integration tests and Playwright E2E run keyless and
 offline at the LLM layer. The contract (TextDelta* -> Directive(signals/INTC)
 -> TextDelta* -> Done) is pinned by test_chat_service.TestFakeChatClient.
+
+If the latest user turn carries a [UI_INTERACTION] envelope (the interaction
+backchannel), the fake acknowledges the selection instead — echoing the
+payload values so tests can assert the envelope round-tripped.
 """
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
+
+_MARKER = "[UI_INTERACTION] "
 
 
 def _text(text):
@@ -23,15 +30,84 @@ def _final(stop_reason, *blocks):
     return SimpleNamespace(stop_reason=stop_reason, content=list(blocks))
 
 
+def _interaction_ack(messages):
+    """If the last user turn has [UI_INTERACTION] lines, build the ack text."""
+    content = messages[-1].get("content", "") if messages else ""
+    if not isinstance(content, str) or _MARKER not in content:
+        return None
+    summaries = []
+    for line in content.splitlines():
+        if not line.startswith(_MARKER):
+            continue
+        try:
+            body = json.loads(line[len(_MARKER):])
+        except ValueError:
+            continue
+        payload = body.get("payload", {})
+        detail = ", ".join(f"{k} {v}" for k, v in sorted(payload.items()))
+        summaries.append(f"{body.get('action', 'interaction')} ({detail})")
+    if not summaries:
+        return None
+    return ["Noted your selection — ", "; ".join(summaries), "."]
+
+
+# Far-future expiration so the payoff card's DTE stays positive in tests forever.
+SPREAD_PROPS = {
+    "ticker": "WMT",
+    "expiration": "2099-12-19",
+    "long_strike": 120,
+    "short_strike": 125,
+    "kind": "call",
+}
+
+
 class FakeChatClient:
     """Scripted stand-in for the Anthropic client. One instance per conversation."""
 
     def __init__(self):
         self._turn = 0
+        self._spread = False
 
     def stream_turn(self, *, system, tools, messages):  # noqa: ARG002 — protocol parity
         self._turn += 1
+        ack = _interaction_ack(messages)
+        if ack is not None:
+            for chunk in ack:
+                yield ("delta", chunk)
+            yield ("final", _final("end_turn", _text("".join(ack))))
+            return
         if self._turn == 1:
+            prompt = messages[-1].get("content", "") if messages else ""
+            self._spread = isinstance(prompt, str) and "spread" in prompt.lower()
+        if self._spread:
+            if self._turn == 1:
+                for chunk in ("Pricing the WMT ", "120/125 call spread."):
+                    yield ("delta", chunk)
+                yield (
+                    "final",
+                    _final(
+                        "tool_use",
+                        _text("Pricing the WMT 120/125 call spread."),
+                        _tool_use(
+                            "fake_tool_spread",
+                            "show_component",
+                            {"component": "spread_payoff", "props": dict(SPREAD_PROPS)},
+                        ),
+                    ),
+                )
+            else:
+                for chunk in ("The risk graph below is live — ", "click a strike to ask about it."):
+                    yield ("delta", chunk)
+                yield (
+                    "final",
+                    _final(
+                        "end_turn",
+                        _text(
+                            "The risk graph below is live — click a strike to ask about it."
+                        ),
+                    ),
+                )
+        elif self._turn == 1:
             for chunk in ("Let me pull up ", "the INTC signals."):
                 yield ("delta", chunk)
             yield (

--- a/quantcore/services/chat_tools.py
+++ b/quantcore/services/chat_tools.py
@@ -28,10 +28,51 @@ BACKEND_COMPONENT_REGISTRY: dict[str, dict[str, object]] = {
 }
 
 
+# Component name -> action name -> payload spec (same typing convention as
+# prop specs). Components absent here are display-only. This is the UI->model
+# backchannel vocabulary: the frontend registry declares the same actions and
+# both sides validate (defense in depth, mirroring the directive registries).
+BACKEND_INTERACTION_REGISTRY: dict[str, dict[str, dict[str, object]]] = {
+    "spread_payoff": {
+        "select_strike": {"strike": _NUMBER},
+        "reprice_leg": {"leg": str, "strike": _NUMBER},
+    },
+    "price_chart": {
+        "select_point": {"date": str, "price": _NUMBER},
+    },
+}
+
+
 def _type_name(expected) -> str:
     if isinstance(expected, tuple):
         return " or ".join(t.__name__ for t in expected)
     return expected.__name__
+
+
+def _check_fields(spec: dict, values: dict, label: str, owner: str) -> tuple[bool, str]:
+    """Strict field check shared by directives and interactions: every spec
+    field required, extras rejected, bool never passes as a number."""
+    extra = set(values) - set(spec)
+    if extra:
+        return False, f"Unexpected {label}s {sorted(extra)} for '{owner}'"
+    for name, expected_type in spec.items():
+        if name not in values:
+            return False, f"Missing required {label} '{name}' for '{owner}'"
+        value = values[name]
+        # bool is an int subclass — never a valid stand-in for a number.
+        if isinstance(value, bool) and expected_type is not bool:
+            return False, (
+                f"{label.capitalize()} '{name}' must be "
+                f"{_type_name(expected_type)}, got bool"
+            )
+        if not isinstance(value, expected_type):
+            return False, (
+                f"{label.capitalize()} '{name}' must be {_type_name(expected_type)}, "
+                f"got {type(value).__name__}"
+            )
+        if expected_type is str and not value.strip():
+            return False, f"{label.capitalize()} '{name}' must be a non-empty string"
+    return True, ""
 
 
 def validate_directive(component: str, props: object) -> tuple[bool, str]:
@@ -44,23 +85,42 @@ def validate_directive(component: str, props: object) -> tuple[bool, str]:
         )
     if not isinstance(props, dict):
         return False, f"props must be an object, got {type(props).__name__}"
-    extra = set(props) - set(spec)
-    if extra:
-        return False, f"Unexpected props {sorted(extra)} for '{component}'"
-    for name, expected_type in spec.items():
-        if name not in props:
-            return False, f"Missing required prop '{name}' for '{component}'"
-        value = props[name]
-        # bool is an int subclass — never a valid stand-in for a number.
-        if isinstance(value, bool) and expected_type is not bool:
-            return False, f"Prop '{name}' must be {_type_name(expected_type)}, got bool"
-        if not isinstance(value, expected_type):
-            return False, (
-                f"Prop '{name}' must be {_type_name(expected_type)}, "
-                f"got {type(value).__name__}"
-            )
-        if expected_type is str and not value.strip():
-            return False, f"Prop '{name}' must be a non-empty string"
+    return _check_fields(spec, props, "prop", component)
+
+
+def validate_interaction(interaction: object) -> tuple[bool, str]:
+    """Validate one UI interaction from the request body before it is folded
+    into the model conversation. Returns (ok, reason-if-rejected)."""
+    if not isinstance(interaction, dict):
+        return False, f"interaction must be an object, got {type(interaction).__name__}"
+    component_id = interaction.get("component_id")
+    if not isinstance(component_id, str) or not component_id.strip():
+        return False, "interaction requires a non-empty 'component_id'"
+    component = interaction.get("component", "")
+    actions = BACKEND_INTERACTION_REGISTRY.get(component)
+    if actions is None:
+        return False, (
+            f"Component '{component}' accepts no interactions. "
+            f"Interactive components: {sorted(BACKEND_INTERACTION_REGISTRY)}"
+        )
+    action = interaction.get("action", "")
+    payload_spec = actions.get(action)
+    if payload_spec is None:
+        return False, (
+            f"Unknown action '{action}' for '{component}'. "
+            f"Valid actions: {sorted(actions)}"
+        )
+    payload = interaction.get("payload", {})
+    if not isinstance(payload, dict):
+        return False, f"payload must be an object, got {type(payload).__name__}"
+    ok, reason = _check_fields(payload_spec, payload, "payload field", action)
+    if not ok:
+        return False, reason
+    props = interaction.get("props")
+    if props is not None:
+        ok, reason = validate_directive(component, props)
+        if not ok:
+            return False, f"interaction props snapshot invalid: {reason}"
     return True, ""
 
 

--- a/test_chat_api.py
+++ b/test_chat_api.py
@@ -6,6 +6,7 @@ exercised against the deterministic FakeChatClient — keyless and offline at th
 LLM layer. DB-safety preamble mirrors test_api_smoke.py.
 """
 
+import json
 import os
 import unittest
 from pathlib import Path
@@ -96,6 +97,71 @@ class ChatApiTest(unittest.TestCase):
         directive_data = next(d for k, d in frames if k == "directive")
         self.assertIn('"signals"', directive_data)
         self.assertIn('"INTC"', directive_data)
+
+    def test_directive_frame_carries_component_id(self):
+        resp = self.client.post("/api/chat", json=VALID_BODY)
+        directive_data = next(
+            d for k, d in parse_frames(resp.text) if k == "directive"
+        )
+        self.assertIn('"component_id"', directive_data)
+        payload = json.loads(directive_data)
+        self.assertTrue(payload["component_id"])
+
+    # -- interactions (the UI->model backchannel) ---------------------------
+
+    def test_valid_interaction_round_trips_to_ack(self):
+        body = {
+            "messages": [{"role": "user", "content": "What about this strike?"}],
+            "interactions": [
+                {
+                    "component_id": "abc123",
+                    "component": "spread_payoff",
+                    "action": "select_strike",
+                    "payload": {"strike": 120.0},
+                }
+            ],
+        }
+        resp = self.client.post("/api/chat", json=body)
+        self.assertEqual(resp.status_code, 200)
+        frames = parse_frames(resp.text)
+        kinds = [k for k, _ in frames]
+        self.assertEqual(kinds[-1], "done")
+        text = "".join(json.loads(d)["delta"] for k, d in frames if k == "text")
+        self.assertIn("120", text)
+        self.assertIn("selection", text.lower())
+
+    def test_unknown_action_streams_error_frame(self):
+        body = {
+            "messages": [{"role": "user", "content": "hi"}],
+            "interactions": [
+                {
+                    "component_id": "abc123",
+                    "component": "spread_payoff",
+                    "action": "explode",
+                    "payload": {},
+                }
+            ],
+        }
+        resp = self.client.post("/api/chat", json=body)
+        self.assertEqual(resp.status_code, 200)  # SSE stream carries the error
+        frames = parse_frames(resp.text)
+        self.assertEqual([k for k, _ in frames], ["error"])
+        self.assertIn("explode", frames[0][1])
+
+    def test_interaction_missing_component_id_422(self):
+        body = {
+            "messages": [{"role": "user", "content": "hi"}],
+            "interactions": [
+                {"component": "spread_payoff", "action": "select_strike", "payload": {}}
+            ],
+        }
+        resp = self.client.post("/api/chat", json=body)
+        self.assertEqual(resp.status_code, 422)
+
+    def test_interactions_default_to_empty(self):
+        # Old clients that never send the field keep working unchanged.
+        resp = self.client.post("/api/chat", json=VALID_BODY)
+        self.assertEqual(resp.status_code, 200)
 
     # -- validation --------------------------------------------------------
 

--- a/test_chat_protocol.py
+++ b/test_chat_protocol.py
@@ -20,8 +20,10 @@ from quantcore.services.chat import (
 )
 from quantcore.services.chat_tools import (
     BACKEND_COMPONENT_REGISTRY,
+    BACKEND_INTERACTION_REGISTRY,
     TOOL_SCHEMAS,
     validate_directive,
+    validate_interaction,
 )
 
 
@@ -96,6 +98,13 @@ class TestEventStream(unittest.TestCase):
     def test_done_is_final_frame_on_clean_exit(self):
         frames = self._frames([TextDelta(delta="x"), Done(stop_reason="end_turn")])
         self.assertTrue(frames[-1].startswith("event: done\n"))
+
+    def test_directive_frame_carries_component_id(self):
+        frames = self._frames(
+            [Directive(component="signals", props={"ticker": "INTC"}, component_id="abc123")]
+        )
+        body = json.loads(frames[0].split("data: ", 1)[1])
+        self.assertEqual(body["component_id"], "abc123")
 
 
 class TestValidateDirective(unittest.TestCase):
@@ -180,6 +189,112 @@ class TestSpreadPayoffDirective(unittest.TestCase):
         ok, reason = validate_directive("spread_payoff", props)
         self.assertFalse(ok)
         self.assertIn("leverage", reason)
+
+
+def interaction(**overrides):
+    """A valid select_strike interaction; override fields per test."""
+    base = {
+        "component_id": "d1",
+        "component": "spread_payoff",
+        "action": "select_strike",
+        "payload": {"strike": 120.0},
+    }
+    base.update(overrides)
+    return base
+
+
+class TestValidateInteraction(unittest.TestCase):
+    def test_valid_select_strike_accepted(self):
+        ok, reason = validate_interaction(interaction())
+        self.assertTrue(ok, reason)
+
+    def test_valid_with_props_snapshot_accepted(self):
+        ok, reason = validate_interaction(
+            interaction(
+                props={
+                    "ticker": "WMT",
+                    "expiration": "2026-12-18",
+                    "long_strike": 120,
+                    "short_strike": 125,
+                    "kind": "call",
+                }
+            )
+        )
+        self.assertTrue(ok, reason)
+
+    def test_valid_reprice_leg_accepted(self):
+        ok, reason = validate_interaction(
+            interaction(action="reprice_leg", payload={"leg": "short", "strike": 122.5})
+        )
+        self.assertTrue(ok, reason)
+
+    def test_valid_price_chart_select_point_accepted(self):
+        ok, reason = validate_interaction(
+            interaction(
+                component="price_chart",
+                action="select_point",
+                payload={"date": "2026-07-10", "price": 96.99},
+            )
+        )
+        self.assertTrue(ok, reason)
+
+    def test_unknown_component_rejected(self):
+        ok, reason = validate_interaction(interaction(component="nope"))
+        self.assertFalse(ok)
+        self.assertIn("nope", reason)
+
+    def test_component_without_interactions_rejected(self):
+        # 'signals' is registered but declares no interactions.
+        ok, reason = validate_interaction(
+            interaction(component="signals", action="select_strike")
+        )
+        self.assertFalse(ok)
+
+    def test_unknown_action_rejected_with_valid_actions_listed(self):
+        ok, reason = validate_interaction(interaction(action="explode"))
+        self.assertFalse(ok)
+        self.assertIn("select_strike", reason)
+
+    def test_payload_missing_key_rejected(self):
+        ok, _ = validate_interaction(interaction(payload={}))
+        self.assertFalse(ok)
+
+    def test_payload_extra_key_rejected(self):
+        ok, _ = validate_interaction(
+            interaction(payload={"strike": 120, "evil": "x"})
+        )
+        self.assertFalse(ok)
+
+    def test_payload_wrong_type_rejected(self):
+        ok, _ = validate_interaction(interaction(payload={"strike": "120"}))
+        self.assertFalse(ok)
+
+    def test_payload_bool_not_a_number(self):
+        ok, _ = validate_interaction(interaction(payload={"strike": True}))
+        self.assertFalse(ok)
+
+    def test_non_dict_payload_rejected(self):
+        ok, _ = validate_interaction(interaction(payload=[120]))
+        self.assertFalse(ok)
+
+    def test_invalid_props_snapshot_rejected(self):
+        ok, _ = validate_interaction(interaction(props={"ticker": ""}))
+        self.assertFalse(ok)
+
+    def test_missing_component_id_rejected(self):
+        bad = interaction()
+        del bad["component_id"]
+        ok, _ = validate_interaction(bad)
+        self.assertFalse(ok)
+
+    def test_non_dict_interaction_rejected(self):
+        ok, _ = validate_interaction("click")
+        self.assertFalse(ok)
+
+    def test_interaction_registry_components_exist(self):
+        # Every component declaring interactions must be a renderable component.
+        for component in BACKEND_INTERACTION_REGISTRY:
+            self.assertIn(component, BACKEND_COMPONENT_REGISTRY)
 
 
 class TestToolSchemas(unittest.TestCase):

--- a/test_chat_service.py
+++ b/test_chat_service.py
@@ -302,6 +302,148 @@ class TestShowComponent(ChatServiceTestBase):
         self.assertIn("nuclear_launch", result_block["content"])
 
 
+def ui_interaction(**overrides):
+    base = {
+        "component_id": "d1",
+        "component": "spread_payoff",
+        "action": "select_strike",
+        "payload": {"strike": 120.0},
+    }
+    base.update(overrides)
+    return base
+
+
+class TestInteractions(ChatServiceTestBase):
+    """The UI->model backchannel: validated interactions are folded into the
+    last user turn as [UI_INTERACTION] envelope lines before the model runs."""
+
+    END = {"final": final("end_turn", text_block("ok"))}
+
+    def test_interaction_folded_into_last_user_message(self):
+        client = ScriptedClient([dict(self.END)])
+        service = self.make_service(client)
+        events = list(
+            service.stream_chat(
+                [{"role": "user", "content": "what about this strike?"}],
+                interactions=[ui_interaction()],
+            )
+        )
+        self.assertIsInstance(events[-1], Done)
+        last = client.calls[0]["messages"][-1]
+        self.assertEqual(last["role"], "user")
+        self.assertIn("what about this strike?", last["content"])
+        self.assertIn("[UI_INTERACTION]", last["content"])
+        self.assertIn('"select_strike"', last["content"])
+        self.assertIn("120", last["content"])
+
+    def test_multiple_interactions_fold_in_order(self):
+        client = ScriptedClient([dict(self.END)])
+        service = self.make_service(client)
+        list(
+            service.stream_chat(
+                [{"role": "user", "content": "hi"}],
+                interactions=[
+                    ui_interaction(payload={"strike": 110.0}),
+                    ui_interaction(payload={"strike": 130.0}, component_id="d2"),
+                ],
+            )
+        )
+        content = client.calls[0]["messages"][-1]["content"]
+        self.assertEqual(content.count("[UI_INTERACTION]"), 2)
+        self.assertLess(content.index("110"), content.index("130"))
+
+    def test_props_snapshot_included_in_envelope(self):
+        client = ScriptedClient([dict(self.END)])
+        service = self.make_service(client)
+        list(
+            service.stream_chat(
+                [{"role": "user", "content": "hi"}],
+                interactions=[
+                    ui_interaction(
+                        props={
+                            "ticker": "WMT",
+                            "expiration": "2026-12-18",
+                            "long_strike": 120,
+                            "short_strike": 125,
+                            "kind": "call",
+                        }
+                    )
+                ],
+            )
+        )
+        content = client.calls[0]["messages"][-1]["content"]
+        self.assertIn("WMT", content)
+        self.assertIn("2026-12-18", content)
+
+    def test_no_interactions_leaves_conversation_untouched(self):
+        client = ScriptedClient([dict(self.END)])
+        service = self.make_service(client)
+        list(service.stream_chat([{"role": "user", "content": "hi"}]))
+        self.assertEqual(client.calls[0]["messages"][-1]["content"], "hi")
+
+    def test_invalid_interaction_errors_before_model_call(self):
+        client = ScriptedClient([dict(self.END)])
+        service = self.make_service(client)
+        events = list(
+            service.stream_chat(
+                [{"role": "user", "content": "hi"}],
+                interactions=[ui_interaction(action="explode")],
+            )
+        )
+        self.assertEqual(len(events), 1)
+        self.assertIsInstance(events[0], ErrorEvent)
+        self.assertEqual(client.calls, [])
+        self.assertEqual(self.options.mock_calls, [])
+
+    def test_assistant_final_message_gets_own_user_turn(self):
+        client = ScriptedClient([dict(self.END)])
+        service = self.make_service(client)
+        list(
+            service.stream_chat(
+                [
+                    {"role": "user", "content": "hi"},
+                    {"role": "assistant", "content": "hello"},
+                ],
+                interactions=[ui_interaction()],
+            )
+        )
+        msgs = client.calls[0]["messages"]
+        self.assertEqual(msgs[-1]["role"], "user")
+        self.assertIn("[UI_INTERACTION]", msgs[-1]["content"])
+        self.assertEqual(msgs[-2]["content"], "hello")
+
+    def test_system_prompt_documents_the_envelope(self):
+        from quantcore.services.chat import SYSTEM_PROMPT
+
+        self.assertIn("[UI_INTERACTION]", SYSTEM_PROMPT)
+
+
+class TestDirectiveComponentIds(ChatServiceTestBase):
+    def test_each_directive_gets_a_unique_component_id(self):
+        show = lambda tu_id, ticker: {  # noqa: E731
+            "final": final(
+                "tool_use",
+                tool_use(
+                    tu_id,
+                    "show_component",
+                    {"component": "signals", "props": {"ticker": ticker}},
+                ),
+            )
+        }
+        client = ScriptedClient(
+            [
+                show("tu_1", "INTC"),
+                show("tu_2", "AMD"),
+                {"final": final("end_turn", text_block("done"))},
+            ]
+        )
+        events = self.run_chat(client)
+        directives = [e for e in events if isinstance(e, Directive)]
+        self.assertEqual(len(directives), 2)
+        self.assertTrue(all(d.component_id for d in directives))
+        self.assertNotEqual(directives[0].component_id, directives[1].component_id)
+
+
 class TestFailureModes(ChatServiceTestBase):
     def test_client_exception_yields_single_error_no_done(self):
         client = ScriptedClient([RuntimeError("api down")])
@@ -378,6 +520,61 @@ class TestFakeChatClient(unittest.TestCase):
         self.assertLess(directive_idx, len(events) - 1)
         joined = "".join(e.delta for e in events if isinstance(e, TextDelta))
         self.assertIn("INTC", joined)
+
+    def test_spread_prompt_renders_spread_payoff(self):
+        """Prompts mentioning a spread play the WMT spread_payoff script —
+        the interactive card the Playwright backchannel spec clicks on."""
+        service = ChatService(
+            prices=Mock(),
+            fundamentals=Mock(),
+            sentiment=Mock(),
+            options=Mock(),
+            client_factory=FakeChatClient,
+        )
+        events = list(
+            service.stream_chat(
+                [{"role": "user", "content": "Price a WMT 120/125 call spread"}]
+            )
+        )
+        directives = [e for e in events if isinstance(e, Directive)]
+        self.assertEqual(len(directives), 1)
+        self.assertEqual(directives[0].component, "spread_payoff")
+        self.assertEqual(directives[0].props["ticker"], "WMT")
+        self.assertEqual(directives[0].props["long_strike"], 120)
+        self.assertTrue(directives[0].component_id)
+        self.assertIsInstance(events[-1], Done)
+        joined = "".join(e.delta for e in events if isinstance(e, TextDelta))
+        self.assertIn("risk graph", joined)
+
+    def test_interaction_envelope_gets_acknowledgement_turn(self):
+        """When the folded user turn carries a [UI_INTERACTION] envelope, the
+        fake acknowledges it instead of replaying the INTC script — pins the
+        contract the Playwright interaction spec relies on."""
+        service = ChatService(
+            prices=Mock(),
+            fundamentals=Mock(),
+            sentiment=Mock(),
+            options=Mock(),
+            client_factory=FakeChatClient,
+        )
+        events = list(
+            service.stream_chat(
+                [{"role": "user", "content": "what about this one?"}],
+                interactions=[
+                    {
+                        "component_id": "d1",
+                        "component": "spread_payoff",
+                        "action": "select_strike",
+                        "payload": {"strike": 120.0},
+                    }
+                ],
+            )
+        )
+        self.assertIsInstance(events[-1], Done)
+        self.assertEqual([e for e in events if isinstance(e, Directive)], [])
+        joined = "".join(e.delta for e in events if isinstance(e, TextDelta))
+        self.assertIn("120", joined)
+        self.assertIn("selection", joined.lower())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Closes the sidekick's one functional gap vs. the 2026 GenUI standards (MCP Apps / AG-UI / A2UI): rendered components were display-only. Now a click inside a component flows back into the conversation — standards-inspired semantics (MCP Apps `update-model-context` / `ui/message`), our own wire format, and the same dual-registry trust model the directive path already uses.

## How it works

- **Two modes, declared per action** in matching backend/frontend interaction registries:
  - `context` — clicking a strike on the payoff chart attaches structured context to your *next* typed message ("what about this one?" just works). Shows as a dismissible composer chip; one-shot, cleared on send.
  - `message` — "Move long/short leg → $X" chips submit a structured turn immediately.
- **Directives gain identity**: `ChatService` assigns a `component_id` per rendered instance; interactions reference exactly the chart that was touched.
- **Wire**: optional `interactions` array on POST `/api/chat` (route surface unchanged — 83 routes). Shape-checked by Pydantic, vocabulary-checked by `validate_interaction` (strict extras, bool≠number, props snapshot revalidated via `validate_directive`). Valid → folded into the final user turn as `[UI_INTERACTION]` JSON envelope lines; invalid → error frame before any model call. Backend stays stateless.
- **v1 vocabulary**: `spread_payoff.select_strike` (context, $0.50-snapped), `spread_payoff.reprice_leg` (message), `price_chart.select_point` (context). Deferred: drag-to-adjust, range brushing.

## Architecture

Vocabulary + validation live in `quantcore/services/chat_tools.py` (pure), folding in `ChatService`; the router stays exactly one service call deep. Components reach the queue through a `DirectiveInteractionProvider` context that is inert outside the chat rail, so shared components (`PriceChart`) are untouched behaviorally — the click handler is an optional prop.

## Tests

- Backend: 230 pass — new `validate_interaction` accept/reject table (aligned with the frontend twin), folding/component-id/error-before-model-call service tests, route tests incl. 422 vs in-stream error split.
- Frontend: 73 vitest pass — registry twins, queue persist/clear, card click → queue, reprice → message-mode send, chip delete.
- E2E: 4 Playwright pass — new backchannel spec drives the REAL backend (CHAT_FAKE=1): render spread card → click chart → chip appears → follow-up POST carries the interaction → real validation → streamed acknowledgement → chip cleared.

`FakeChatClient` gained a spread_payoff script and an `[UI_INTERACTION]` ack turn (both pinned by unit tests) to make that round trip keyless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)