### PR TITLE
DB: batch executemany — full-chain options persist drops from ~5 min to <1 s

### DIFF
--- a/quantcore/db.py
+++ b/quantcore/db.py
@@ -377,7 +377,11 @@ class _PGConn:
         else:
             sql = sql.replace('?', '%s')
         cur = self._c.cursor()
-        cur.executemany(sql, seq)
+        # psycopg2's cursor.executemany() is one server round trip PER ROW.
+        # Against Cloud SQL through the auth proxy (~90ms RTT) that made a
+        # 3.2K-contract options snapshot take ~5 minutes; execute_batch sends
+        # pages of statements per round trip (500 rows ≈ 7 trips, <1s).
+        psycopg2.extras.execute_batch(cur, sql, seq, page_size=500)
         return cur
 
     def commit(self):

--- a/test_options_contract_tools.py
+++ b/test_options_contract_tools.py
@@ -129,6 +129,59 @@ class OptionsContractToolsTest(unittest.TestCase):
         self.assertEqual(len(snapshot["expirations"]), 1)
         self.assertEqual(len(snapshot["expirations"][0]["contracts"]), 4)
 
+    def test_save_full_chain_batches_across_page_boundaries(self):
+        """A MSTR-sized chain (>500 contracts per side) must survive the
+        execute_batch paging in _PGConn.executemany with every row intact —
+        pins the fix for the ~5-minute per-row persist over the proxy."""
+        n = 601  # crosses the 500-row page boundary within one executemany
+        contracts = [
+            {
+                "strike": 10.0 + i,
+                "last": 1.0,
+                "bid": 0.9,
+                "ask": 1.1,
+                "iv": 50.0,
+                "volume": i,
+                "open_interest": i,
+                "in_the_money": i % 2 == 0,
+            }
+            for i in range(n)
+        ]
+        big = [
+            {
+                "expiration": "2026-06-19",
+                "put_call_ratio": 1.0,
+                "calls": {
+                    "contracts": contracts,
+                    "total_open_interest": n,
+                    "total_volume": n,
+                    "avg_iv_pct": 50.0,
+                },
+                "puts": {
+                    "contracts": contracts,
+                    "total_open_interest": n,
+                    "total_volume": n,
+                    "avg_iv_pct": 50.0,
+                },
+            }
+        ]
+        store = self._store()
+        snapshot_id = store.save_full_chain(
+            symbol=TEST_SYMBOL,
+            price=100.0,
+            bollinger_bands=None,
+            expirations_data=big,
+            captured_at="2026-05-19T12:00:00Z",
+        )
+        self.assertIsNotNone(snapshot_id)
+        snapshot = store.get_full_chain(TEST_SYMBOL)
+        rows = snapshot["expirations"][0]["contracts"]
+        self.assertEqual(len(rows), 2 * n)
+        # Spot-check a row from the second page.
+        strikes = {(c["kind"], c["strike"]) for c in rows}
+        self.assertIn(("call", 10.0 + 550), strikes)
+        self.assertIn(("put", 10.0 + 600), strikes)
+
     def test_duplicate_snapshot_returns_none_without_corrupting_rows(self):
         store = self._store()
         first = self._seed_store(store)


### PR DESCRIPTION
## Symptom

`price_vertical_spread` (sidekick + MCP) took ~5 minutes for MSTR on a cold cache.

## Diagnosis

On a cache miss the tool fetches and persists the full chain before pricing. The fetch is ~10 s; the persist was the killer: `OptionsStore.save_full_chain` inserts contracts through `_PGConn.executemany`, and psycopg2's `cursor.executemany()` is **one server round trip per row**. MSTR's chain is 3,208 contracts × ~90 ms RTT through the Cloud SQL auth proxy ≈ 4.8 minutes. Every ticker pays this on a cold cache; MSTR's giant strike ladder just pays the most. (Cloud Run is less affected — the API sits beside the DB — so this mostly bit local dev, but it's pure waste everywhere.)

## Fix

One change at the shared choke point: `_PGConn.executemany` now uses `psycopg2.extras.execute_batch` with `page_size=500` — pages of statements per round trip, ~7 trips for that same snapshot. Same approach `scripts/migrate_sqlite_to_postgres.py` already uses for bulk copies.

- No call-site changes (both repository `executemany` users flow through the wrapper)
- `ON CONFLICT` and `?`/named parameter styles unchanged
- No caller reads `cursor.rowcount` after `executemany` (audited), which is the one semantic difference of `execute_batch`

## Tests

199 pass, including a new test persisting a 601-contract-per-side chain — crossing the 500-row page boundary — and verifying all 1,202 rows round-trip intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)