### PR TITLE
Support tools PR A: ATR bands + Anchored VWAP (issue #93, Phases 1-2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ Per [`docs/proposals/architectural-standard-v2.md`](docs/proposals/architectural
 
 - **`quantcore/gateways/`** — external-IO wrappers: `YFinanceGateway` (yfinance), `PolygonGateway` (Polygon HTTP/pagination). These are the *only* place outside `portfolio/` (the legacy domain layer, retained for `main.py`'s report path) and the standalone `experiments/` monitors that imports `yfinance`.
 - **`quantcore/repositories/`** — SQL-only persistence, no analytics: `OhlcvRepository`, `OptionsStore`, `OptionsPositionStore`, `NewsStore`, `SentimentStore`, `FundamentalsRepository`, `HarvesterPlanDB`, `PortfolioRepository`.
-- **`quantcore/analytics/`** — pure functions (DataFrame/dict in, value out), no I/O: `indicators.py` (RSI/MACD), `options_math.py` (Black–Scholes delta/gamma, max-pain, expected-move — single home, deduped).
+- **`quantcore/analytics/`** — pure functions (DataFrame/dict in, value out), no I/O: `indicators.py` (RSI/MACD, Wilder ATR, anchored VWAP, swing detection), `options_math.py` (Black–Scholes delta/gamma, max-pain, expected-move — single home, deduped).
 - **`quantcore/services/`** — the business logic: `PricesService`, `OptionsService`, `OptionsScreeningService`, `FundamentalsService`, `SentimentService`, `MicrostructureService`, `HarvesterService`, `PortfolioService`, `RecommendationsService` (composes the other services).
 - **`quantcore/services/registry.py`** — the composition root: a lazy `@lru_cache get_services()` returning a frozen `Services` dataclass with all dependencies constructor-injected. Adapters call `get_services().<service>.<method>(...)`; service modules never import each other or the registry (acyclic).
 

--- a/api/routers/prices.py
+++ b/api/routers/prices.py
@@ -127,6 +127,22 @@ def get_atr_bands(
         return route_error_plain(str(exc), 500)
 
 
+# /anchored-vwap is declared before /vwap so the literal sub-path is never shadowed.
+@router.get("/{ticker}/anchored-vwap")
+def get_anchored_vwap(
+    ticker: str,
+    anchor_date: Optional[str] = None,
+    lookback_days: int = 365,
+    swing_bars: int = 5,
+) -> QuantCoreJSONResponse:
+    try:
+        return QuantCoreJSONResponse(
+            services().prices.get_anchored_vwap(ticker, anchor_date, lookback_days, swing_bars)
+        )
+    except Exception as exc:  # noqa: BLE001
+        return route_error_plain(str(exc), 500)
+
+
 # /vwap/history is declared before /vwap so the literal sub-path is never shadowed.
 @router.get("/{ticker}/vwap/history")
 def get_vwap_history(

--- a/api/routers/prices.py
+++ b/api/routers/prices.py
@@ -110,6 +110,23 @@ def get_obv(ticker: str, lookback: int = 20, interval: str = "1d") -> QuantCoreJ
         return route_error_plain(str(exc), 500)
 
 
+@router.get("/{ticker}/atr-bands")
+def get_atr_bands(
+    ticker: str,
+    period: int = 14,
+    band_mult: float = 2.0,
+    stop_mult: float = 3.0,
+    interval: str = "1d",
+    lookback: int = 250,
+) -> QuantCoreJSONResponse:
+    try:
+        return QuantCoreJSONResponse(
+            services().prices.get_atr_bands(ticker, period, band_mult, stop_mult, interval, lookback)
+        )
+    except Exception as exc:  # noqa: BLE001
+        return route_error_plain(str(exc), 500)
+
+
 # /vwap/history is declared before /vwap so the literal sub-path is never shadowed.
 @router.get("/{ticker}/vwap/history")
 def get_vwap_history(

--- a/docs/capabilities-matrix.md
+++ b/docs/capabilities-matrix.md
@@ -2,8 +2,8 @@
 
 This document is a comprehensive inventory of every user-facing capability in the StockPortfolioManager project, mapped to the surface(s) through which it can be accessed.
 
-**Last Updated:** 2026-06-15  
-**MCP Tools:** 47 | **REST Endpoints:** 50 | **WebUI Pages:** 6 | **CLI Tools:** 2 | **Standalone Scripts:** 8
+**Last Updated:** 2026-07-15  
+**MCP Tools:** 49 | **REST Endpoints:** 85 routes (see `docs/openapi-surface.txt`) | **WebUI Pages:** 6 | **CLI Tools:** 2 | **Standalone Scripts:** 8
 
 > **Refactor status (2026-06-17):** This inventory is the evidence base for [`proposals/architectural-standard-v2.md`](proposals/architectural-standard-v2.md). Phase 1 (extraction of all business logic into `quantcore/services/`, with MCP tools and REST routes reduced to one-call-deep adapters) is **complete** — see `proposals/phase1-migration-plan.md`. Phase 2 (FastAPI/Pydantic REST tier) is **complete** — see `proposals/phase2-fastapi-plan.md`: the Flask app (`api/app.py`) was rebuilt on FastAPI (`api/main.py`) preserving every route path and JSON shape, then retired; OpenAPI is published at `/docs`; and 12 previously MCP-only capabilities were exposed over REST (50 method-distinct operations across 45 paths). Phase 3 (AI gateway + GCP deployment) is **complete on the test project** — see `proposals/phase3-gateway-plan.md`: Step 1 closed the residual tool→endpoint gaps (32 thin routes + 3 param fixes, the surface is now 82 method+path operations), then all five MCP servers were inverted into thin HTTP gateway wrappers calling the REST tier through `mcp_gateway/rest_client.py` (Rule 6), JWT auth was added (`api/auth.py`, inert until configured), and the whole system was containerized and deployed to GCP Cloud Run (`quantcore-api` + 5 wrappers + a daily report Cloud Run Job) with CI/CD in `.github/workflows/deploy.yml`. Prod cutover (test→prod DSN) stays a supervised manual step.
 
@@ -33,7 +33,7 @@ The project exposes capabilities through five distinct surfaces:
 | CLI Tools | 2 | `collect_options.py` (EOD snapshot; broken), `options_analysis.py` (strategy analysis; hybrid CLI + MCP) |
 | Standalone Scripts | 8 | Portfolio reports, watchlist fundamentals report, spread monitors (6 superseded experiments deleted in Phase 1 Step 10) |
 
-**MCP tool count by server:** stock-price 23 · options-analysis 5 · company-fundamentals 12 · market-analysis 3 · news-sentiment 4. `get_option_contracts` and `price_vertical_spread` are exposed on both stock-price and options-analysis (shared implementation in `quantcore/services/options_contracts.py`).
+**MCP tool count by server:** stock-price 25 · options-analysis 5 · company-fundamentals 12 · market-analysis 3 · news-sentiment 4. `get_option_contracts` and `price_vertical_spread` are exposed on both stock-price and options-analysis (shared implementation in `quantcore/services/options_contracts.py`).
 
 **New since 2026-05-19:** `get_vwap_history`, `get_relative_strength_history`, `get_gamma_wall_history` (stock-price); `analyze_options_watchlist`, `analyze_options_symbol`, `mcp_health_check` (options-analysis — the `options_analysis.py` CLI is now also a FastMCP server); REST `GET /api/rungs/<rung_id>`; scripts `scripts/generate_watchlist_fundamentals_report.py`, `experiments/INTC_bear_call_spread_monitor.py`, `experiments/WMT_bull_call_spread_monitor.py`, `scripts/migrate_sqlite_to_postgres.py`.
 
@@ -62,6 +62,8 @@ Capabilities are organized by domain. A row with empty cells in the surface colu
 | Relative strength vs SPY/QQQ/sector ETF | `get_relative_strength` (stock_price) | `GET /api/securities/<ticker>/relative-strength` | — | — | — |
 | Relative strength history (trend over time) | `get_relative_strength_history` (stock_price) **NEW** | `GET /api/securities/<ticker>/relative-strength/history` | — | — | — |
 | Historical drawdown (worst 1d/5d, trailing stop %) | `get_historical_drawdown` (stock_price) | `GET /api/securities/<ticker>/signals/risk` | Securities Detail → Signals tab | — | `experiments/MaxDrawDownAnalyzer.py` |
+| ATR bands + chandelier trailing stop (volatility-calibrated) | `get_atr_bands` (stock_price) **NEW (issue #93)** | `GET /api/securities/<ticker>/atr-bands` | — | — | — |
+| Anchored VWAP (auto-anchors: earnings, 52w H/L, gaps, swings) | `get_anchored_vwap` (stock_price) **NEW (issue #93)** | `GET /api/securities/<ticker>/anchored-vwap` | — | — | — |
 | Composite trade recommendation (19 signals) | `get_trade_recommendation` (stock_price) | `GET /api/securities/<ticker>/recommendation?capital=` | — | — | — |
 | Stop-loss synthesis (7 sub-analyses: BB, VWAP, MACD, RSI, DAOI, drawdown, short interest) | `get_stop_loss_analysis` (stock_price) | `GET /api/securities/<ticker>/stop-loss` | — | — | — |
 

--- a/docs/openapi-surface.txt
+++ b/docs/openapi-surface.txt
@@ -19,6 +19,8 @@ GET    /api/securities/lookup  ->  lookup_security_api_securities_lookup_get
 GET    /api/securities/news/sentiment-summary  ->  get_sentiment_summary_api_securities_news_sentiment_summary_get
 GET    /api/securities/news/symbols  ->  list_news_symbols_api_securities_news_symbols_get
 GET    /api/securities/screen  ->  screen_securities_api_securities_screen_get
+GET    /api/securities/{ticker}/anchored-vwap  ->  get_anchored_vwap_api_securities__ticker__anchored_vwap_get
+GET    /api/securities/{ticker}/atr-bands  ->  get_atr_bands_api_securities__ticker__atr_bands_get
 GET    /api/securities/{ticker}/bid-ask-spread  ->  get_bid_ask_spread_api_securities__ticker__bid_ask_spread_get
 GET    /api/securities/{ticker}/candlestick  ->  get_candlestick_patterns_api_securities__ticker__candlestick_get
 GET    /api/securities/{ticker}/dark-pool  ->  get_dark_pool_api_securities__ticker__dark_pool_get

--- a/docs/proposals/support-confluence-tools-plan.md
+++ b/docs/proposals/support-confluence-tools-plan.md
@@ -1,0 +1,254 @@
+# Proposal: Support-Level Analysis Tools (ATR, Anchored VWAP, Volume Profile, OI-Change, GEX, Confluence)
+
+Status: **DRAFT — for team discussion before implementation**
+Date: 2026-07-15
+Tracking: [Issue #93](https://github.com/JohnFunkCode/StockPortfolioManager/issues/93) — progress comments posted there at the completion of each phase
+
+## Context
+
+A codebase audit against a professional support-level techniques list (gamma/GEX, volume profile, anchored VWAP, OI analysis, ATR, confluence) found six high-value tools buildable from data sources the system already has. The current analysis workflow (trim-and-hold, VWAP-reclaim entries, gamma-wall supports, drawdown-calibrated trailing stops distorted by earnings gaps) manually assembles confluence across many tool calls — these tools automate that, culminating in a single `get_support_confluence` composite.
+
+Every tool follows [`architectural-standard-v2.md`](architectural-standard-v2.md): pure math in `quantcore/analytics/`, business logic as a service method, thin FastAPI route (`QuantCoreJSONResponse` + `route_error_plain`, no Pydantic response model for analytics GETs), curated `@mcp.tool()` exactly one `rest_client.get()` deep in `fastMCPTest/stock_price_server.py` (that server hosts price AND gamma/DAOI tools — split is LLM-facing, not by service class). No registry changes needed anywhere — all methods extend existing `PricesService`, `OptionsService`, `OptionsStore`, `RecommendationsService`.
+
+## Build order / PR grouping
+
+- **PR A — Phase 1 (ATR bands) + Phase 2 (Anchored VWAP)** — both pure price/technicals in `PricesService`; Phase 2's swing-helper extraction is reused by Phase 6.
+- **PR B — Phase 3 (Volume Profile)** — standalone analytics module.
+- **PR C — Phase 4 (OI change) + Phase 5 (Vanna/Charm + signed GEX)** — both options-domain.
+- **PR D — Phase 6 (Support Confluence)** — composes everything; lands after A–C.
+- **PR E — Phase 7 (QuantUI front end)** — surfaces confluence in the Technical Analysis panel; needs Phase 6's endpoint merged (or at least running locally).
+
+Each PR ends with `PYTHONPATH=. python scripts/check_openapi_snapshot.py --update` and committing `docs/openapi-surface.txt` (CI diffs it).
+
+**Documentation pass (required at the completion of every phase):** scan `readme.md`, `CLAUDE.md`, and `docs/**` for any section describing tools, endpoints, MCP servers, schema, or the daily job, and update them for that phase's new functionality before the PR is opened — readme's MCP tool listings / API examples, CLAUDE.md's architecture sections (new analytics modules, `gex_history` as the 17th table, daily-job chain capture, frontend card), and any affected docs/proposals status notes.
+
+---
+
+## Phase 1 — ATR Bands + ATR trailing stop
+
+**Analytics** — `quantcore/analytics/indicators.py` (next to `rsi_series`/`macd_series`):
+- `true_range_series(high, low, close) -> pd.Series` — `TR = max(H−L, |H−C_prev|, |L−C_prev|)`; first bar = H−L.
+- `atr_series(high, low, close, period=14) -> pd.Series` — Wilder: `tr.ewm(alpha=1/period, adjust=False).mean()`. Document the seed convention so exact-value tests match.
+
+**Service** — `PricesService` (`quantcore/services/prices.py`):
+```python
+def get_atr_bands(self, symbol, period=14, band_mult=2.0, stop_mult=3.0,
+                  interval="1d", lookback=250) -> dict
+```
+Fetch via `self.get_history()` (the single OHLCV seam). Return: `atr`, `atr_pct`, `upper_band`/`lower_band` (close ± band_mult·ATR), `atr_trend` (expanding/contracting vs 3-month mean), **chandelier stop** = `max(High, 22 bars) − stop_mult·ATR` with `stop_distance_pct`, last ~20 bars `{date, atr, upper, lower}` history, and an interpretation contrasting with the drawdown-based stop (ATR re-adapts after earnings gaps within ~period bars).
+
+**REST** — `api/routers/prices.py`: `GET /api/securities/{ticker}/atr-bands` (params mirror service signature). Follow the `get_vwap_history` idiom.
+
+**MCP** — `get_atr_bands` in `fastMCPTest/stock_price_server.py`; docstring: volatility-calibrated stop placement, "prefer over get_stop_loss_analysis trailing % when earnings gaps pollute drawdown history".
+
+**Tests** — `test_atr_bands.py`: exact-value Wilder test on a hand-computed ~20-bar series; service test with the `make_service()` Mock-repo/gateway + synthetic DataFrame pattern from `test_prices_history_policy.py`; gap-robustness case (inject −15% gap bar, assert stop stays bounded).
+
+---
+
+## Phase 2 — Anchored VWAP
+
+**Analytics** — `quantcore/analytics/indicators.py`:
+- `anchored_vwap(df, anchor_idx) -> float` — `Σ(TP·V)/ΣV` from anchor to last, `TP=(H+L+C)/3` (same convention as `get_vwap`).
+- `find_swings(highs, lows, swing_bars=3) -> dict` — generalizes the confirmed-swing scan in `get_higher_lows` to return `{"lows": [...], "highs": [...]}` (high at i requires `high[i] >= high[i±k]`; skip last `swing_bars` unconfirmed bars). **Refactor `get_higher_lows` to call it** — output must stay identical (keep existing `<=` low semantics), guarded by a regression test.
+
+**Service** — `PricesService`:
+```python
+def get_anchored_vwap(self, symbol, anchor_date: str | None = None,
+                      lookback_days=365, swing_bars=5) -> dict
+```
+Anchor resolution, each source in its own try/except so one failure never kills the call:
+- `user` — explicit `anchor_date` (flagged first if given)
+- `earnings` — `self._yf.earnings_dates(symbol)` (defensive handling per `fundamentals.py`), last 2 past dates
+- `gap` — `self.get_gap_analysis(symbol)` top 2 `all_gaps` by `|gap_pct|`
+- `swing` — `find_swings` on 1y daily; most recent confirmed swing high + low
+- `52w_high` / `52w_low` — argmax(High)/argmin(Low) over 252 bars
+
+Dedupe anchors within 3 trading days (priority: user > earnings > 52w > gap > swing). One daily-history fetch (respect the 730-day gateway cap). Return `price`, `anchors: [{type, date, label, avwap, distance_pct, position}]` sorted by |distance_pct|, plus `nearest_support`/`nearest_resistance` (closest AVWAP below/above).
+
+**REST** — `GET /api/securities/{ticker}/anchored-vwap?anchor_date=&lookback_days=&swing_bars=`; declare above `/{ticker}/vwap` per the existing ordering convention.
+
+**MCP** — `get_anchored_vwap(symbol, anchor_date=None, lookback_days=365)`; docstring explains auto-anchor types and AVWAP as institutional cost-basis level.
+
+**Tests** — `test_anchored_vwap.py`: exact cumulative AVWAP on a tiny DataFrame; anchor resolution with stubbed gateway, dedupe/priority asserts; **`get_higher_lows` regression** (snapshot output on fixed synthetic series pre/post refactor).
+
+---
+
+## Phase 3 — Volume Profile
+
+**Analytics** — new module `quantcore/analytics/volume_profile.py` (pure numpy/pandas):
+```python
+def build_volume_profile(highs, lows, volumes, bins=50, value_area_pct=0.70) -> dict
+def find_volume_nodes(bin_centers, bin_volumes, hvn_ratio=1.25, lvn_ratio=0.60) -> dict
+```
+- Bin edges `linspace(min(low), max(high), bins+1)`; distribute each bar's volume **uniformly across [low, high]** by bin-overlap fraction (degenerate high==low → all to that bin). Uniform intrabar distribution is the standard approximation; close-only binning distorts daily profiles.
+- **POC** = argmax bin. **Value area (70%)**: start at POC, repeatedly annex the higher-volume adjacent bin until ≥70% of total → `(val, vah)`.
+- **HVN/LVN**: 3-bin centered rolling-mean smoothing; local maxima ≥ 1.25·median → HVN; local minima ≤ 0.60·median → LVN.
+
+**Service** — `PricesService`:
+```python
+def get_volume_profile(self, symbol, days=365, interval="1d",
+                       bins=50, value_area_pct=0.70) -> dict
+```
+Interval ∈ {"1d","1h"}; when `1h` + `days > 60`, surface a `note` (get_history already caps intraday) rather than erroring. Return `poc`, `value_area {low, high}`, `hvns`/`lvns`, `nearest_hvn_below/above`, `nearest_lvn_below/above` vs current close, `in_value_area`, compact `profile` array, interpretation (HVN = acceptance/support, LVN = rejection/air-pocket).
+
+**REST** — `GET /api/securities/{ticker}/volume-profile?days=&interval=&bins=&value_area_pct=`.
+
+**MCP** — `get_volume_profile`; docstring: daily/1y for structural levels, `interval="1h"` for the 60-day micro-profile.
+
+**Tests** — `test_volume_profile.py`: exact 3-bar overlap math → POC/VA/HVN/LVN; degenerate high==low bar; all-in-one-bin edge; service test with `make_service()` stub asserting nearest-node selection.
+
+---
+
+## Phase 4 — OI-Change Analysis (2×2)
+
+**Repository** — `quantcore/repositories/options_repository.py` (`OptionsStore`), one new method:
+```python
+def get_oi_timeseries(self, symbol, days=30, expiration=None) -> list[dict]
+```
+SQL: `DISTINCT ON (captured_at::date, expiration, kind, strike)` over `options_contracts ⋈ options_expirations ⋈ options_snapshots` filtered `symbol = %s AND chain_type = 'full'`, ordered `..., captured_at DESC` to keep the last full-chain snapshot per day. **Note: `captured_at` is TEXT** — cast `captured_at::timestamptz` (ISO strings) for the `>= now() - (%s || ' days')::interval` window and `::date` for grouping. Select `snap_date, underlying price, expiration, kind, strike, open_interest, volume, implied_vol`.
+
+**Service** — `OptionsService` (`quantcore/services/options.py`):
+```python
+def get_oi_change_analysis(self, symbol, days=30, top_n=10,
+                           min_oi=100, expiration=None) -> dict
+```
+- **Graceful degradation is required**: if < 2 distinct snapshot dates, return `{symbol, snapshot_dates, oi_changes: [], note: "OI history accumulates only when full-chain snapshots are captured — call get_full_options_chain periodically"}` — never a 500. (History is forward-accumulating like `gamma_wall_history`.)
+- Compare earliest vs latest date in window (plus latest-vs-previous as `latest_day_change`). Per (expiration, kind, strike): ΔOI, ΔOI%; Δunderlying from snapshot prices.
+- **2×2 classification** (movers with |ΔOI| ≥ min_oi): OI↑+price↑ → `new_longs`; OI↑+price↓ → `new_shorts`; OI↓+price↑ → `short_covering`; OI↓+price↓ → `long_liquidation`. Options overlay: large put-OI builds below spot → put-writing support; call-OI builds above → call-wall resistance.
+- Return `snapshot_dates_used`, `underlying_change_pct`, `top_oi_builds`/`top_oi_drains` (classified + interpreted), `put_oi_support_strikes`, `call_oi_resistance_strikes`, summary.
+
+**Daily capture (decision #2)** — extend `main.py`'s daily report job to call `get_full_options_chain` (in-process services, per the cron rule; cap ~6 expirations) for portfolio + watchlist symbols, so `options_contracts` accumulates the OI time series. Wrapped per-symbol in try/except — a failed chain fetch must never fail the report. This lands in PR C so history starts accumulating immediately.
+
+**REST** — `api/routers/options.py`: `GET /api/securities/{ticker}/options/oi-change?days=&top_n=&min_oi=&expiration=`.
+
+**MCP** — `get_oi_change_analysis` in stock_price_server.py (alongside `get_delta_adjusted_oi`); docstring states the sparse-history caveat.
+
+**Tests** — `test_oi_change_tools.py`: DB-backed per `test_options_contract_tools.py` (QUANTCORE_TEST_DB_DSN prelude + `db_safety.assert_not_production()`, ticker `ZZOICHG`): two `save_full_chain` snapshots with shifted OI/price → assert deltas, DISTINCT-ON dedupe (two snapshots same day), classification labels; tearDown cleanup. Plus a Mock-store unit test covering the <2-dates degradation path (no DB).
+
+---
+
+## Phase 5 — Vanna/Charm + Signed GEX Profile
+
+**Analytics** — `quantcore/analytics/options_math.py` (next to `bs_gamma`; q=0 like existing fns; each accepts precomputed `d1`):
+```python
+def bs_vega(S, K, T, sigma, r, d1=None)   # S·φ(d1)·√T
+def bs_vanna(S, K, T, sigma, r, d1=None)  # −φ(d1)·d2/σ, d2 = d1 − σ√T (call == put)
+def bs_charm(S, K, T, sigma, r, is_call, d1=None)
+    # −φ(d1)·(2rT − d2·σ√T)/(2T·σ√T); q=0 → call/put coincide; keep is_call for forward-compat
+```
+
+**Service** — `OptionsService`, **new method (do NOT extend `get_delta_adjusted_oi`)** — DAOI persists into `gamma_wall_history` with a `gamma_wall_method` marker; overloading a persisted payload consumers parse is the wrong seam.
+```python
+def get_gex_profile(self, symbol, max_expirations=6, risk_free_rate=0.045) -> dict
+```
+- Mirror the DAOI loop: `self._yf.expirations`/`option_chain`, one `bs_d1` per contract, IV fallback 0.30, skip K≤0 / OI≤0.
+- **Signed GEX** per contract: `gamma · OI · 100 · S² · 0.01` (dollar gamma per 1% move); calls +, puts − ; include `"convention": "dealers long calls / short puts"` in the payload.
+- Per-strike ladder `{strike: net_gex, call_gex, put_gex}`. **Zero-gamma flip**: cumulative net GEX over ascending strikes, linear-interpolate the first sign change (same idea as the existing `flip_crossing`). Report `top_positive_gex_strike` (call wall/pin) and `top_negative_gex_strike` (put support/vol trigger).
+- Aggregates: `net_gex`, `regime` (positive_gamma = dampening / negative_gamma = amplifying), `net_vanna_exposure`, `net_charm_exposure` (Σ sign·greek·OI·100) with flow-tilt interpretations.
+- Return `gex_ladder` (top ~20 strikes by |net_gex| plus all within ±10% of spot), `zero_gamma_level`, `dist_to_zero_gamma_pct`, `by_expiration` summaries.
+
+**Persistence (decision #4)** — new `gex_history` table (17th table in `quantcore/db.py` `init_schema()`): `(symbol, date_only, net_gex, zero_gamma_level, regime)` with `UNIQUE(symbol, date_only)` ON CONFLICT upsert (mirror `gamma_wall_history`). `OptionsStore.save_gex_summary()` + `get_gex_history(symbol, since_days)`; `get_gex_profile` persists its summary on each call (last-write-wins per day), so the daily chain-capture pass (Phase 4) also accumulates GEX regime history for free. The per-strike ladder is NOT persisted.
+
+**REST** — `GET /api/securities/{ticker}/options/gex-profile?max_expirations=&risk_free_rate=`.
+
+**MCP** — `get_gex_profile` in stock_price_server.py; docstring: GEX walls for support/resistance, zero-gamma as the volatility-regime boundary, vanna/charm as hedge-flow tilts.
+
+**Tests** — extend `test_options_math.py` (exact hand-computed vega/vanna/charm at S=100, K=100, T=0.25, σ=0.2, r=0.045; sign checks; d1-passthrough equivalence). New `test_gex_profile.py`: OptionsService with stub gateway (synthetic calls/puts DataFrames) → assert call+/put− signs, zero-gamma interpolation on a constructed crossing, no-expirations degradation, and that `save_gex_summary` is called with the computed summary (Mock store).
+
+---
+
+## Phase 6 — Support Confluence (composes Phases 1–5)
+
+**Service** — `RecommendationsService` (`quantcore/services/recommendations.py`) — it already composes `self._prices` + `self._options` (no registry change). Model on the supports-dict idiom in `get_stop_loss_analysis`.
+```python
+def get_support_confluence(self, symbol, tolerance_pct=1.0,
+                           max_expirations=4, max_zones=5) -> dict
+```
+Level sources — options-dependent ones each in own try/except; failures recorded in `methods_failed`:
+
+| Source | Call | Weight |
+|---|---|---|
+| Gamma wall | `_options.get_delta_adjusted_oi` | 1.0 |
+| GEX strikes + zero-gamma | `_options.get_gex_profile` | 1.0 |
+| Volume profile POC/VA/HVNs | `_prices.get_volume_profile` | 0.9 |
+| Anchored VWAPs | `_prices.get_anchored_vwap` | 0.9 |
+| Put-OI support / call-OI resistance | `_options.get_oi_change_analysis` | 0.8 |
+| Expected move (spot ± EM) | `_options.get_options_analytics` | 0.7 |
+| Rolling VWAP | `_prices.get_vwap` | 0.7 |
+| SMA 200 / 100 / 50 | `_prices.get_technicals_table` | 0.7 / 0.6 / 0.6 |
+| Prev week & month H/L | `_prices.get_history("1wk"/"1mo")`, bar −2 | 0.6 |
+| Prev day H/L | `get_history("1d", 10)`, bar −2 | 0.5 |
+| SMA20 + Bollinger | `_prices.get_stock_price` (bb_middle/lower/upper) | 0.5 |
+| ATR bands + chandelier stop | `_prices.get_atr_bands` | 0.5 |
+| Fib retracements (0.382/0.5/0.618/0.786 of last major swing) | `find_swings` on 1y daily | 0.3 |
+
+Weights follow the professional-importance guidance (dealer positioning + volume acceptance highest, fib lowest); exposed as module-level `_CONFLUENCE_WEIGHTS` dict so they're testable and tunable.
+
+**Clustering + scoring:**
+1. Collect `{level, method, weight, detail}`; drop outside spot ± 25%.
+2. Sort ascending; greedy sweep: add levels while `level ≤ weighted_center·(1 + tolerance_pct/100)`, recomputing the weight-weighted center per addition.
+3. Zone score = `Σ (max weight per distinct method) + 0.2·n_extra_levels` — independent methods dominate.
+4. Partition into support (center < price) / resistance (center > price); rank by score, top `max_zones` each.
+
+Return: `{symbol, price, tolerance_pct, methods_available, methods_failed, support_zones: [{zone_low, zone_high, center, distance_pct, score, method_count, contributors}], resistance_zones, strongest_support, interpretation}`.
+
+**REST** — `api/routers/recommendations.py`: `GET /api/securities/{ticker}/support-confluence?tolerance_pct=&max_expirations=&max_zones=`.
+
+**MCP** — `get_support_confluence` in stock_price_server.py; docstring: THE composite support/resistance tool — prefer over individual tools when the question is "where is support".
+
+**Tests** — `test_support_confluence.py` (per `test_recommendations_service.py`): Mock prices/options returning canned dicts for every source; assert clustering merge/split at tolerance, multi-method zones outscore single-method stacks, options-source exceptions land in `methods_failed` without failing the call, correct support/resistance partitioning.
+
+---
+
+## Phase 7 — Front end: Support Confluence in the Technical Analysis panel
+
+Surface the Phase-6 endpoint in the QuantUI React app (`frontend/`), on the securities detail page's **Technical Analysis tab** (Tab 1 of `frontend/src/components/securities/SecurityDetailPage.tsx` — a `Stack` of MUI `Paper` cards).
+
+**Types** — `frontend/src/api/securitiesTypes.ts` (model on `TechnicalSignalsResponse`):
+```ts
+interface SupportContributor { method: string; level: number; weight: number; detail?: string }
+interface SupportZone { zone_low: number; zone_high: number; center: number;
+                        distance_pct: number; score: number; method_count: number;
+                        contributors: SupportContributor[] }
+interface SupportConfluenceResponse { symbol: string; price: number; tolerance_pct: number;
+  methods_available: string[]; methods_failed: string[];
+  support_zones: SupportZone[]; resistance_zones: SupportZone[];
+  strongest_support: SupportZone | null; interpretation: string }
+```
+Re-export via `securities.ts` like the existing types.
+
+**API client** — `frontend/src/api/securities.ts`, add to `securitiesApi` (next to `getTechnicals`):
+`getSupportConfluence: (ticker) => apiRequest<SupportConfluenceResponse>(...)`.
+
+**Hook** — `frontend/src/hooks/useSecurities.ts`, `useSupportConfluence(ticker)` mirroring `useTechnicalSignals`: `useQuery({ queryKey: ['support-confluence', ticker], queryFn, enabled: !!ticker, staleTime: 15*60*1000 })`. The endpoint fans out to many sub-analyses server-side — long staleTime, no auto-refetch.
+
+**Component** — new `frontend/src/components/securities/SupportConfluenceCard.tsx` (dedicated component, not inline JSX). Rendered as an additional `Paper` card in the Technical Analysis tab Stack (after "Signal Summary"). Reuse the presentation patterns from `SignalsTab.tsx`: `SectionHeader`/`MetricRow`/`SignalBadge`/`SectionError` helpers, loading/error idiom (`CircularProgress` / `SectionError` with retry). Content:
+- Header row: current price + strongest-support chip (center + distance_pct, colored by proximity).
+- **Support zones table** (`Table size="small"`): zone range (low–high), distance %, score, method-count chip; a secondary line listing contributor methods. Resistance zones as a second table or a toggle.
+- Interpretation text as italic caption; `methods_failed` shown as a muted warning line when non-empty.
+
+**Tests** — co-located `SupportConfluenceCard.test.tsx` (vitest + Testing Library, per `ChatRail.test.tsx` pattern): `vi.mock` the hook/api module, wrap in `QueryClientProvider` (retry: false), assert zones render with scores/contributors, loading spinner, error state with retry, methods_failed warning.
+
+**No proxy/config changes**: the Vite dev server already proxies `/api` → `http://127.0.0.1:5001`; the deployed Express server proxies `/api/*` with the injected JWT the same way.
+
+**Deploy**: merge → `deploy.yml` auto-builds `quantcore-ui` and rolls the test `quantui` service; verify at the test URL, then promote to prod via `prod-rollout.yml` dispatch with the 7-char SHA.
+
+---
+
+## Verification (per PR and final)
+
+1. `python -m unittest discover`; check diff coverage locally (`coverage run -m unittest discover && coverage xml && diff-cover coverage.xml --fail-under=85`) — CI enforces ≥85% on changed lines, ≥37% global.
+2. `PYTHONPATH=. python scripts/check_openapi_snapshot.py --update`; commit `docs/openapi-surface.txt`.
+3. REST locally: `uvicorn api.main:app --port 5001`; curl each new endpoint on a liquid symbol (NVDA) + one degradation case (oi-change on a no-snapshot ticker must return the note payload, not 500).
+4. MCP: `python scripts/ci_wrapper_smoke.py` (covers new tools in existing servers automatically); exercise tools end-to-end against the running REST tier.
+5. `python -m unittest test_architecture_guards` — no service/DB imports leaked into MCP tool bodies.
+6. OI tool: capture `get_full_options_chain` twice across two synthetic `captured_at` days in the test DB and confirm deltas.
+7. Front end: `cd frontend && npx vitest run --coverage` + `npm run build`; eyeball the card locally, then on the test `quantui` service before prod promotion.
+8. Documentation: confirm the phase's doc pass happened — `readme.md`, `CLAUDE.md`, and `docs/**` accurately describe the new tools/endpoints/tables before the PR is opened.
+
+## Decisions (resolved 2026-07-15)
+
+1. **GEX sign convention** — hardcode the standard "dealers long calls / short puts" heuristic (calls +, puts −), stated in the payload. Matches SpotGamma/SqueezeMetrics-style naive GEX so our numbers are comparable to public tools. No configurable convention until dealer-positioning data exists to justify one.
+2. **OI snapshot cadence** — **yes**: the daily report job (`main.py`) captures full chains for portfolio + watchlist symbols (capped ~6 expirations), via in-process services per the cron rule. History can't be backfilled, so this ships in PR C so accumulation starts as early as possible. (Folded into Phase 4.)
+3. **Confluence weights** — hardcoded module-level `_CONFLUENCE_WEIGHTS`; promoting to query params later is non-breaking if usage shows the defaults are wrong.
+4. **GEX persistence** — persist a **daily summary row** per symbol — `(symbol, date, net_gex, zero_gamma_level, regime)` — in a new `gex_history` table (gamma_wall_history-style, last-write-wins per day), computed in the same daily pass as the chain capture. The per-strike ladder stays recompute-on-demand. (Folded into Phase 5.)

--- a/fastMCPTest/stock_price_server.py
+++ b/fastMCPTest/stock_price_server.py
@@ -397,6 +397,52 @@ def get_gap_analysis(symbol: str, min_gap_pct: float = 0.5, lookback: int = 60,
 
 
 @mcp.tool()
+def get_atr_bands(symbol: str, period: int = 14, band_mult: float = 2.0,
+                  stop_mult: float = 3.0, interval: str = "1d", lookback: int = 250) -> dict:
+    """Compute ATR (Average True Range) volatility bands and a chandelier trailing stop.
+
+    ATR measures how far a stock actually moves per bar, gap-inclusive (True
+    Range = max of H−L, |H−prev close|, |L−prev close|, Wilder-smoothed). It is
+    the standard way to calibrate stop distance and price targets to CURRENT
+    volatility instead of a fixed percentage.
+
+    INTENDED USE — volatility-calibrated stop placement:
+      - Prefer this over get_stop_loss_analysis's trailing % when earnings gaps
+        pollute the drawdown history: ATR re-adapts within ~`period` bars after
+        a gap, while a drawdown-calibrated % stays distorted for months.
+      - chandelier_stop (highest high of last 22 bars − stop_mult×ATR) is the
+        classic volatility trailing stop for a trim-and-hold position.
+      - upper_band / lower_band (close ± band_mult×ATR) frame the expected
+        near-term trading range; a close outside them is a volatility event.
+
+    Signals returned:
+      atr, atr_pct          — current ATR in dollars and as % of price
+      atr_trend             — 'expanding' / 'contracting' / 'stable' vs ~3-month mean
+      upper_band/lower_band — close ± band_mult×ATR
+      chandelier_stop       — 22-bar highest high − stop_mult×ATR
+      stop_distance_pct     — how far below the last close that stop sits
+      bands_history         — last ~20 bars of {date, atr, upper, lower}
+      interpretation        — plain-English summary
+
+    Args:
+        symbol:    Stock ticker symbol (e.g. 'AAPL')
+        period:    ATR smoothing period in bars (default: 14)
+        band_mult: Band width in ATR multiples (default: 2.0)
+        stop_mult: Chandelier stop offset in ATR multiples (default: 3.0)
+        interval:  '1d' daily (default), '1h' hourly, '1wk' weekly
+        lookback:  Bars of history to analyse (default: 250)
+    """
+    return rest_client.get(
+        f"/api/securities/{symbol}/atr-bands",
+        period=period,
+        band_mult=band_mult,
+        stop_mult=stop_mult,
+        interval=interval,
+        lookback=lookback,
+    )
+
+
+@mcp.tool()
 def get_unusual_calls(
     symbol: str,
     min_volume: int = 100,

--- a/fastMCPTest/stock_price_server.py
+++ b/fastMCPTest/stock_price_server.py
@@ -443,6 +443,52 @@ def get_atr_bands(symbol: str, period: int = 14, band_mult: float = 2.0,
 
 
 @mcp.tool()
+def get_anchored_vwap(symbol: str, anchor_date: str = None,
+                      lookback_days: int = 365) -> dict:
+    """Compute Anchored VWAPs — volume-weighted average price measured from significant events.
+
+    An Anchored VWAP (AVWAP) is the average cost basis of every share traded
+    since a specific anchor event. Institutions defend these levels: price
+    above an AVWAP means holders since the anchor are in profit (the level acts
+    as support on pullbacks); price below means they are trapped (the level
+    acts as resistance on rallies).
+
+    Anchors are resolved automatically from multiple event types:
+      earnings          — last 2 earnings report dates
+      52w_high/52w_low  — the 52-week price extremes
+      gap               — the 2 largest recent price gaps
+      swing_high/swing_low — most recent confirmed daily swing pivots
+      user              — pass anchor_date to add your own (e.g. a news event)
+    Anchors within 3 trading days of each other are deduplicated
+    (user > earnings > 52w extremes > gaps > swings).
+
+    INTENDED USE — institutional cost-basis support/resistance:
+      - nearest_support is the closest AVWAP below price: a natural pullback
+        entry / stop-placement reference for a trim-and-hold position.
+      - nearest_resistance is the closest AVWAP above price: where trapped
+        holders are likely to sell into a bounce.
+      - An AVWAP reclaim (price crossing back above a lost anchor VWAP) is a
+        classic institutional re-accumulation signal.
+
+    Signals returned:
+      anchors            — [{type, date, label, avwap, distance_pct, position}]
+                           sorted by proximity to the current price
+      nearest_support    — closest AVWAP below the current price
+      nearest_resistance — closest AVWAP above the current price
+      interpretation     — plain-English summary
+
+    Args:
+        symbol:        Stock ticker symbol (e.g. 'AAPL')
+        anchor_date:   Optional explicit anchor 'YYYY-MM-DD' (added to the auto anchors)
+        lookback_days: Calendar days of daily history to anchor within (default: 365, max 730)
+    """
+    params = {"lookback_days": lookback_days}
+    if anchor_date:
+        params["anchor_date"] = anchor_date
+    return rest_client.get(f"/api/securities/{symbol}/anchored-vwap", **params)
+
+
+@mcp.tool()
 def get_unusual_calls(
     symbol: str,
     min_volume: int = 100,

--- a/quantcore/analytics/indicators.py
+++ b/quantcore/analytics/indicators.py
@@ -40,3 +40,59 @@ def macd_series(closes: pd.Series):
     signal_line = macd_line.ewm(span=9, min_periods=9).mean()
     histogram = macd_line - signal_line
     return macd_line, signal_line, histogram
+
+
+def true_range_series(high: pd.Series, low: pd.Series, close: pd.Series) -> pd.Series:
+    """True Range: max(H−L, |H−prev C|, |L−prev C|); first bar has no prior close → H−L."""
+    prev_close = close.shift(1)
+    tr = pd.concat(
+        [high - low, (high - prev_close).abs(), (low - prev_close).abs()], axis=1
+    ).max(axis=1)
+    tr.iloc[0] = float(high.iloc[0] - low.iloc[0])
+    return tr
+
+
+def atr_series(high: pd.Series, low: pd.Series, close: pd.Series, period: int = 14) -> pd.Series:
+    """Wilder ATR: recursive smoothing ATR_t = ATR_{t-1} + (TR_t − ATR_{t-1})/period.
+
+    Seed convention: ewm(alpha=1/period, adjust=False) seeds from the first TR
+    value (not an SMA of the first `period` TRs), so early values converge to
+    Wilder's within a few periods.
+    """
+    tr = true_range_series(high, low, close)
+    return tr.ewm(alpha=1 / period, adjust=False).mean()
+
+
+def anchored_vwap(df: pd.DataFrame, anchor_idx: int) -> Optional[float]:
+    """Volume-weighted average of typical price (H+L+C)/3 from anchor_idx to the last bar."""
+    window = df.iloc[anchor_idx:]
+    typical = (window["High"] + window["Low"] + window["Close"]) / 3
+    total_volume = float(window["Volume"].sum())
+    if total_volume <= 0:
+        return None
+    return float((typical * window["Volume"]).sum() / total_volume)
+
+
+def find_swings(highs: pd.Series, lows: pd.Series, swing_bars: int = 3) -> dict:
+    """Confirmed swing pivots: positional indices of local extremes.
+
+    A swing low at i requires low[i] <= low[i±k] for k in 1..swing_bars (the
+    `<=` semantics match PricesService.get_higher_lows); a swing high requires
+    high[i] >= high[i±k]. The last `swing_bars` bars are skipped — they cannot
+    be confirmed until enough right-side bars complete.
+    """
+    swing_lows: list[int] = []
+    swing_highs: list[int] = []
+    scan_end = len(lows) - swing_bars
+    for i in range(swing_bars, scan_end):
+        l = float(lows.iloc[i])
+        if all(l <= float(lows.iloc[i - k]) for k in range(1, swing_bars + 1)) and all(
+            l <= float(lows.iloc[i + k]) for k in range(1, swing_bars + 1)
+        ):
+            swing_lows.append(i)
+        h = float(highs.iloc[i])
+        if all(h >= float(highs.iloc[i - k]) for k in range(1, swing_bars + 1)) and all(
+            h >= float(highs.iloc[i + k]) for k in range(1, swing_bars + 1)
+        ):
+            swing_highs.append(i)
+    return {"lows": swing_lows, "highs": swing_highs}

--- a/quantcore/services/prices.py
+++ b/quantcore/services/prices.py
@@ -12,6 +12,7 @@ screener's sentiment overlay through SentimentStore.
 
 from __future__ import annotations
 
+import bisect
 import datetime
 import math
 from collections import defaultdict
@@ -20,7 +21,14 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import numpy as np
 import pandas as pd
 
-from quantcore.analytics.indicators import atr_series, macd_series, rsi_series, safe_float
+from quantcore.analytics.indicators import (
+    anchored_vwap,
+    atr_series,
+    find_swings,
+    macd_series,
+    rsi_series,
+    safe_float,
+)
 from quantcore.analytics.market_time import latest_completed_session, period_to_days
 from quantcore.gateways.yfinance_gateway import YFinanceGateway
 from quantcore.repositories.ohlcv_repository import OhlcvRepository
@@ -1041,6 +1049,159 @@ class PricesService:
             "interpretation":    interpretation,
         }
 
+    # Dedupe priority when two anchors land within 3 trading days of each other:
+    # an explicit user anchor beats event anchors; earnings beat price extremes.
+    _ANCHOR_PRIORITY = {
+        "user": 0, "earnings": 1, "52w_high": 2, "52w_low": 2,
+        "gap": 3, "swing_high": 4, "swing_low": 4,
+    }
+
+    def get_anchored_vwap(self, symbol: str, anchor_date: str | None = None,
+                          lookback_days: int = 365, swing_bars: int = 5) -> dict:
+        sym = symbol.upper()
+        days = min(int(lookback_days), 730)  # yfinance daily-fetch cap
+        hist = self.get_history(sym, "1d", days).copy()
+
+        min_bars = swing_bars * 2 + 10
+        if len(hist) < min_bars:
+            raise ValueError(f"Not enough data for {symbol} (got {len(hist)} bars, need {min_bars})")
+
+        bar_dates = [ts.date() for ts in hist.index]
+        last_close = float(hist["Close"].iloc[-1])
+
+        def idx_for(target: datetime.date):
+            """Positional index of the first bar on/after target; None if past the last bar."""
+            i = bisect.bisect_left(bar_dates, target)
+            return i if i < len(bar_dates) else None
+
+        candidates = []  # {type, idx, label}
+
+        # user — explicit anchor; errors here are the caller's to see, not swallowed
+        if anchor_date:
+            try:
+                target = datetime.datetime.strptime(anchor_date, "%Y-%m-%d").date()
+            except ValueError:
+                raise ValueError(f"Invalid anchor_date '{anchor_date}' — expected YYYY-MM-DD")
+            if target < bar_dates[0] or target > bar_dates[-1]:
+                raise ValueError(
+                    f"anchor_date {anchor_date} is outside the available history "
+                    f"({bar_dates[0].isoformat()} to {bar_dates[-1].isoformat()})"
+                )
+            candidates.append({"type": "user", "idx": idx_for(target),
+                               "label": f"user anchor {anchor_date}"})
+
+        # earnings — last 2 past report dates (network-backed; never kills the call)
+        try:
+            ed = self._yf.earnings_dates(sym)
+            if ed is not None and not ed.empty:
+                past = sorted(
+                    {ts.date() for ts in ed.index
+                     if bar_dates[0] <= ts.date() <= bar_dates[-1]},
+                    reverse=True,
+                )[:2]
+                for d in past:
+                    idx = idx_for(d)
+                    if idx is not None:
+                        candidates.append({"type": "earnings", "idx": idx,
+                                           "label": f"earnings {d.isoformat()}"})
+        except Exception:
+            pass
+
+        # 52-week high/low — extremes over the last ~252 bars
+        start = len(hist) - min(252, len(hist))
+        hi_pos = start + int(np.argmax(hist["High"].iloc[start:].to_numpy()))
+        lo_pos = start + int(np.argmin(hist["Low"].iloc[start:].to_numpy()))
+        candidates.append({"type": "52w_high", "idx": hi_pos,
+                           "label": f"52w high {bar_dates[hi_pos].isoformat()}"})
+        candidates.append({"type": "52w_low", "idx": lo_pos,
+                           "label": f"52w low {bar_dates[lo_pos].isoformat()}"})
+
+        # gaps — 2 largest |gap %| in the recent window
+        try:
+            gaps = self.get_gap_analysis(sym)["all_gaps"]
+            for g in sorted(gaps, key=lambda g: abs(g["gap_pct"]), reverse=True)[:2]:
+                d = datetime.datetime.strptime(g["date"], "%Y-%m-%d").date()
+                idx = idx_for(d)
+                if idx is not None:
+                    candidates.append({
+                        "type": "gap", "idx": idx,
+                        "label": f"{g['direction']} {g['gap_pct']:+.1f}% on {g['date']}",
+                    })
+        except Exception:
+            pass
+
+        # swings — most recent confirmed swing high + low on the daily series
+        swings = find_swings(hist["High"], hist["Low"], swing_bars)
+        if swings["highs"]:
+            i = swings["highs"][-1]
+            candidates.append({"type": "swing_high", "idx": i,
+                               "label": f"swing high {bar_dates[i].isoformat()}"})
+        if swings["lows"]:
+            i = swings["lows"][-1]
+            candidates.append({"type": "swing_low", "idx": i,
+                               "label": f"swing low {bar_dates[i].isoformat()}"})
+
+        # Dedupe anchors within 3 trading days, keeping the higher-priority type.
+        candidates.sort(key=lambda c: self._ANCHOR_PRIORITY[c["type"]])
+        kept = []
+        for c in candidates:
+            if any(abs(c["idx"] - k["idx"]) <= 3 for k in kept):
+                continue
+            kept.append(c)
+
+        anchors = []
+        for c in kept:
+            av = anchored_vwap(hist, c["idx"])
+            if av is None:
+                continue
+            dist = (av - last_close) / last_close * 100
+            anchors.append({
+                "type":         c["type"],
+                "date":         bar_dates[c["idx"]].isoformat(),
+                "label":        c["label"],
+                "avwap":        round(av, 4),
+                "distance_pct": round(dist, 3),
+                "position":     "support" if av <= last_close else "resistance",
+            })
+        anchors.sort(key=lambda a: abs(a["distance_pct"]))
+
+        supports    = [a for a in anchors if a["position"] == "support"]
+        resistances = [a for a in anchors if a["position"] == "resistance"]
+        nearest_support    = max(supports, key=lambda a: a["avwap"]) if supports else None
+        nearest_resistance = min(resistances, key=lambda a: a["avwap"]) if resistances else None
+
+        lines = []
+        if nearest_support:
+            lines.append(
+                f"Nearest AVWAP support: {nearest_support['label']} at "
+                f"{nearest_support['avwap']:.2f} ({nearest_support['distance_pct']:+.1f}%)."
+            )
+        if nearest_resistance:
+            lines.append(
+                f"Nearest AVWAP resistance: {nearest_resistance['label']} at "
+                f"{nearest_resistance['avwap']:.2f} ({nearest_resistance['distance_pct']:+.1f}%)."
+            )
+        if not anchors:
+            lines.append("No anchors could be resolved from the available history.")
+        else:
+            lines.append(
+                "Each AVWAP is the volume-weighted average cost of all shares traded "
+                "since that anchor event — holders from the event tend to defend it as "
+                "support from above and sell into it as resistance from below."
+            )
+
+        return {
+            "symbol":             sym,
+            "price":              round(last_close, 4),
+            "lookback_days":      days,
+            "swing_bars":         swing_bars,
+            "anchor_count":       len(anchors),
+            "anchors":            anchors,
+            "nearest_support":    nearest_support,
+            "nearest_resistance": nearest_resistance,
+            "interpretation":     " ".join(lines),
+        }
+
     def get_higher_lows(self, symbol: str, swing_bars: int = 3, lookback_swings: int = 6,
                         interval: str = "1h") -> dict:
         valid_intervals = {"15m", "30m", "1h", "1d"}
@@ -1060,17 +1221,10 @@ class PricesService:
         high  = hist["High"]
 
         # --- Identify swing lows ---
-        # A swing low at index i requires: low[i] < low[i-k] and low[i] < low[i+k]
-        # for all k in 1..swing_bars.  We skip the last `swing_bars` bars since they
-        # cannot be confirmed yet (right-side bars not yet complete).
-        swing_low_indices = []
-        scan_end = len(hist) - swing_bars
-        for i in range(swing_bars, scan_end):
-            l = float(low.iloc[i])
-            left_ok  = all(l <= float(low.iloc[i - k]) for k in range(1, swing_bars + 1))
-            right_ok = all(l <= float(low.iloc[i + k]) for k in range(1, swing_bars + 1))
-            if left_ok and right_ok:
-                swing_low_indices.append(i)
+        # A swing low at index i requires: low[i] <= low[i-k] and low[i] <= low[i+k]
+        # for all k in 1..swing_bars; the last `swing_bars` bars are skipped since
+        # they cannot be confirmed yet (delegated to the shared pure helper).
+        swing_low_indices = find_swings(high, low, swing_bars)["lows"]
 
         # Keep only the most recent `lookback_swings` swing lows
         recent_indices = swing_low_indices[-lookback_swings:]

--- a/quantcore/services/prices.py
+++ b/quantcore/services/prices.py
@@ -20,7 +20,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import numpy as np
 import pandas as pd
 
-from quantcore.analytics.indicators import macd_series, rsi_series, safe_float
+from quantcore.analytics.indicators import atr_series, macd_series, rsi_series, safe_float
 from quantcore.analytics.market_time import latest_completed_session, period_to_days
 from quantcore.gateways.yfinance_gateway import YFinanceGateway
 from quantcore.repositories.ohlcv_repository import OhlcvRepository
@@ -954,6 +954,91 @@ class PricesService:
             "patterns_found": patterns_found,
             "pattern_count": len(patterns_found),
             "bounce_signal": bounce_signal,
+        }
+
+    def get_atr_bands(self, symbol: str, period: int = 14, band_mult: float = 2.0,
+                      stop_mult: float = 3.0, interval: str = "1d", lookback: int = 250) -> dict:
+        valid_intervals = {"1d", "1h", "1wk"}
+        if interval not in valid_intervals:
+            raise ValueError(f"Invalid interval '{interval}'. Choose from: {', '.join(sorted(valid_intervals))}")
+
+        fetch_period = {"1d": "2y", "1h": "60d", "1wk": "5y"}[interval]
+
+        hist = self.get_history(symbol.upper(), interval, period_to_days(fetch_period)).copy()
+
+        min_bars = period * 2 + 5
+        if len(hist) < min_bars:
+            raise ValueError(f"Not enough data for {symbol} (got {len(hist)} bars, need {min_bars})")
+
+        if len(hist) > lookback:
+            hist = hist.tail(lookback)
+
+        high  = hist["High"]
+        low   = hist["Low"]
+        close = hist["Close"]
+
+        atr = atr_series(high, low, close, period)
+
+        last_close = float(close.iloc[-1])
+        last_atr   = float(atr.iloc[-1])
+        atr_pct    = last_atr / last_close * 100
+
+        upper_band = last_close + band_mult * last_atr
+        lower_band = last_close - band_mult * last_atr
+
+        # ATR regime: current reading vs its ~3-month mean (63 daily bars)
+        trend_window = min(63, len(atr))
+        atr_mean = float(atr.tail(trend_window).mean())
+        if last_atr > atr_mean * 1.1:
+            atr_trend = "expanding"
+        elif last_atr < atr_mean * 0.9:
+            atr_trend = "contracting"
+        else:
+            atr_trend = "stable"
+
+        # Chandelier exit: trailing stop hung from the highest high of the
+        # last 22 bars, offset by stop_mult ATRs.
+        chan_window   = min(22, len(hist))
+        highest_high  = float(high.tail(chan_window).max())
+        chandelier_stop   = highest_high - stop_mult * last_atr
+        stop_distance_pct = (last_close - chandelier_stop) / last_close * 100
+
+        fmt = "%Y-%m-%d %H:%M" if interval == "1h" else "%Y-%m-%d"
+        bands_history = []
+        tail = min(20, len(hist))
+        for ts, c, a in zip(hist.index[-tail:], close.iloc[-tail:], atr.iloc[-tail:]):
+            c_f, a_f = float(c), float(a)
+            bands_history.append({
+                "date":  ts.strftime(fmt),
+                "atr":   round(a_f, 4),
+                "upper": round(c_f + band_mult * a_f, 4),
+                "lower": round(c_f - band_mult * a_f, 4),
+            })
+
+        interpretation = (
+            f"ATR({period}) = {last_atr:.2f} ({atr_pct:.1f}% of price), {atr_trend} vs its "
+            f"{trend_window}-bar mean. Chandelier stop ({chan_window}-bar high − {stop_mult}×ATR) "
+            f"sits at {chandelier_stop:.2f}, {stop_distance_pct:.1f}% below the last close. "
+            f"Unlike a drawdown-calibrated trailing %, ATR re-adapts within ~{period} bars after "
+            f"an earnings gap, so the stop reflects current volatility rather than stale gap history."
+        )
+
+        return {
+            "symbol":            symbol.upper(),
+            "interval":          interval,
+            "period":            period,
+            "band_mult":         band_mult,
+            "stop_mult":         stop_mult,
+            "last_close":        round(last_close, 4),
+            "atr":               round(last_atr, 4),
+            "atr_pct":           round(atr_pct, 3),
+            "atr_trend":         atr_trend,
+            "upper_band":        round(upper_band, 4),
+            "lower_band":        round(lower_band, 4),
+            "chandelier_stop":   round(chandelier_stop, 4),
+            "stop_distance_pct": round(stop_distance_pct, 3),
+            "bands_history":     bands_history,
+            "interpretation":    interpretation,
         }
 
     def get_higher_lows(self, symbol: str, swing_bars: int = 3, lookback_swings: int = 6,

--- a/readme.md
+++ b/readme.md
@@ -515,11 +515,11 @@ For full implementation details, see [docs/FUNDAMENTALS_CACHE_IMPLEMENTATION.md]
 
 Three MCP tools expose historical views of key technical metrics to support multi-week position monitoring. They differ in how their history is sourced:
 
-| Tool | Source | Backfill |
-|------|--------|----------|
-| `get_vwap_history(symbol, since_days=90)` | Computed from OHLCV data in the unified QuantCore database | Up to 2 years |
+| Tool                                                   | Source | Backfill |
+|--------------------------------------------------------|--------|----------|
+| `get_vwap_history(symbol, since_days=90)`              | Computed from OHLCV data in the unified QuantCore database | Up to 2 years |
 | `get_relative_strength_history(symbol, since_days=90)` | Computed from OHLCV data in the unified QuantCore database | Up to 2 years |
-| `get_gamma_wall_history(symbol, since_days=90)` | Stored snapshots in the unified QuantCore database | Forward-only from first call |
+| `get_gamma_wall_history(symbol, since_days=90)`        | Stored snapshots in the unified QuantCore database | Forward-only from first call |
 
 #### VWAP History
 
@@ -545,6 +545,13 @@ The strike with the highest `|delta × OI|` concentration, **auto-persisted on e
 Gamma wall is an **intraday and weekly tool** used by professional services (SpotGamma, Tier1Alpha) to identify price pinning zones and MM hedging flows around expirations. It is **not** designed for multi-week equity decisions. Primary use of historical data: post-hoc analysis ("did price pin at the gamma wall on OpEx Fridays?").
 
 Our implementation uses `max(|delta × OI|)` as a GEX proxy — directional intuition, not institutional-grade precision.
+
+### Support-Level Analysis Tools
+
+Tools for locating durable support/resistance levels and volatility-calibrated stops (built per issue [#93](https://github.com/JohnFunkCode/StockPortfolioManager/issues/93); each is also a REST endpoint under `/api/securities/<ticker>/…`):
+
+- `get_atr_bands(symbol, period=14, band_mult=2.0, stop_mult=3.0, interval="1d", lookback=250)` — Wilder ATR volatility bands (close ± mult·ATR) plus a **chandelier trailing stop** (22-bar highest high − mult·ATR) with distance-to-stop and an expanding/contracting ATR trend read. Prefer this over `get_stop_loss_analysis`'s drawdown-based trailing % when earnings gaps pollute the drawdown history — ATR re-adapts within ~one period after a gap. REST: `GET /api/securities/<ticker>/atr-bands`.
+- `get_anchored_vwap(symbol, anchor_date=None, lookback_days=365)` — volume-weighted average price anchored at significant events, approximating the **cost basis of participants since that event**. Anchors resolve automatically — recent earnings dates, the 52-week high/low, the largest unfilled gaps, and the most recent confirmed swing high/low — deduped within 3 trading days (a user-supplied `anchor_date` outranks all). Each anchor reports its AVWAP, distance from spot, and whether it acts as support or resistance, plus the nearest AVWAP support/resistance overall. An AVWAP reclaim is an institutional re-accumulation signal. REST: `GET /api/securities/<ticker>/anchored-vwap`.
 
 ### Trade Recommendations (`get_trade_recommendation`)
 

--- a/test_anchored_vwap.py
+++ b/test_anchored_vwap.py
@@ -1,0 +1,206 @@
+"""Tests for anchored-VWAP analytics (anchored_vwap / find_swings),
+PricesService.get_anchored_vwap anchor resolution, and the get_higher_lows
+regression after its swing-scan was extracted into find_swings (issue #93,
+Phase 2). No network, no DB — mocked collaborators throughout.
+"""
+import unittest
+from unittest.mock import Mock
+
+import numpy as np
+import pandas as pd
+
+from quantcore.analytics.indicators import anchored_vwap, find_swings
+from quantcore.services.prices import PricesService
+
+
+def make_service():
+    return PricesService(
+        ohlcv_repository=Mock(),
+        yfinance_gateway=Mock(),
+        options_repository=Mock(),
+        sentiment_repository=Mock(),
+    )
+
+
+def make_ohlcv(bars, start="2025-01-02"):
+    """bars = list of (high, low, close, volume) tuples on business days."""
+    idx = pd.bdate_range(start, periods=len(bars))
+    return pd.DataFrame(
+        {
+            "Open":   [c for _, _, c, _ in bars],
+            "High":   [h for h, _, _, _ in bars],
+            "Low":    [l for _, l, _, _ in bars],
+            "Close":  [c for _, _, c, _ in bars],
+            "Volume": [v for _, _, _, v in bars],
+        },
+        index=idx,
+    )
+
+
+class TestAnchoredVwapMath(unittest.TestCase):
+    def setUp(self):
+        # Typical prices: 11, 12, 13 with volumes 100, 200, 300.
+        self.df = make_ohlcv([(12, 10, 11, 100), (13, 11, 12, 200), (14, 12, 13, 300)])
+
+    def test_cumulative_from_first_bar(self):
+        # (11*100 + 12*200 + 13*300) / 600 = 7400/600
+        self.assertAlmostEqual(anchored_vwap(self.df, 0), 7400 / 600, places=10)
+
+    def test_cumulative_from_middle_bar(self):
+        # (12*200 + 13*300) / 500 = 12.6
+        self.assertAlmostEqual(anchored_vwap(self.df, 1), 12.6, places=10)
+
+    def test_zero_volume_returns_none(self):
+        df = make_ohlcv([(12, 10, 11, 0), (13, 11, 12, 0)])
+        self.assertIsNone(anchored_vwap(df, 0))
+
+
+class TestFindSwings(unittest.TestCase):
+    def test_exact_pivot_indices(self):
+        lows  = pd.Series([5.0, 4, 3, 2, 3, 4, 5, 6, 7])
+        highs = pd.Series([5.0, 6, 7, 8, 7, 6, 5, 4, 3])
+        swings = find_swings(highs, lows, swing_bars=2)
+        self.assertEqual(swings["lows"], [3])
+        self.assertEqual(swings["highs"], [3])
+
+    def test_last_bars_never_confirmed(self):
+        # Minimum at the very end must not be reported — right side incomplete.
+        lows  = pd.Series([5.0, 5, 5, 5, 5, 5, 1])
+        highs = pd.Series([5.0] * 7)
+        swings = find_swings(highs, lows, swing_bars=2)
+        self.assertNotIn(6, swings["lows"])
+
+    def test_tie_semantics_match_get_higher_lows(self):
+        # Flat series: `<=` / `>=` semantics accept ties, so every interior
+        # scanned bar is both a swing low and a swing high.
+        flat = pd.Series([5.0] * 8)
+        swings = find_swings(flat, flat, swing_bars=2)
+        self.assertEqual(swings["lows"], [2, 3, 4, 5])
+        self.assertEqual(swings["highs"], [2, 3, 4, 5])
+
+
+class TestGetAnchoredVwap(unittest.TestCase):
+    """300 flat bars (H=101, L=99, C=100) with a 52w low trough at bar 200, a
+    52w high spike at bar 250 (its AVWAP window is clean of the trough; the
+    trough's window contains the spike but the deeper trough TP dominates),
+    and a stubbed earnings date at bar 280."""
+
+    def setUp(self):
+        bars = [(101.0, 99.0, 100.0, 1_000)] * 300
+        bars[200] = (101.0, 60.0, 100.0, 1_000)   # 52w low + swing low
+        bars[250] = (120.0, 99.0, 100.0, 1_000)   # 52w high + swing high
+        self.hist = make_ohlcv(bars)
+        self.service = make_service()
+        self.service.get_history = Mock(return_value=self.hist)
+        self.service._yf.earnings_dates.return_value = pd.DataFrame(
+            {"EPS Estimate": [1.0]}, index=pd.DatetimeIndex([self.hist.index[280]])
+        )
+
+    def test_anchor_resolution_and_dedupe(self):
+        result = self.service.get_anchored_vwap("intc")
+
+        self.assertEqual(result["symbol"], "INTC")
+        types = {a["type"] for a in result["anchors"]}
+        self.assertEqual(types, {"earnings", "52w_high", "52w_low", "swing_high"})
+        # swing_low resolves to the same flat-region bar as swing_high and is
+        # deduped away by priority (swing ties resolve in collection order).
+        self.assertEqual(result["anchor_count"], 4)
+
+    def test_avwap_values_and_nearest_levels(self):
+        result = self.service.get_anchored_vwap("INTC")
+        by_type = {a["type"]: a for a in result["anchors"]}
+
+        # From bar 250: spike TP 319/3 once, then 49 flat bars of TP 100.
+        expected_high_anchor = (319 / 3 + 49 * 100) / 50
+        self.assertAlmostEqual(by_type["52w_high"]["avwap"], round(expected_high_anchor, 4), places=4)
+        self.assertEqual(by_type["52w_high"]["position"], "resistance")
+
+        # From bar 200: trough TP 261/3, spike TP 319/3, and 98 flat bars of
+        # TP 100 — the trough's 13-point TP deficit outweighs the spike's
+        # 6.33-point excess, keeping this anchor below price.
+        expected_low_anchor = (261 / 3 + 319 / 3 + 98 * 100) / 100
+        self.assertAlmostEqual(by_type["52w_low"]["avwap"], round(expected_low_anchor, 4), places=4)
+        self.assertEqual(by_type["52w_low"]["position"], "support")
+
+        self.assertEqual(result["nearest_resistance"]["type"], "52w_high")
+        # Earnings anchor sits in the flat region → AVWAP 100.0 == price → support.
+        self.assertEqual(result["nearest_support"]["avwap"], 100.0)
+
+    def test_user_anchor_outranks_earnings_in_dedupe(self):
+        anchor = self.hist.index[281].strftime("%Y-%m-%d")
+        result = self.service.get_anchored_vwap("INTC", anchor_date=anchor)
+        types = {a["type"] for a in result["anchors"]}
+        self.assertIn("user", types)
+        self.assertNotIn("earnings", types)  # within 3 trading days of the user anchor
+
+    def test_earnings_failure_degrades_gracefully(self):
+        self.service._yf.earnings_dates.side_effect = RuntimeError("yahoo down")
+        result = self.service.get_anchored_vwap("INTC")
+        types = {a["type"] for a in result["anchors"]}
+        self.assertNotIn("earnings", types)
+        self.assertGreater(result["anchor_count"], 0)
+
+    def test_invalid_anchor_date_raises(self):
+        with self.assertRaises(ValueError):
+            self.service.get_anchored_vwap("INTC", anchor_date="07/15/2026")
+
+    def test_out_of_range_anchor_date_raises(self):
+        with self.assertRaises(ValueError):
+            self.service.get_anchored_vwap("INTC", anchor_date="2020-01-01")
+
+
+def original_swing_low_scan(low: pd.Series, swing_bars: int) -> list:
+    """Verbatim copy of the pre-refactor scan from get_higher_lows — the
+    regression oracle for the find_swings extraction."""
+    swing_low_indices = []
+    scan_end = len(low) - swing_bars
+    for i in range(swing_bars, scan_end):
+        l = float(low.iloc[i])
+        left_ok  = all(l <= float(low.iloc[i - k]) for k in range(1, swing_bars + 1))
+        right_ok = all(l <= float(low.iloc[i + k]) for k in range(1, swing_bars + 1))
+        if left_ok and right_ok:
+            swing_low_indices.append(i)
+    return swing_low_indices
+
+
+class TestGetHigherLowsRegression(unittest.TestCase):
+    def test_swing_scan_matches_original_on_random_series(self):
+        rng = np.random.default_rng(42)
+        lows = pd.Series(100 + rng.normal(0, 2, 500).cumsum())
+        highs = lows + rng.uniform(0.5, 3.0, 500)
+        for swing_bars in (2, 3, 5):
+            self.assertEqual(
+                find_swings(highs, lows, swing_bars)["lows"],
+                original_swing_low_scan(lows, swing_bars),
+                f"swing_bars={swing_bars}",
+            )
+
+    def test_get_higher_lows_output_on_fixed_series(self):
+        # Rising dips at bars 10/20/30/40 (lows 90→91→92→93) on a gently
+        # increasing base (no ties): exactly 4 swing lows, 3 consecutive
+        # higher, min rise (93−92)/92 ≈ 1.087% → strong; the base slopes down
+        # 5.2% into the first dip → downtrend.
+        bars = []
+        for i in range(60):
+            base_low = 95 + i * 0.01
+            if i in (10, 20, 30, 40):
+                dip = {10: 90.0, 20: 91.0, 30: 92.0, 40: 93.0}[i]
+                bars.append((dip + 5, dip, dip + 2, 1_000))
+            else:
+                bars.append((base_low + 5, base_low, base_low + 2, 1_000))
+        service = make_service()
+        service.get_history = Mock(return_value=make_ohlcv(bars))
+
+        result = service.get_higher_lows("INTC", swing_bars=3, lookback_swings=6, interval="1d")
+
+        self.assertEqual(result["swing_lows_found"], 4)
+        self.assertTrue(result["higher_low_pattern"])
+        self.assertEqual(result["consecutive_higher_lows"], 3)
+        self.assertEqual(result["pattern_strength"], "strong")
+        self.assertEqual(result["trend_before_lows"], "downtrend")
+        self.assertEqual([s["low"] for s in result["swing_lows"]], [90.0, 91.0, 92.0, 93.0])
+        self.assertAlmostEqual(result["min_rise_between_lows_pct"], round(1 / 92 * 100, 3), places=3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_atr_bands.py
+++ b/test_atr_bands.py
@@ -1,0 +1,139 @@
+"""Tests for ATR analytics (true_range_series / atr_series) and
+PricesService.get_atr_bands (issue #93, Phase 1).
+
+Analytics tests are exact-value on hand-computed series; the service test uses
+the mocked-collaborator pattern from test_prices_history_policy.py — no
+network, no DB.
+"""
+import unittest
+from unittest.mock import Mock
+
+import pandas as pd
+
+from quantcore.analytics.indicators import atr_series, true_range_series
+from quantcore.services.prices import PricesService
+
+
+def make_service():
+    return PricesService(
+        ohlcv_repository=Mock(),
+        yfinance_gateway=Mock(),
+        options_repository=Mock(),
+        sentiment_repository=Mock(),
+    )
+
+
+def make_ohlcv(bars):
+    """bars = list of (high, low, close) tuples → OHLCV DataFrame on business days."""
+    idx = pd.bdate_range("2026-01-02", periods=len(bars))
+    return pd.DataFrame(
+        {
+            "Open":   [c for _, _, c in bars],
+            "High":   [h for h, _, _ in bars],
+            "Low":    [l for _, l, _ in bars],
+            "Close":  [c for _, _, c in bars],
+            "Volume": [1_000] * len(bars),
+        },
+        index=idx,
+    )
+
+
+# Hand-computed case, period=3 (alpha=1/3):
+#   TR = [2, 2, 2, 5, 2]  (bar 3 gaps: |H−prev C| = |18−13| = 5)
+#   ATR (seed = first TR, then ATR_t = (1−α)·ATR_{t−1} + α·TR_t):
+#   [2, 2, 2, 3, 8/3]
+HAND_BARS = [
+    (12, 10, 11),
+    (13, 11, 12),
+    (14, 12, 13),
+    (18, 15, 16),
+    (17, 15, 16),
+]
+
+
+class TestTrueRangeAndATR(unittest.TestCase):
+    def setUp(self):
+        self.df = make_ohlcv(HAND_BARS)
+
+    def test_true_range_exact(self):
+        tr = true_range_series(self.df["High"], self.df["Low"], self.df["Close"])
+        expected = [2.0, 2.0, 2.0, 5.0, 2.0]
+        for i, exp in enumerate(expected):
+            self.assertAlmostEqual(float(tr.iloc[i]), exp, places=10)
+
+    def test_true_range_first_bar_is_high_minus_low(self):
+        tr = true_range_series(self.df["High"], self.df["Low"], self.df["Close"])
+        self.assertAlmostEqual(float(tr.iloc[0]), 12 - 10, places=10)
+
+    def test_wilder_atr_exact(self):
+        atr = atr_series(self.df["High"], self.df["Low"], self.df["Close"], period=3)
+        expected = [2.0, 2.0, 2.0, 3.0, 8.0 / 3.0]
+        for i, exp in enumerate(expected):
+            self.assertAlmostEqual(float(atr.iloc[i]), exp, places=10)
+
+    def test_gap_dominates_true_range(self):
+        # Bar 3's intrabar range is only 3, but the gap from prior close makes TR 5.
+        tr = true_range_series(self.df["High"], self.df["Low"], self.df["Close"])
+        self.assertAlmostEqual(float(tr.iloc[3]), 5.0, places=10)
+
+
+class TestGetATRBands(unittest.TestCase):
+    def setUp(self):
+        self.service = make_service()
+        # 60 quiet bars around 100: H=101, L=99, C=100 → TR converges to 2.
+        self.quiet = make_ohlcv([(101, 99, 100)] * 60)
+
+    def test_invalid_interval_raises(self):
+        with self.assertRaises(ValueError):
+            self.service.get_atr_bands("INTC", interval="13m")
+
+    def test_not_enough_data_raises(self):
+        self.service.get_history = Mock(return_value=make_ohlcv([(101, 99, 100)] * 10))
+        with self.assertRaises(ValueError):
+            self.service.get_atr_bands("INTC")
+
+    def test_band_and_stop_arithmetic(self):
+        self.service.get_history = Mock(return_value=self.quiet)
+        result = self.service.get_atr_bands("intc", period=14, band_mult=2.0, stop_mult=3.0)
+
+        self.assertEqual(result["symbol"], "INTC")
+        atr = result["atr"]
+        self.assertAlmostEqual(atr, 2.0, places=6)
+        self.assertAlmostEqual(result["last_close"], 100.0, places=6)
+        self.assertAlmostEqual(result["upper_band"], 100 + 2.0 * atr, places=4)
+        self.assertAlmostEqual(result["lower_band"], 100 - 2.0 * atr, places=4)
+        # Chandelier: highest high of last 22 bars (101) − 3×ATR.
+        self.assertAlmostEqual(result["chandelier_stop"], 101 - 3.0 * atr, places=4)
+        self.assertAlmostEqual(
+            result["stop_distance_pct"],
+            (100 - result["chandelier_stop"]) / 100 * 100,
+            places=3,
+        )
+        self.assertEqual(result["atr_trend"], "stable")
+        self.assertEqual(len(result["bands_history"]), 20)
+        self.assertIn("date", result["bands_history"][0])
+
+    def test_stop_stays_bounded_after_gap(self):
+        # 40 quiet bars at 100, a −15% gap-down bar, then 19 quiet bars at 85.
+        bars = [(101, 99, 100)] * 40
+        bars.append((86, 84, 85))          # gaps down from 100 → TR = |84−100| = 16
+        bars += [(86, 84, 85)] * 19
+        self.service.get_history = Mock(return_value=make_ohlcv(bars))
+
+        result = self.service.get_atr_bands("INTC", period=14)
+
+        # 19 quiet bars after the gap: Wilder ATR has decayed most of the gap
+        # spike back toward the intrabar range, so the stop is not blown out.
+        self.assertLess(result["atr"], 6.0)
+        self.assertGreater(result["atr"], 2.0)
+        self.assertGreater(result["chandelier_stop"], 0)
+        self.assertLess(result["stop_distance_pct"], 30)
+
+    def test_lookback_trims_history(self):
+        self.service.get_history = Mock(return_value=self.quiet)
+        result = self.service.get_atr_bands("INTC", lookback=40)
+        self.assertAlmostEqual(result["atr"], 2.0, places=4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_support_tools_adapters.py
+++ b/test_support_tools_adapters.py
@@ -1,0 +1,116 @@
+"""Adapter-layer tests for the support-level tools (issue #93, Phases 1–2):
+the FastAPI routes and MCP wrapper tools for ATR bands and Anchored VWAP.
+
+Both adapters must stay exactly one call deep (architectural standard v2), so
+these tests assert pure pass-through: the route forwards its params to the
+service and ships the dict verbatim (or the plain ``{"error": str}`` 500), and
+the MCP wrapper translates a tool call into a single ``rest_client.get``.
+No network, no DB — the service registry and REST client are patched.
+"""
+import unittest
+from unittest.mock import Mock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.routers import prices as prices_router
+from fastMCPTest import stock_price_server
+
+
+def make_client():
+    app = FastAPI()
+    app.include_router(prices_router.router)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class TestSupportToolRoutes(unittest.TestCase):
+    def setUp(self):
+        self.services = Mock()
+        patcher = patch.object(prices_router, "services", return_value=self.services)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self.client = make_client()
+
+    def test_atr_bands_passes_params_and_ships_dict_verbatim(self):
+        payload = {"symbol": "NVDA", "atr": 4.2, "chandelier_stop": 118.6}
+        self.services.prices.get_atr_bands.return_value = payload
+
+        resp = self.client.get(
+            "/api/securities/NVDA/atr-bands",
+            params={"period": 21, "band_mult": 1.5, "stop_mult": 2.5,
+                    "interval": "1h", "lookback": 100},
+        )
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), payload)
+        self.services.prices.get_atr_bands.assert_called_once_with(
+            "NVDA", 21, 1.5, 2.5, "1h", 100
+        )
+
+    def test_atr_bands_error_becomes_plain_500(self):
+        self.services.prices.get_atr_bands.side_effect = ValueError("bad interval")
+        resp = self.client.get("/api/securities/NVDA/atr-bands")
+        self.assertEqual(resp.status_code, 500)
+        self.assertEqual(resp.json(), {"error": "bad interval"})
+
+    def test_anchored_vwap_passes_params_and_ships_dict_verbatim(self):
+        payload = {"symbol": "NVDA", "anchors": [], "nearest_support": None}
+        self.services.prices.get_anchored_vwap.return_value = payload
+
+        resp = self.client.get(
+            "/api/securities/NVDA/anchored-vwap",
+            params={"anchor_date": "2026-05-01", "lookback_days": 200, "swing_bars": 3},
+        )
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), payload)
+        self.services.prices.get_anchored_vwap.assert_called_once_with(
+            "NVDA", "2026-05-01", 200, 3
+        )
+
+    def test_anchored_vwap_defaults_and_error_path(self):
+        self.services.prices.get_anchored_vwap.side_effect = ValueError("out of range")
+        resp = self.client.get("/api/securities/NVDA/anchored-vwap")
+        self.assertEqual(resp.status_code, 500)
+        self.assertEqual(resp.json(), {"error": "out of range"})
+        self.services.prices.get_anchored_vwap.assert_called_once_with(
+            "NVDA", None, 365, 5
+        )
+
+
+class TestSupportToolMcpWrappers(unittest.TestCase):
+    def setUp(self):
+        self.rest_get = Mock(return_value={"ok": True})
+        patcher = patch.object(stock_price_server.rest_client, "get", self.rest_get)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_get_atr_bands_is_one_rest_call(self):
+        result = stock_price_server.get_atr_bands(
+            "NVDA", period=21, band_mult=1.5, stop_mult=2.5, interval="1wk", lookback=100
+        )
+        self.assertEqual(result, {"ok": True})
+        self.rest_get.assert_called_once_with(
+            "/api/securities/NVDA/atr-bands",
+            period=21, band_mult=1.5, stop_mult=2.5, interval="1wk", lookback=100,
+        )
+
+    def test_get_anchored_vwap_omits_absent_anchor_date(self):
+        result = stock_price_server.get_anchored_vwap("NVDA")
+        self.assertEqual(result, {"ok": True})
+        self.rest_get.assert_called_once_with(
+            "/api/securities/NVDA/anchored-vwap", lookback_days=365
+        )
+
+    def test_get_anchored_vwap_forwards_anchor_date(self):
+        stock_price_server.get_anchored_vwap(
+            "NVDA", anchor_date="2026-05-01", lookback_days=200
+        )
+        self.rest_get.assert_called_once_with(
+            "/api/securities/NVDA/anchored-vwap",
+            lookback_days=200, anchor_date="2026-05-01",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

First PR of the support-level analysis tools plan ([#93](https://github.com/JohnFunkCode/StockPortfolioManager/issues/93), [proposal](docs/proposals/support-confluence-tools-plan.md) — included in this PR). Two new tools, each on all three surfaces per [architectural-standard-v2](docs/proposals/architectural-standard-v2.md) (pure analytics → service → thin REST route → one-call-deep MCP wrapper):

### Phase 1 — ATR bands + chandelier trailing stop
- **Analytics:** `true_range_series` / `atr_series` (Wilder smoothing, seed convention documented) in `quantcore/analytics/indicators.py`
- **Service:** `PricesService.get_atr_bands` — volatility bands (close ± mult·ATR), expanding/contracting ATR trend, chandelier stop (22-bar highest high − mult·ATR) with distance-to-stop, 20-bar bands history
- **REST:** `GET /api/securities/{ticker}/atr-bands`
- **MCP:** `get_atr_bands` — docstring steers toward it over `get_stop_loss_analysis`'s trailing % when earnings gaps pollute drawdown history

### Phase 2 — Anchored VWAP with auto-anchor resolution
- **Analytics:** `anchored_vwap`, `find_swings` in `indicators.py`; `get_higher_lows` refactored to delegate its swing scan to `find_swings` (identical `<=` tie semantics), guarded by a verbatim-oracle regression test
- **Service:** `PricesService.get_anchored_vwap` — anchors from user date, earnings, 52w high/low, largest gaps, confirmed swings; deduped within 3 trading days by priority (user > earnings > 52w > gap > swing); per-anchor AVWAP + support/resistance position + nearest levels; each anchor source degrades independently
- **REST:** `GET /api/securities/{ticker}/anchored-vwap` (declared above `/vwap` so the literal sub-path is never shadowed)
- **MCP:** `get_anchored_vwap`

### Docs & close-out
- `docs/openapi-surface.txt` regenerated (+2 routes, 85 total); `docs/capabilities-matrix.md` rows + counts; readme "Support-Level Analysis Tools" section; CLAUDE.md analytics note
- ⚠️ **Note for reviewer:** readme.md had a pre-existing uncommitted table reformat that mangled `get_vwap_history` into `ghwap_history`; this PR keeps the reformat and repairs the name — please eyeball that hunk

## Tests

- `test_atr_bands.py` (9) — exact hand-computed Wilder ATR, gap-robustness, band/stop arithmetic
- `test_anchored_vwap.py` (14) — exact AVWAP math, `find_swings` pivot/tie/confirmation semantics, anchor resolution + dedupe + graceful earnings degradation, `get_higher_lows` regression oracle
- `test_support_tools_adapters.py` (7) — route pass-through (params, verbatim dict, plain `{"error"}` 500) and MCP wrappers exactly one `rest_client.get` deep

Verified: full suite **261 green** (test DB), architecture guards green, diff coverage **93%** (gate ≥85%), global floor clears, wrapper smoke **5/5** (stock-price lists 25 tools), OpenAPI snapshot committed.

Next: PR B (volume profile), PR C (OI-change + GEX), PR D (confluence composite), PR E (QuantUI card).

🤖 Generated with [Claude Code](https://claude.com/claude-code)