### PR TITLE
Tests: coverage uplift wave 2 — options + fundamentals internals, 55.3% → 61.2%, floor 60

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,15 +80,15 @@ jobs:
       - name: Unit tests (under coverage)
         run: coverage run -m unittest discover -v
       # COVERAGE RATCHET: the floor below is pinned ~1pt under the measured
-      # baseline (55.3% on 2026-07-15 after the coverage-uplift suites; scope
-      # in .coveragerc). It only ever moves UP — when a PR meaningfully raises
+      # baseline (61.2% on 2026-07-15 after uplift wave 2; scope in
+      # .coveragerc). It only ever moves UP — when a PR meaningfully raises
       # coverage, bump it in the same PR. The behavioral gate is diff-cover:
       # changed lines need >= 85%.
       - name: Coverage report + floor
         run: |
           coverage report
           coverage report --format=markdown >> "$GITHUB_STEP_SUMMARY"
-          coverage report --fail-under=54
+          coverage report --fail-under=60
       - name: Diff coverage (changed lines >= 85%, PRs only)
         if: github.event_name == 'pull_request'
         run: |

--- a/test_fundamentals_service.py
+++ b/test_fundamentals_service.py
@@ -298,5 +298,196 @@ class TestTopRankings(FundamentalsServiceTestBase):
         self.assertEqual(out["rankings"][0]["rank"], 1)
 
 
