### PR TITLE
Tests: coverage uplift wave 3 — trade builders + options repository, floor 62

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Unit tests (under coverage)
         run: coverage run -m unittest discover -v
       # COVERAGE RATCHET: the floor below is pinned ~1pt under the measured
-      # baseline (61.2% on 2026-07-15 after uplift wave 2; scope in
+      # baseline (63.4% on 2026-07-15 after uplift wave 3; scope in
       # .coveragerc). It only ever moves UP — when a PR meaningfully raises
       # coverage, bump it in the same PR. The behavioral gate is diff-cover:
       # changed lines need >= 85%.
@@ -88,7 +88,7 @@ jobs:
         run: |
           coverage report
           coverage report --format=markdown >> "$GITHUB_STEP_SUMMARY"
-          coverage report --fail-under=60
+          coverage report --fail-under=62
       - name: Diff coverage (changed lines >= 85%, PRs only)
         if: github.event_name == 'pull_request'
         run: |

--- a/test_options_repository.py
+++ b/test_options_repository.py
@@ -1,0 +1,167 @@
+"""DB round-trip tests for OptionsStore's ATM-snapshot, P/C-history, IV-history
+and gamma-wall surfaces (wave 3 coverage — the full-chain paths are pinned in
+test_options_contract_tools.py). Runs against the test database only.
+"""
+import os
+import unittest
+from contextlib import closing
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+# Standard preamble: swap in the test DSN BEFORE quantcore.db is imported.
+_env_file = Path(__file__).parent / ".env"
+if _env_file.exists():
+    for _line in _env_file.read_text().splitlines():
+        if _line.strip().startswith("QUANTCORE_TEST_DB_DSN="):
+            os.environ["QUANTCORE_DB_DSN"] = _line.split("=", 1)[1].strip()
+            break
+
+from quantcore.db_safety import assert_not_production  # noqa: E402
+
+assert_not_production()
+
+from quantcore.db import get_connection  # noqa: E402
+from quantcore.repositories.options_repository import OptionsStore  # noqa: E402
+
+TEST_SYMBOL = "ZZOPTREPO"
+
+
+def iso(days_ago: float) -> str:
+    ts = datetime.now(timezone.utc) - timedelta(days=days_ago)
+    return ts.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def atm_side(iv_pct, strikes=(95.0, 100.0)):
+    return {
+        "total_open_interest": 1_000,
+        "total_volume": 500,
+        "avg_iv_pct": iv_pct,
+        "atm_contracts": [
+            {"strike": s, "last": 2.0, "bid": 1.9, "ask": 2.1, "iv": iv_pct,
+             "volume": 10, "open_interest": 100, "in_the_money": s < 100}
+            for s in strikes
+        ],
+    }
+
+
+def options_payload(pcr=1.2, call_iv=40.0, put_iv=50.0):
+    return {
+        "expiration": "2026-08-21",
+        "put_call_ratio": pcr,
+        "calls": atm_side(call_iv),
+        "puts": atm_side(put_iv),
+    }
+
+
+class OptionsRepositoryTest(unittest.TestCase):
+    def setUp(self):
+        self._purge()
+        self.addCleanup(self._purge)
+        self.store = OptionsStore()
+
+    def _purge(self):
+        with closing(get_connection()) as conn:
+            conn.execute("DELETE FROM options_snapshots WHERE symbol = %s",
+                         (TEST_SYMBOL,))
+            conn.execute("DELETE FROM gamma_wall_history WHERE symbol = %s",
+                         (TEST_SYMBOL,))
+            conn.commit()
+
+    def seed(self, days_ago=0.0, price=100.0, pcr=1.2, **payload_kw):
+        return self.store.save_snapshot(
+            symbol=TEST_SYMBOL,
+            price=price,
+            bollinger_bands={"upper": 110.0, "middle": 100.0, "lower": 90.0,
+                             "period": 20},
+            options=options_payload(pcr=pcr, **payload_kw),
+            captured_at=iso(days_ago),
+        )
+
+    # -- ATM snapshot round trips ----------------------------------------
+
+    def test_snapshot_roundtrip_and_duplicate_rejection(self):
+        ts = iso(0.0)
+        first = self.store.save_snapshot(
+            symbol=TEST_SYMBOL, price=101.5,
+            bollinger_bands={"upper": 110, "middle": 100, "lower": 90},
+            options=options_payload(), captured_at=ts,
+        )
+        self.assertIsNotNone(first)
+        # Same symbol+timestamp is a duplicate — must return None, not raise.
+        self.assertIsNone(self.store.save_snapshot(
+            symbol=TEST_SYMBOL, price=999.0,
+            bollinger_bands=None, options=options_payload(), captured_at=ts,
+        ))
+        snap = self.store.get_latest_snapshot(TEST_SYMBOL)
+        self.assertEqual(float(snap["price"]), 101.5)
+
+    def test_snapshot_without_options_still_persists(self):
+        sid = self.store.save_snapshot(
+            symbol=TEST_SYMBOL, price=55.0, bollinger_bands=None,
+            options=None, captured_at=iso(0.0),
+        )
+        self.assertIsNotNone(sid)
+        self.assertEqual(self.store.snapshot_count(TEST_SYMBOL), 1)
+
+    def test_symbols_dates_and_counts(self):
+        self.seed(days_ago=2.0)
+        self.seed(days_ago=1.0)
+        self.assertIn(TEST_SYMBOL, self.store.get_symbols())
+        self.assertEqual(self.store.snapshot_count(TEST_SYMBOL), 2)
+        self.assertEqual(len(self.store.get_snapshot_dates(TEST_SYMBOL)), 2)
+
+    # -- History surfaces ---------------------------------------------------
+
+    def test_pc_history_window_and_values(self):
+        self.seed(days_ago=2.0, price=98.0, pcr=1.5)
+        self.seed(days_ago=1.0, price=99.0, pcr=1.0)
+        self.seed(days_ago=45.0, price=90.0, pcr=3.0)   # outside 30d window
+        rows = self.store.get_pc_history(TEST_SYMBOL, days=30)
+        self.assertEqual(len(rows), 2)
+        pcrs = {round(float(r["put_call_ratio"]), 2) for r in rows}
+        self.assertEqual(pcrs, {1.5, 1.0})
+        for r in rows:
+            self.assertIn("captured_at", r)
+            self.assertIn("price", r)
+
+    def test_iv_history_composites_both_sides(self):
+        self.seed(days_ago=1.0, call_iv=40.0, put_iv=50.0)
+        rows = self.store.get_iv_history(TEST_SYMBOL, days=365)
+        self.assertEqual(len(rows), 1)
+        composite = rows[0]["composite_iv"]
+        self.assertIsNotNone(composite)
+        self.assertGreaterEqual(float(composite), 40.0)
+        self.assertLessEqual(float(composite), 50.0)
+
+    # -- Gamma wall history --------------------------------------------------
+
+    def daoi_result(self, price=100.0, wall=105.0):
+        return {
+            "price": price,
+            "gamma_wall_strike": wall,
+            "gamma_wall_method": "bs_gamma_oi",
+            "delta_flip_strike": 100.0,
+            "dist_to_flip_pct": 0.0,
+            "net_daoi_shares": -12_000.0,
+            "call_daoi_shares": 3_000.0,
+            "put_daoi_shares": -15_000.0,
+            "mm_hedge_bias": "buy_on_rally",
+            "signal": "strong",
+            "expirations_scanned": ["2026-08-21"],
+        }
+
+    def test_gamma_wall_last_write_of_day_wins(self):
+        self.store.save_gamma_wall(TEST_SYMBOL, self.daoi_result(price=100.0))
+        self.store.save_gamma_wall(TEST_SYMBOL, self.daoi_result(price=104.0,
+                                                                 wall=110.0))
+        rows = self.store.get_gamma_wall_history(TEST_SYMBOL, since_days=7)
+        self.assertEqual(len(rows), 1)                  # one row per calendar day
+        self.assertEqual(float(rows[0]["price"]), 104.0)
+        self.assertEqual(float(rows[0]["gamma_wall_strike"]), 110.0)
+
+    def test_gamma_wall_history_empty_for_unknown_symbol(self):
+        self.assertEqual(self.store.get_gamma_wall_history("ZZNOWALL"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_options_screening_service.py
+++ b/test_options_screening_service.py
@@ -16,16 +16,20 @@ import tempfile
 import unittest
 from pathlib import Path
 
+import pandas as pd
+
 from quantcore.services.options_screening import (
     OptionsScreeningService,
     SecurityAnalysis,
     BollingerBands,
     OptionsSummary,
     IVAnalysis,
+    PutCallAnalysis,
     CONVICTION_WEIGHT,
     ROI_WEIGHT,
     ROI_CAP_FOR_RANKING,
     MAX_PUT_SCORE,
+    _chain_pc,
 )
 
 
@@ -209,6 +213,179 @@ class WatchlistHelperTests(unittest.TestCase):
         self.assertEqual([e["symbol"] for e in entries], ["AAPL", "MSFT"])
         self.assertEqual(entries[0]["tags"], ["tech", "core"])
         self.assertEqual(entries[1]["name"], "MSFT")
+
+
+# ---------------------------------------------------------------------------
+# Wave 3 additions: band math, chain P/C helper, PutCallAnalysis-driven score
+# paths, and the trade builders (previously untested).
+# ---------------------------------------------------------------------------
+
+
+def _pc(**overrides) -> PutCallAnalysis:
+    data = dict(near_expiry="2026-07-17", near_oi_pc=1.0, near_vol_pc=1.0,
+                near_atm_pc=None, mid_expiry=None, mid_oi_pc=None,
+                term_skew=None, vol_oi_ratio=1.0,
+                put_unwinding=False, fresh_put_buying=False,
+                near_term_fear=False)
+    data.update(overrides)
+    return PutCallAnalysis(**data)
+
+
+class BandMathTests(unittest.TestCase):
+    def test_position_normalization_and_breakouts(self):
+        b = BollingerBands(upper=110.0, middle=100.0, lower=90.0)
+        self.assertEqual(b.position(90.0), 0.0)
+        self.assertEqual(b.position(100.0), 0.5)
+        self.assertEqual(b.position(110.0), 1.0)
+        self.assertGreater(b.position(115.0), 1.0)
+        self.assertAlmostEqual(b.pct_from_lower(94.5), 5.0)
+        self.assertAlmostEqual(b.pct_from_upper(104.5), -5.0)
+
+    def test_zero_width_bands_read_neutral(self):
+        b = BollingerBands(upper=100.0, middle=100.0, lower=100.0)
+        self.assertEqual(b.position(100.0), 0.5)
+
+
+class ChainPcTests(unittest.TestCase):
+    def test_oi_and_volume_ratios(self):
+        calls = pd.DataFrame({"strike": [95.0, 100.0], "openInterest": [100, 100],
+                              "volume": [10, 10]})
+        puts = pd.DataFrame({"strike": [95.0, 100.0], "openInterest": [200, 200],
+                             "volume": [40, 40]})
+        oi_pc, vol_pc, _ = _chain_pc(calls, puts, price=100.0)
+        self.assertEqual(oi_pc, 2.0)
+        self.assertEqual(vol_pc, 4.0)
+
+    def test_missing_or_empty_frames(self):
+        calls = pd.DataFrame({"strike": [100.0], "openInterest": [1], "volume": [1]})
+        self.assertEqual(_chain_pc(calls, pd.DataFrame(), 100.0), (None, None, None))
+        self.assertEqual(_chain_pc(None, None, 100.0), (None, None, None))
+
+
+class PutCallScorePathTests(unittest.TestCase):
+    def test_put_unwinding_and_fear_skew_add_long_points(self):
+        svc = _svc()
+        sec = _security(pc=_pc(
+            near_oi_pc=1.6, near_vol_pc=1.0,
+            put_unwinding=True,                          # +2
+            near_term_fear=True, mid_oi_pc=1.1, term_skew=0.5,   # +1
+            near_atm_pc=1.0,                             # < 0.85 x total: +1
+        ))
+        svc.score(sec)
+        self.assertEqual(sec.long_score, 4)
+        self.assertIn("put unwinding", sec.long_reason)
+        self.assertIn("near-term fear", sec.long_reason)
+        self.assertIn("near-money calls", sec.long_reason)
+
+    def test_fresh_put_buying_and_atm_hedging_add_put_points(self):
+        svc = _svc()
+        sec = _security(pc=_pc(
+            near_oi_pc=1.0, near_vol_pc=2.0,
+            fresh_put_buying=True,                       # +2
+            near_atm_pc=1.5,                             # > 1.2 x total: +1
+        ))
+        svc.score(sec)
+        self.assertEqual(sec.put_score, 3)
+        self.assertIn("fresh put buying", sec.put_reason)
+        self.assertIn("targeted hedging", sec.put_reason)
+
+
+ATM_PUT = {"strike": 100.0, "ask": 3.0, "iv": 40.0}
+ATM_CALL = {"strike": 100.0, "ask": 3.0, "iv": 40.0}
+
+
+class BuildPutTradeTests(unittest.TestCase):
+    def bearish(self, **overrides):
+        sec = _security(
+            options=_options(atm_puts=[dict(ATM_PUT)], put_call_ratio=2.2,
+                             total_put_oi=5_000),
+            **overrides,
+        )
+        sec.put_score = 8.0
+        return sec
+
+    def test_happy_path_targets_the_lower_band(self):
+        trade = _svc().build_put_trade(self.bearish())
+        self.assertEqual(trade["strike"], 100.0)
+        self.assertEqual(trade["total_cost"], 300.0)            # 1 x $3.00 x 100
+        self.assertEqual(trade["target_price"], 90.0)           # the lower band
+        self.assertEqual(trade["profit_at_target_per_contract"], 700.0)  # (10-3)x100
+        self.assertAlmostEqual(trade["roi_at_target_pct"], 233.3, places=1)
+        self.assertFalse(trade["suggest_spread"])
+
+    def test_breakdown_extends_target_below_the_band(self):
+        trade = _svc().build_put_trade(self.bearish(price=85.0))
+        self.assertEqual(trade["target_price"], 85.5)           # lower band x 0.95
+
+    def test_high_iv_suggests_a_spread(self):
+        sec = self.bearish()
+        sec.options.atm_puts[0]["iv"] = 70.0
+        self.assertTrue(_svc().build_put_trade(sec)["suggest_spread"])
+
+    def test_guardrails_veto_the_trade(self):
+        svc = _svc()
+        self.assertIsNone(svc.build_put_trade(self.bearish(days_to_earnings=5)))
+        self.assertIsNone(svc.build_put_trade(
+            self.bearish(recent_positive_catalyst=True)))
+        contradicted = self.bearish()
+        contradicted.long_score = 4.0
+        contradicted.put_score = 4.0
+        self.assertIsNone(svc.build_put_trade(contradicted))
+
+    def test_economic_vetoes(self):
+        svc = _svc()
+        rich = self.bearish()
+        rich.options.atm_puts[0]["ask"] = 15.0                  # $1500 > $1000 budget
+        self.assertIsNone(svc.build_put_trade(rich, total_budget=1000.0))
+
+        no_edge = self.bearish(
+            bands=BollingerBands(upper=110.0, middle=104.0, lower=98.0)
+        )
+        self.assertIsNone(svc.build_put_trade(no_edge))         # intrinsic 2 < ask 3
+
+        crossed = self.bearish()
+        crossed.options.atm_puts[0]["ask"] = 0.0
+        self.assertIsNone(svc.build_put_trade(crossed))
+
+        self.assertIsNone(svc.build_put_trade(_security()))     # no puts at all
+
+
+class BuildCallTradeTests(unittest.TestCase):
+    def bullish(self, **overrides):
+        sec = _security(
+            options=_options(atm_calls=[dict(ATM_CALL)], put_call_ratio=0.5),
+            **overrides,
+        )
+        sec.long_score = 8.0
+        return sec
+
+    def test_happy_path_targets_the_upper_band(self):
+        trade = _svc().build_call_trade(self.bullish())
+        self.assertEqual(trade["target_price"], 110.0)
+        self.assertEqual(trade["profit_at_target_per_contract"], 700.0)
+        self.assertEqual(trade["long_score"], 8.0)
+
+    def test_breakout_extends_target_above_the_band(self):
+        trade = _svc().build_call_trade(self.bullish(price=112.0))
+        self.assertEqual(trade["target_price"], 115.5)          # upper band x 1.05
+
+    def test_earnings_blackout_applies_but_catalyst_supports(self):
+        svc = _svc()
+        self.assertIsNone(svc.build_call_trade(self.bullish(days_to_earnings=3)))
+        # A positive catalyst SUPPORTS the call thesis — trade still builds.
+        self.assertIsNotNone(
+            svc.build_call_trade(self.bullish(recent_positive_catalyst=True))
+        )
+
+    def test_economic_vetoes(self):
+        svc = _svc()
+        rich = self.bullish()
+        rich.options.atm_calls[0]["ask"] = 15.0
+        self.assertIsNone(svc.build_call_trade(rich, total_budget=1000.0))
+        no_edge = self.bullish(
+            bands=BollingerBands(upper=102.0, middle=96.0, lower=90.0)
+        )
+        self.assertIsNone(svc.build_call_trade(no_edge))        # intrinsic 2 < ask 3
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> **Stacked on #91.** Same discipline: engineered fixtures, analytically-known outcomes, zero production changes.

| Module | Before | After |
|---|---|---|
| `quantcore/services/options_screening.py` | 40.9% | **53.9%** |
| `quantcore/repositories/options_repository.py` | 39.0% | **88.4%** |
| **Total (scoped)** | 61.2% | **63.4%** |

Floor ratcheted **60 → 62**. 390 tests green.

## What got pinned

- **The trade builders** (previously 0% — the screener's actual output): an ATM put at $3.00 targeting the lower band must yield exactly $700/contract and 233% ROI; a confirmed breakdown must extend the target to band×0.95 (calls: ×1.05); every guardrail (earnings blackout, catalyst-cooldown-puts-only, contradiction) and economic veto (budget cap, negative-edge, crossed quote) returns `None` precisely when it should.
- **`PutCallAnalysis` score paths**: put-unwinding/fresh-buying/ATM-vs-total signals were unexercised by the existing suite.
- **`OptionsStore` round trips** on the seeded test DB: duplicate-timestamp rejection, optionless snapshots, P/C history windowing (45-day-old rows excluded from a 30-day query), IV compositing, and gamma-wall last-write-of-day-wins.

## Remaining (wave 4 candidates, diminishing returns)

`options_screening`'s live `fetch_*`/`_run_analysis` orchestration, `harvester_repository` (42%), `recommendations` composition paths (73%), and the Polygon backfill/refresh orchestrators. These are increasingly integration-shaped; the diff gate protects them going forward regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)