+# ---------------------------------------------------------------------------
+# _compute_* internals (wave 2) — full yfinance-statement-shaped fixtures
+# ---------------------------------------------------------------------------
+
+from datetime import date, timedelta  # noqa: E402
+
+
+def statement(rows: dict, dates):
+    return pd.DataFrame(
+        {pd.Timestamp(d): [float(rows[label][i]) for label in rows]
+         for i, d in enumerate(dates)},
+        index=list(rows),
+    )
+
+
+ANNUAL_DATES = ["2022-12-31", "2023-12-31", "2024-12-31", "2025-12-31"]
+
+FINANCIALS = statement(
+    {"Total Revenue": [100, 120, 150, 200],
+     "Operating Income": [25, 30, 37.5, 50]},   # constant 25% margin
+    ANNUAL_DATES,
+)
+CASHFLOW = statement(
+    {"Operating Cash Flow": [40, 48, 60, 80],   # 40% of revenue
+     "Capital Expenditure": [10, 12, 15, 20]},  # 10% -> FCF margin 30%
+    ANNUAL_DATES,
+)
+
+
+def momentum_history(n=300):
+    return pd.DataFrame(
+        {"Close": [float(100 + i * 0.1) for i in range(n)]},
+        index=pd.bdate_range(end="2026-07-14", periods=n),
+    )
+
+
+class TestComputeFundamentalScore(FundamentalsServiceTestBase):
+    def test_strong_compounder_composite(self):
+        yf = self.service._yf
+        yf.info.return_value = {"enterpriseToRevenue": 3.0,
+                                "sector": "Technology", "marketCap": 1_000}
+        yf.financials.return_value = FINANCIALS
+        yf.cashflow.return_value = CASHFLOW
+        yf.history.return_value = momentum_history()
+
+        out = self.service._compute_fundamental_score("INTC")
+
+        ms = out["metric_scores"]
+        self.assertEqual(ms["RevCAGR3Y"]["score"], 2)     # 26% CAGR
+        self.assertEqual(ms["RevAccel"]["score"], 1)      # +8.3pp acceleration
+        self.assertEqual(ms["OpMargin3Y"]["score"], 2)    # 25% margins
+        self.assertEqual(ms["OpMarginTrend"]["score"], 0) # flat
+        self.assertEqual(ms["FCFMargin3Y"]["score"], 2)   # 30% FCF margin
+        self.assertEqual(ms["ValMetric"]["score"], 2)     # log(3) cheap
+        self.assertEqual(ms["Mom12_1"]["score"], 2)       # ~22% 12-1 momentum
+        self.assertEqual(out["composite_score"], 11)
+        self.assertEqual(out["fundamental_label"], "strong_compounder")
+        self.assertEqual(out["coverage"], 1.0)
+        self.assertEqual(out["val_type"], "EV/Sales")
+        self.assertEqual(out["sector"], "Technology")
+
+    def test_no_data_degrades_to_average_zero_coverage(self):
+        yf = self.service._yf
+        yf.info.side_effect = RuntimeError("yahoo down")
+        yf.financials.return_value = pd.DataFrame()
+        yf.cashflow.return_value = pd.DataFrame()
+        yf.history.return_value = pd.DataFrame()
+
+        out = self.service._compute_fundamental_score("ZZZ")
+        self.assertEqual(out["composite_score"], 0)
+        self.assertEqual(out["coverage"], 0.0)
+        self.assertEqual(out["fundamental_label"], "average")
+        self.assertEqual(out["val_type"], "NA")
+
+
+QUARTER_DATES = ["2025-06-30", "2025-09-30", "2025-12-31", "2026-03-31", "2026-06-30"]
+
+
+class TestComputeRevenueGrowth(FundamentalsServiceTestBase):
+    def quarters(self, revenues):
+        return statement({"Total Revenue": revenues}, QUARTER_DATES)
+
+    def test_accelerating_quarters(self):
+        yf = self.service._yf
+        yf.quarterly_financials.return_value = self.quarters([100, 102, 105, 110, 120])
+        yf.financials.return_value = FINANCIALS
+        out = self.service._compute_revenue_growth("INTC")
+        self.assertEqual(out["trajectory"], "accelerating")
+        self.assertEqual(out["weighted_score"], 1.0)      # all-positive growth
+        self.assertEqual(len(out["quarterly_revenues"]), 5)
+        self.assertAlmostEqual(out["cagr_3y"], 2.0 ** (1 / 3) - 1, places=4)
+        self.assertAlmostEqual(out["rev_accel"], (200 / 150 - 1) - (150 / 120 - 1),
+                               places=4)
+
+    def test_positive_inflection(self):
+        yf = self.service._yf
+        # Last QoQ positive after a negative one -> inflecting_positive.
+        yf.quarterly_financials.return_value = self.quarters([100, 110, 104.5, 100, 103])
+        yf.financials.return_value = pd.DataFrame()
+        out = self.service._compute_revenue_growth("INTC")
+        self.assertEqual(out["trajectory"], "inflecting_positive")
+
+    def test_insufficient_quarters(self):
+        yf = self.service._yf
+        yf.quarterly_financials.return_value = statement(
+            {"Total Revenue": [100, 110]}, QUARTER_DATES[:2]
+        )
+        yf.financials.return_value = pd.DataFrame()
+        out = self.service._compute_revenue_growth("INTC")
+        self.assertEqual(out["trajectory"], "insufficient_data")
+        self.assertEqual(out["quarterly_revenues"], [])
+
+
+class TestComputeEarningsAccelerationService(FundamentalsServiceTestBase):
+    def test_strong_acceleration(self):
+        self.service._yf.quarterly_income_stmt.return_value = quarterly_income(
+            [100e6, 50e6, 30e6, 20e6, 15e6]
+        )
+        out = self.service._compute_earnings_acceleration("INTC")
+        self.assertEqual(out["acceleration_label"], "strong")
+        self.assertEqual(out["acceleration_score"], 2)
+        self.assertEqual(out["accel_count"], 3)
+        self.assertEqual(out["net_incomes_M"][0], 15.0)   # scaled to millions
+
+    def test_decelerating(self):
+        self.service._yf.quarterly_income_stmt.return_value = quarterly_income(
+            [50e6, 40e6, 30e6, 20e6, 10e6]
+        )
+        out = self.service._compute_earnings_acceleration("INTC")
+        self.assertEqual(out["acceleration_label"], "decelerating")
+        self.assertEqual(out["acceleration_score"], -1)
+
+    def test_gateway_failure_degrades(self):
+        self.service._yf.quarterly_income_stmt.side_effect = RuntimeError("nope")
+        out = self.service._compute_earnings_acceleration("INTC")
+        self.assertEqual(out["acceleration_label"], "insufficient_data")
+
+
+class TestComputeEarningsCalendar(FundamentalsServiceTestBase):
+    def arm_history(self):
+        yf = self.service._yf
+        yf.history.return_value = pd.DataFrame()
+        yf.earnings_dates.return_value = pd.DataFrame()
+
+    def calendar_at(self, days_out):
+        earn = date.today() + timedelta(days=days_out)
+        return pd.DataFrame(
+            {0: [pd.Timestamp(earn)]}, index=["Earnings Date"]
+        )
+
+    def test_risk_ladder(self):
+        self.arm_history()
+        for days_out, expected in ((3, "CRITICAL"), (10, "HIGH"),
+                                   (20, "MODERATE"), (45, "LOW")):
+            self.service._yf.calendar.return_value = self.calendar_at(days_out)
+            out = self.service._compute_earnings_calendar("INTC")
+            self.assertEqual(out["risk_level"], expected, days_out)
+            self.assertEqual(out["days_to_earnings"], days_out)
+        # MODERATE also flags the pre-earnings IV setup.
+        self.service._yf.calendar.return_value = self.calendar_at(20)
+        self.assertTrue(self.service._compute_earnings_calendar("INTC")["pre_earnings_setup"])
+
+    def test_dict_form_calendar(self):
+        self.arm_history()
+        earn = date.today() + timedelta(days=40)
+        self.service._yf.calendar.return_value = {"Earnings Date": [earn]}
+        out = self.service._compute_earnings_calendar("INTC")
+        self.assertEqual(out["risk_level"], "LOW")
+        self.assertEqual(out["earnings_date"], earn.isoformat())
+
+    def test_calendar_failure_stays_unknown(self):
+        self.arm_history()
+        self.service._yf.calendar.side_effect = RuntimeError("yahoo calendar down")
+        out = self.service._compute_earnings_calendar("INTC")
+        self.assertEqual(out["risk_level"], "UNKNOWN")
+        self.assertIsNone(out["days_to_earnings"])
+
+    def test_historical_earnings_move_measured(self):
+        yf = self.service._yf
+        yf.calendar.return_value = None
+        idx = pd.bdate_range(end="2026-07-14", periods=10)
+        closes = [100.0] * 10
+        closes[5] = 110.0                                  # +10% earnings pop
+        yf.history.return_value = pd.DataFrame({"Close": closes}, index=idx)
+        yf.earnings_dates.return_value = pd.DataFrame(
+            {"EPS Estimate": [1.0]}, index=[idx[5]]
+        )
+        out = self.service._compute_earnings_calendar("INTC")
+        self.assertEqual(out["historical_avg_move_pct"], 10.0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test_options_service.py
+++ b/test_options_service.py
@@ -1,0 +1,295 @@
+"""Unit tests for OptionsService's analytics surfaces (wave 2 coverage).
+
+Everything is driven by literal chain fixtures with analytically known
+outcomes: a 2.5x vol/OI call filled at the ask 8% OTM MUST score a strong
+sweep; a put-heavy book MUST flip market makers to buy-on-rally; the ATM
+straddle at 100 with last prices 4 + 3.5 MUST read a 7.5% expected move.
+Gateway/repositories are Mocks; the Polygon-backed backfill and the
+refresh orchestrator are integration surfaces left to wave 3.
+"""
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pandas as pd
+
+from quantcore.services.options import OptionsService
+
+TODAY_EXP = "2026-08-14"  # ~30 days out from the July 2026 test runs
+
+
+def call_row(strike, volume, oi, last, bid, ask, iv=0.45, itm=False):
+    return {
+        "strike": float(strike), "volume": volume, "openInterest": oi,
+        "lastPrice": last, "bid": bid, "ask": ask,
+        "impliedVolatility": iv, "inTheMoney": itm,
+    }
+
+
+def chain_frames(calls_rows, puts_rows=()):
+    cols = ["strike", "volume", "openInterest", "lastPrice", "bid", "ask",
+            "impliedVolatility", "inTheMoney"]
+    calls = pd.DataFrame(list(calls_rows), columns=cols)
+    puts = pd.DataFrame(list(puts_rows), columns=cols)
+    return SimpleNamespace(calls=calls, puts=puts)
+
+
+class OptionsServiceTestBase(unittest.TestCase):
+    def setUp(self):
+        self.yf = Mock()
+        self.options = Mock()
+        self.service = OptionsService(
+            ohlcv_repository=Mock(),
+            yfinance_gateway=self.yf,
+            options_repository=self.options,
+            polygon_gateway=Mock(),
+            prices=Mock(),
+        )
+
+    def arm_price(self, price=100.0, expirations=(TODAY_EXP,)):
+        self.yf.fast_info.return_value = SimpleNamespace(last_price=price)
+        self.yf.expirations.return_value = tuple(expirations)
+
+
+class TestUnusualCalls(OptionsServiceTestBase):
+    def test_aggressive_otm_sweep_scores_strong(self):
+        self.arm_price()
+        self.yf.option_chain.return_value = chain_frames([
+            # 2.5x vol/OI (+3), last >= ask (+2), 8% OTM (+2) => score 7.
+            call_row(108, volume=500, oi=200, last=2.60, bid=2.40, ask=2.50),
+        ])
+        out = self.service.get_unusual_calls("intc")
+        self.assertEqual(out["sweep_signal"], "strong")
+        top = out["unusual_calls"][0]
+        self.assertEqual(top["sweep_score"], 7)
+        self.assertEqual(top["conviction"], "very high")
+        self.assertIn("aggressive sweep fill", " ".join(top["notes"]))
+
+    def test_itm_hedge_flow_reads_weak(self):
+        self.arm_price()
+        self.yf.option_chain.return_value = chain_frames([
+            # High vol/OI but ITM and filled below mid: hedge, not a sweep.
+            call_row(90, volume=300, oi=100, last=9.0, bid=9.5, ask=10.5, itm=True),
+        ])
+        out = self.service.get_unusual_calls("INTC")
+        self.assertEqual(out["sweep_signal"], "weak")
+        self.assertEqual(out["unusual_calls"][0]["conviction"], "low")
+        self.assertIn("hedge", " ".join(out["unusual_calls"][0]["notes"]))
+
+    def test_thresholds_filter_everything_out(self):
+        self.arm_price()
+        self.yf.option_chain.return_value = chain_frames([
+            call_row(105, volume=50, oi=1000, last=1.0, bid=0.9, ask=1.1),
+        ])
+        out = self.service.get_unusual_calls("INTC")
+        self.assertEqual(out["sweep_signal"], "none")
+        self.assertEqual(out["unusual_call_count"], 0)
+
+    def test_no_expirations_and_bad_price(self):
+        self.arm_price(expirations=())
+        out = self.service.get_unusual_calls("INTC")
+        self.assertEqual(out["sweep_signal"], "none")
+        self.yf.fast_info.return_value = SimpleNamespace(last_price=None)
+        with self.assertRaises(ValueError):
+            self.service.get_unusual_calls("INTC")
+
+
+class TestDeltaAdjustedOi(OptionsServiceTestBase):
+    def test_put_heavy_book_flips_mm_to_buy_on_rally_strong(self):
+        self.arm_price()
+        self.yf.option_chain.return_value = chain_frames(
+            calls_rows=[call_row(100, volume=0, oi=100, last=4, bid=3.9, ask=4.1, iv=0.3)],
+            puts_rows=[call_row(100, volume=0, oi=40_000, last=3.5, bid=3.4, ask=3.6, iv=0.3)],
+        )
+        out = self.service.get_delta_adjusted_oi("intc", max_expirations=1)
+        self.assertLess(out["net_daoi_shares"], 0)
+        self.assertEqual(out["mm_hedge_bias"], "buy_on_rally")
+        self.assertEqual(out["signal"], "strong")     # near flip (same strike) + big magnitude
+        self.assertEqual(out["delta_flip_strike"], 100.0)
+        self.assertEqual(out["gamma_wall_strike"], 100.0)
+        self.assertEqual(out["gamma_wall_method"], "bs_gamma_oi")
+        self.options.save_gamma_wall.assert_called_once()
+
+    def test_call_heavy_book_reads_sell_on_rally_none(self):
+        self.arm_price()
+        self.yf.option_chain.return_value = chain_frames(
+            calls_rows=[call_row(100, volume=0, oi=40_000, last=4, bid=3.9, ask=4.1, iv=0.3)],
+        )
+        out = self.service.get_delta_adjusted_oi("INTC", max_expirations=1)
+        self.assertEqual(out["mm_hedge_bias"], "sell_on_rally")
+        self.assertEqual(out["signal"], "none")
+
+    def test_no_expirations_short_circuits(self):
+        self.arm_price(expirations=())
+        out = self.service.get_delta_adjusted_oi("INTC")
+        self.assertEqual(out["signal"], "none")
+        self.options.save_gamma_wall.assert_not_called()
+
+
+class TestRepoBackedSurfaces(OptionsServiceTestBase):
+    def test_gamma_wall_history_notes(self):
+        self.options.get_gamma_wall_history.return_value = [{"d": 1}]
+        out = self.service.get_gamma_wall_history("intc")
+        self.assertEqual(out["data_points"], 1)
+        self.assertIn("One row per calendar day", out["note"])
+        self.options.get_gamma_wall_history.return_value = []
+        out = self.service.get_gamma_wall_history("INTC")
+        self.assertIn("No history yet", out["note"])
+
+    def test_options_latest(self):
+        self.options.get_latest_snapshot.return_value = None
+        self.assertIsNone(self.service.get_options_latest("intc")["snapshot"])
+        self.options.get_latest_snapshot.return_value = {"price": 1}
+        self.assertEqual(self.service.get_options_latest("INTC")["snapshot"], {"price": 1})
+
+    def test_options_history_collapses_intraday_rows(self):
+        self.options.get_pc_history.return_value = [
+            {"captured_at": "2026-07-14T10:00:00Z", "price": 99.0, "put_call_ratio": 1.0},
+            {"captured_at": "2026-07-14T15:00:00Z", "price": 101.0, "put_call_ratio": 2.0},
+            {"captured_at": "2026-07-13T15:00:00Z", "price": 98.0, "put_call_ratio": None},
+        ]
+        out = self.service.get_options_history("INTC")
+        self.assertEqual(len(out["history"]), 2)
+        d13, d14 = out["history"][0], out["history"][1]
+        self.assertIsNone(d13["put_call_ratio"])
+        self.assertEqual(d14["put_call_ratio"], 1.5)      # intraday average
+        self.assertEqual(d14["price"], 101.0)             # latest row wins
+        self.assertEqual(d14["captured_at"], "2026-07-14T15:00:00Z")
+
+    def full_chain_fixture(self):
+        contracts = [
+            {"kind": "call", "strike": 95.0, "open_interest": 100, "last_price": 7.0},
+            {"kind": "call", "strike": 100.0, "open_interest": 500, "last_price": 4.0},
+            {"kind": "call", "strike": 105.0, "open_interest": 100, "last_price": 2.0},
+            {"kind": "put", "strike": 95.0, "open_interest": 100, "last_price": 1.5},
+            {"kind": "put", "strike": 100.0, "open_interest": 500, "last_price": 3.5},
+            {"kind": "put", "strike": 105.0, "open_interest": 100, "last_price": 6.0},
+        ]
+        return {
+            "price": 100.0,
+            "captured_at": "2026-07-14T15:00:00Z",
+            "expirations": [{
+                "expiration": TODAY_EXP,
+                "contracts": contracts,
+                "total_call_oi": 700, "total_put_oi": 700, "put_call_ratio": 1.0,
+            }],
+        }
+
+    def test_options_analytics_max_pain_and_expected_move(self):
+        self.options.get_full_chain.return_value = self.full_chain_fixture()
+        out = self.service.get_options_analytics("intc")
+        row = out["analytics"][0]
+        self.assertEqual(row["max_pain"], 100.0)          # OI concentrated at 100
+        self.assertEqual(row["atm_strike"], 100.0)
+        self.assertEqual(row["expected_move_dollar"], 7.5)  # 4.0 + 3.5 straddle
+        self.assertEqual(row["expected_move_pct"], 7.5)
+        self.assertEqual(row["upper_bound"], 107.5)
+        self.assertEqual(row["lower_bound"], 92.5)
+        self.assertTrue(row["pain_curve"])
+
+    def test_options_analytics_without_chain(self):
+        self.options.get_full_chain.return_value = None
+        out = self.service.get_options_analytics("INTC")
+        self.assertIsNone(out["analytics"])
+
+    def test_options_chain_expiration_filter(self):
+        chain = self.full_chain_fixture()
+        chain["expirations"].append({"expiration": "2026-09-18", "contracts": []})
+        self.options.get_full_chain.return_value = chain
+        out = self.service.get_options_chain("INTC", expiration=TODAY_EXP)
+        self.assertEqual(len(out["chain"]["expirations"]), 1)
+        self.assertEqual(out["chain"]["expirations"][0]["expiration"], TODAY_EXP)
+
+    def test_iv_rank_math(self):
+        self.options.get_iv_history.return_value = [
+            {"composite_iv": 20.0}, {"composite_iv": 60.0},
+            {"composite_iv": None}, {"composite_iv": 40.0},
+        ]
+        out = self.service.get_iv_rank("intc")
+        self.assertEqual(out["current_iv"], 40.0)
+        self.assertEqual(out["iv_rank"], 50.0)            # (40-20)/(60-20)
+        self.assertEqual(out["iv_percentile"], 50.0)      # 1 of 2 past values below
+        self.assertEqual(out["iv_52w_high"], 60.0)
+        self.assertEqual(out["iv_52w_low"], 20.0)
+
+    def test_iv_rank_insufficient_history(self):
+        self.options.get_iv_history.return_value = [{"composite_iv": 33.0}]
+        out = self.service.get_iv_rank("INTC")
+        self.assertIsNone(out["iv_rank"])
+        self.assertEqual(out["current_iv"], 33.0)
+
+
+class TestFlowSignalsAndPortfolioDelta(OptionsServiceTestBase):
+    def test_flow_signals_isolate_failures(self):
+        ok = {"sweep_signal": "none"}
+        with unittest.mock.patch.object(self.service, "get_unusual_calls",
+                                        return_value=ok), \
+             unittest.mock.patch.object(self.service, "get_delta_adjusted_oi",
+                                        side_effect=RuntimeError("daoi boom")):
+            out = self.service.get_options_flow_signals("intc")
+        self.assertEqual(out["unusual_calls"], ok)
+        self.assertIsNone(out["delta_adjusted_oi"])
+        self.assertIn("daoi boom", out["_errors"]["delta_adjusted_oi"])
+
+    def test_portfolio_delta_exposure_put_heavy_position(self):
+        chain = {
+            "price": 100.0,
+            "captured_at": "t",
+            "expirations": [{
+                "expiration": TODAY_EXP,
+                "contracts": [
+                    {"kind": "put", "strike": 100.0, "open_interest": 10_000,
+                     "implied_vol": 30.0},   # percent form exercises normalization
+                ],
+            }],
+        }
+        self.options.get_full_chain.side_effect = lambda sym: (
+            chain if sym == "INTC" else None
+        )
+        out = self.service.get_portfolio_delta_exposure([
+            {"symbol": "INTC", "name": "Intel", "quantity": 500},
+            {"symbol": "NOCHAIN", "name": "Nothing", "quantity": 1},
+        ])
+        self.assertEqual(len(out["positions"]), 1)
+        pos = out["positions"][0]
+        self.assertEqual(pos["stock_delta"], 500.0)
+        self.assertLess(pos["net_daoi_shares"], 0)         # puts carry negative delta
+        self.assertEqual(pos["mm_hedge_bias"], "buy_on_rally")
+        self.assertEqual(out["portfolio_net_daoi"], pos["net_daoi_shares"])
+
+
+class TestFullChainFetch(OptionsServiceTestBase):
+    def test_full_chain_persists_and_summarizes(self):
+        self.arm_price()
+        prices = self.service._prices
+        prices.get_history.return_value = pd.DataFrame(
+            {"Close": [100.0] * 30},
+            index=pd.bdate_range(end="2026-07-14", periods=30),
+        )
+        self.yf.option_chain.return_value = chain_frames(
+            calls_rows=[call_row(100, volume=10, oi=100, last=4, bid=3.9, ask=4.1)],
+            puts_rows=[call_row(100, volume=10, oi=200, last=3.5, bid=3.4, ask=3.6)],
+        )
+        self.options.save_full_chain.return_value = 42
+        out = self.service.get_full_options_chain("intc")
+        self.assertEqual(out["snapshot_id"], 42)
+        self.assertTrue(out["persisted"])
+        self.assertEqual(out["expiration_count"], 1)
+        self.assertEqual(out["total_contracts"], 2)
+        self.assertEqual(out["expirations"], [TODAY_EXP])
+        self.assertIsNotNone(out["bollinger_bands"])
+
+    def test_full_chain_duplicate_snapshot_flagged(self):
+        self.arm_price(expirations=())
+        prices = self.service._prices
+        prices.get_history.return_value = pd.DataFrame(
+            {"Close": [100.0] * 10},
+            index=pd.bdate_range(end="2026-07-14", periods=10),
+        )
+        out = self.service.get_full_options_chain("INTC")
+        self.assertEqual(out["expiration_count"], 0)
+        self.assertEqual(out["total_contracts"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> **Stacked on #90** (base = `test/coverage-uplift`; auto-retargets when it merges). Same method as wave 1: engineered fixtures with analytically known outcomes, no production code changes needed.

| Module | Before | After | Tests |
|---|---|---|---|
| `quantcore/services/options.py` | 7.3% | **67.0%** | 19 |
| `quantcore/services/fundamentals.py` | 44.6% | **67.3%** | +12 |
| **Total (scoped)** | **55.3%** | **61.2%** | 393 total |

Floor ratcheted **54 → 60** per policy.

## Highlights

- **Sweep scoring pinned end-to-end**: a 2.5× vol/OI call filled at the ask 8% OTM must score exactly 7 → "very high" conviction → `strong` signal; the same volume ITM below mid must read as hedge flow → `weak`.
- **Dealer positioning**: a put-heavy book must flip market makers to `buy_on_rally` with the delta-flip strike and BS gamma wall identified and persisted via `save_gamma_wall`; a call-heavy book must read `sell_on_rally`/`none`.
- **Expected move is arithmetic**: ATM straddle 4.00 + 3.50 at spot 100 must report exactly ±7.5%.
- **Fundamentals internals now covered on statement-shaped fixtures**: an engineered compounder (26% CAGR, 25% margins, 30% FCF margin, cheap EV/S, +22% momentum) must compose to exactly **11/strong_compounder at 1.0 coverage**; the earnings-calendar risk ladder (CRITICAL <7d / HIGH <14d / MODERATE ≤30d / LOW) is walked with relative dates, including yfinance's dict-form calendar variant and a measured +10% historical earnings-day move.

## Wave 3 (deferred deliberately)

`options_screening.py` score/build-trade internals, Polygon backfill + refresh orchestrators, and the DB-backed repositories via the seeded-test-DB pattern.

## Verification

393 tests green under coverage; floor verified passing at 60. CI runs the real gate + diff-cover on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)