### PR TITLE
Fix: restore coverage waves 1–3 (lost in stacked merges) + db_safety preambles for #94 tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,14 +80,15 @@ jobs:
       - name: Unit tests (under coverage)
         run: coverage run -m unittest discover -v
       # COVERAGE RATCHET: the floor below is pinned ~1pt under the measured
-      # baseline (38.7% on 2026-07-14, scope in .coveragerc). It only ever
+      # baseline (66.5% on 2026-07-16, waves 1-3 restored; scope in
+      # .coveragerc). It only ever
       # moves UP — when a PR meaningfully raises coverage, bump it in the same
       # PR. The behavioral gate is diff-cover: changed lines need >= 85%.
       - name: Coverage report + floor
         run: |
           coverage report
           coverage report --format=markdown >> "$GITHUB_STEP_SUMMARY"
-          coverage report --fail-under=37
+          coverage report --fail-under=65
       - name: Diff coverage (changed lines >= 85%, PRs only)
         if: github.event_name == 'pull_request'
         run: |

--- a/test_anchored_vwap.py
+++ b/test_anchored_vwap.py
@@ -3,14 +3,28 @@ PricesService.get_anchored_vwap anchor resolution, and the get_higher_lows
 regression after its swing-scan was extracted into find_swings (issue #93,
 Phase 2). No network, no DB — mocked collaborators throughout.
 """
-import unittest
-from unittest.mock import Mock
+import os
+from pathlib import Path
 
-import numpy as np
-import pandas as pd
+# Swap in the test DSN BEFORE quantcore.db is imported transitively (DB_DSN
+# freezes at import time). This module sorts ahead of the DB-backed suites in
+# unittest discovery, so freezing the prod DSN here would trip db_safety's
+# guard in every one of them (local runs only — CI has no .env).
+_env_file = Path(__file__).parent / ".env"
+if _env_file.exists():
+    for _line in _env_file.read_text().splitlines():
+        if _line.strip().startswith("QUANTCORE_TEST_DB_DSN="):
+            os.environ["QUANTCORE_DB_DSN"] = _line.split("=", 1)[1].strip()
+            break
 
-from quantcore.analytics.indicators import anchored_vwap, find_swings
-from quantcore.services.prices import PricesService
+import unittest  # noqa: E402
+from unittest.mock import Mock  # noqa: E402
+
+import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
+
+from quantcore.analytics.indicators import anchored_vwap, find_swings  # noqa: E402
+from quantcore.services.prices import PricesService  # noqa: E402
 
 
 def make_service():

--- a/test_atr_bands.py
+++ b/test_atr_bands.py
@@ -5,13 +5,27 @@ Analytics tests are exact-value on hand-computed series; the service test uses
 the mocked-collaborator pattern from test_prices_history_policy.py — no
 network, no DB.
 """
-import unittest
-from unittest.mock import Mock
+import os
+from pathlib import Path
 
-import pandas as pd
+# Swap in the test DSN BEFORE quantcore.db is imported transitively (DB_DSN
+# freezes at import time). This module sorts ahead of the DB-backed suites in
+# unittest discovery, so freezing the prod DSN here would trip db_safety's
+# guard in every one of them (local runs only — CI has no .env).
+_env_file = Path(__file__).parent / ".env"
+if _env_file.exists():
+    for _line in _env_file.read_text().splitlines():
+        if _line.strip().startswith("QUANTCORE_TEST_DB_DSN="):
+            os.environ["QUANTCORE_DB_DSN"] = _line.split("=", 1)[1].strip()
+            break
 
-from quantcore.analytics.indicators import atr_series, true_range_series
-from quantcore.services.prices import PricesService
+import unittest  # noqa: E402
+from unittest.mock import Mock  # noqa: E402
+
+import pandas as pd  # noqa: E402
+
+from quantcore.analytics.indicators import atr_series, true_range_series  # noqa: E402
+from quantcore.services.prices import PricesService  # noqa: E402
 
 
 def make_service():

--- a/test_fundamentals_service.py
+++ b/test_fundamentals_service.py
@@ -1,0 +1,493 @@
+"""Unit tests for FundamentalsService's pure scoring helpers and the
+cache-orchestration surface.
+
+Coverage uplift (July 2026). The `_compute_*` bodies that parse raw yfinance
+financial statements are exercised only through their pure extracted helpers
+here (statement-shaped fixtures for those internals are a follow-up); the
+cache wrappers, batch scorer, profile composer, and rankings are covered
+fully with a mocked repository.
+"""
+import math
+import unittest
+from unittest.mock import Mock, patch
+
+import pandas as pd
+
+from quantcore.services.fundamentals import (
+    FundamentalsService,
+    _compute_earnings_acceleration,
+    _fcf_margin_3y,
+    _get_annual_cfo_and_capex,
+    _get_annual_revenue_and_operating_income,
+    _get_quarterly_revenue,
+    _mom_12_1,
+    _op_margin_3y_and_trend,
+    _rev_accel,
+    _rev_cagr_3y,
+    _score_metric,
+    _valuation_metric,
+)
+
+
+def series(values):
+    return pd.Series([float(v) for v in values],
+                     index=pd.period_range("2022", periods=len(values), freq="Y"))
+
+
+class TestStatementExtractors(unittest.TestCase):
+    def test_revenue_and_operating_income(self):
+        fin = pd.DataFrame(
+            [[100.0, 120.0], [10.0, 18.0]],
+            index=["Total Revenue", "Operating Income"],
+            columns=pd.to_datetime(["2024-12-31", "2025-12-31"]),
+        )
+        rev, op = _get_annual_revenue_and_operating_income(fin)
+        self.assertEqual(list(rev.values), [100.0, 120.0])
+        self.assertEqual(list(op.values), [10.0, 18.0])
+
+    def test_missing_revenue_row_returns_nones(self):
+        fin = pd.DataFrame([[1.0]], index=["Something Else"],
+                           columns=pd.to_datetime(["2025-12-31"]))
+        self.assertEqual(_get_annual_revenue_and_operating_income(fin), (None, None))
+        self.assertEqual(_get_annual_revenue_and_operating_income(None), (None, None))
+
+    def test_cfo_capex_label_variants(self):
+        cf = pd.DataFrame(
+            [[30.0], [10.0]],
+            index=["Operating Cash Flow", "Capital Expenditure"],
+            columns=pd.to_datetime(["2025-12-31"]),
+        )
+        cfo, capex = _get_annual_cfo_and_capex(cf)
+        self.assertEqual(float(cfo.iloc[0]), 30.0)
+        self.assertEqual(float(capex.iloc[0]), 10.0)
+        self.assertEqual(_get_annual_cfo_and_capex(None), (None, None))
+
+    def test_quarterly_revenue(self):
+        qf = pd.DataFrame([[50.0, 60.0]], index=["Total Revenue"],
+                          columns=pd.to_datetime(["2026-03-31", "2025-12-31"]))
+        qrev = _get_quarterly_revenue(qf)
+        self.assertEqual(len(qrev), 2)
+        self.assertIsNone(_get_quarterly_revenue(None))
+
+
+class TestGrowthMath(unittest.TestCase):
+    def test_cagr_3y_exact(self):
+        cagr = _rev_cagr_3y(series([100, 120, 150, 200]))
+        self.assertAlmostEqual(cagr, 2.0 ** (1 / 3) - 1, places=9)
+
+    def test_cagr_needs_four_years_and_positive_base(self):
+        self.assertIsNone(_rev_cagr_3y(series([100, 120, 150])))
+        self.assertIsNone(_rev_cagr_3y(series([0, 120, 150, 200])))
+        self.assertIsNone(_rev_cagr_3y(None))
+
+    def test_revenue_acceleration_delta(self):
+        self.assertAlmostEqual(_rev_accel(series([100, 120, 150])), 0.05, places=9)
+        self.assertIsNone(_rev_accel(series([100, 120])))
+
+    def test_op_margin_mean_and_trend(self):
+        mean_om, trend = _op_margin_3y_and_trend(
+            series([100, 100, 100]), series([10, 20, 30])
+        )
+        self.assertAlmostEqual(mean_om, 0.2, places=9)
+        self.assertAlmostEqual(trend, 0.3 - 0.15, places=9)
+        self.assertEqual(_op_margin_3y_and_trend(None, None), (None, None))
+
+    def test_fcf_margin(self):
+        margin = _fcf_margin_3y(
+            series([100, 100, 100]), series([30, 30, 30]), series([10, 10, 10])
+        )
+        self.assertAlmostEqual(margin, 0.2, places=9)
+        self.assertIsNone(_fcf_margin_3y(series([100, 100]), series([30, 30]),
+                                         series([10, 10])))
+
+    def test_valuation_metric_preference_order(self):
+        val, label = _valuation_metric({"enterpriseToRevenue": 5.0, "trailingPE": 30.0})
+        self.assertEqual(label, "EV/Sales")
+        self.assertAlmostEqual(val, math.log(5.0), places=9)
+        val, label = _valuation_metric({"trailingPE": 30.0})
+        self.assertEqual(label, "P/E")
+        self.assertEqual(_valuation_metric({}), (None, "NA"))
+
+    def test_momentum_12_1(self):
+        closes = pd.DataFrame({"Close": [float(100 + i * 0.1) for i in range(300)]})
+        mom = _mom_12_1(closes)
+        p252, p21 = 100 + (300 - 252) * 0.1, 100 + (300 - 21) * 0.1
+        self.assertAlmostEqual(mom, p21 / p252 - 1, places=9)
+        self.assertIsNone(_mom_12_1(pd.DataFrame({"Close": [1.0] * 100})))
+        self.assertIsNone(_mom_12_1(None))
+
+
+class TestScoreMetric(unittest.TestCase):
+    CASES = [
+        ("RevCAGR3Y", 0.30, 2), ("RevCAGR3Y", 0.15, 1), ("RevCAGR3Y", 0.05, 0),
+        ("RevCAGR3Y", -0.10, -1),
+        ("RevAccel", 0.10, 1), ("RevAccel", -0.10, -1), ("RevAccel", 0.0, 0),
+        ("OpMargin3Y", 0.25, 2), ("OpMargin3Y", 0.12, 1), ("OpMargin3Y", 0.05, 0),
+        ("OpMargin3Y", -0.05, -1),
+        ("OpMarginTrend", 0.05, 1), ("OpMarginTrend", -0.05, -1), ("OpMarginTrend", 0.0, 0),
+        ("FCFMargin3Y", 0.20, 2), ("FCFMargin3Y", 0.08, 1), ("FCFMargin3Y", 0.01, 0),
+        ("FCFMargin3Y", -0.10, -1),
+        ("ValMetric", 1.0, 2), ("ValMetric", 2.0, 1), ("ValMetric", 3.0, 0),
+        ("ValMetric", 4.0, -1),
+        ("Mom12_1", 0.30, 2), ("Mom12_1", 0.05, 1), ("Mom12_1", -0.05, 0),
+        ("Mom12_1", -0.30, -1),
+    ]
+
+    def test_threshold_table(self):
+        for metric, value, expected in self.CASES:
+            score, detail = _score_metric(value, metric)
+            self.assertEqual(score, expected, f"{metric}={value} -> {detail}")
+
+    def test_missing_value_scores_zero(self):
+        self.assertEqual(_score_metric(None, "RevCAGR3Y"), (0, "no data"))
+
+
+def quarterly_income(newest_first):
+    return pd.DataFrame(
+        [list(map(float, newest_first))],
+        index=["Net Income"],
+        columns=pd.to_datetime(
+            [f"202{6 - i}-03-31" for i in range(len(newest_first))]
+        ),
+    )
+
+
+class TestEarningsAcceleration(unittest.TestCase):
+    def test_accelerating_growth_counts_all_deltas(self):
+        count, total, avg_delta, rates, incomes = _compute_earnings_acceleration(
+            quarterly_income([100, 50, 30, 20, 15])  # oldest->newest: 15,20,30,50,100
+        )
+        self.assertEqual((count, total), (3, 3))
+        self.assertGreater(avg_delta, 0)
+        self.assertEqual(len(rates), 4)
+        self.assertEqual(incomes[0], 15.0)
+
+    def test_decelerating_growth_counts_none(self):
+        count, total, avg_delta, _, _ = _compute_earnings_acceleration(
+            quarterly_income([50, 40, 30, 20, 10])  # steady adds, falling growth rate
+        )
+        self.assertEqual(count, 0)
+        self.assertLess(avg_delta, 0)
+
+    def test_too_few_quarters(self):
+        count, total, avg_delta, rates, incomes = _compute_earnings_acceleration(
+            quarterly_income([30, 20, 10])
+        )
+        self.assertIsNone(count)
+        self.assertEqual(len(incomes), 3)
+
+    def test_missing_row(self):
+        df = pd.DataFrame([[1.0]], index=["Revenue"],
+                          columns=pd.to_datetime(["2026-03-31"]))
+        self.assertEqual(_compute_earnings_acceleration(df), (None, None, None, [], []))
+
+
+class FundamentalsServiceTestBase(unittest.TestCase):
+    def setUp(self):
+        self.repo = Mock()
+        self.service = FundamentalsService(
+            fundamentals_repository=self.repo, yfinance_gateway=Mock()
+        )
+
+
+class TestCacheOrchestration(FundamentalsServiceTestBase):
+    def test_cache_hit_skips_compute(self):
+        self.repo.get.return_value = {"composite_score": 7}
+        with patch.object(self.service, "_compute_fundamental_score",
+                          side_effect=AssertionError("must not compute")):
+            out = self.service.get_fundamental_score("intc")
+        self.assertEqual(out["composite_score"], 7)
+        self.repo.set.assert_not_called()
+
+    def test_cache_miss_computes_and_stores(self):
+        self.repo.get.return_value = None
+        with patch.object(self.service, "_compute_fundamental_score",
+                          return_value={"composite_score": 3}) as compute:
+            out = self.service.get_fundamental_score("intc")
+        compute.assert_called_once_with("INTC")
+        self.repo.set.assert_called_once()
+        self.assertEqual(out["composite_score"], 3)
+
+    def test_all_four_wrappers_share_the_pattern(self):
+        self.repo.get.return_value = {"cached": True}
+        for method in ("get_earnings_calendar", "get_revenue_growth",
+                       "get_earnings_acceleration"):
+            self.assertEqual(getattr(self.service, method)("intc"), {"cached": True})
+
+
+class TestBatchScoring(FundamentalsServiceTestBase):
+    def test_batch_mixes_hits_computes_and_errors(self):
+        def repo_get(sym, kind):
+            return {"symbol": "AAA", "composite_score": 2} if sym == "AAA" else None
+
+        self.repo.get.side_effect = repo_get
+
+        def compute(sym):
+            if sym == "CCC":
+                raise RuntimeError("yahoo choked")
+            return {"symbol": sym, "composite_score": 9}
+
+        with patch.object(self.service, "_compute_fundamental_score",
+                          side_effect=compute):
+            out = self.service.get_fundamental_scores_batch(["aaa", "bbb", "ccc"])
+
+        self.assertEqual(out["requested"], 3)
+        self.assertEqual(out["cache_hits"], 1)
+        self.assertEqual(out["fetched"], 1)
+        self.assertEqual(out["errors"], 1)
+        # Sorted by composite descending; flags mark provenance.
+        self.assertEqual([r["symbol"] for r in out["results"]], ["BBB", "AAA"])
+        self.assertFalse(out["results"][0]["cache_hit"])
+        self.assertTrue(out["results"][1]["cache_hit"])
+
+
+class TestFullProfile(FundamentalsServiceTestBase):
+    def arm(self, composite=9, trajectory="accelerating", accel="strong",
+            risk="LOW", days_to_earnings=None, cagr=0.3):
+        patches = [
+            patch.object(self.service, "get_earnings_calendar", return_value={
+                "risk_level": risk, "days_to_earnings": days_to_earnings}),
+            patch.object(self.service, "get_fundamental_score", return_value={
+                "composite_score": composite}),
+            patch.object(self.service, "get_revenue_growth", return_value={
+                "trajectory": trajectory, "cagr_3y": cagr}),
+            patch.object(self.service, "get_earnings_acceleration", return_value={
+                "acceleration_label": accel}),
+        ]
+        for p in patches:
+            p.start()
+            self.addCleanup(p.stop)
+
+    def test_strong_everything_reads_bullish_with_highlights(self):
+        self.arm()
+        out = self.service.get_full_fundamental_profile("intc")
+        self.assertEqual(out["summary"]["overall_signal"], "bullish")
+        joined = " ".join(out["summary"]["highlights"])
+        self.assertIn("Strong fundamentals", joined)
+        self.assertIn("Revenue accelerating", joined)
+        self.assertIn("EPS acceleration", joined)
+        self.assertIn("Strong 3Y CAGR", joined)
+
+    def test_deteriorating_reads_bearish(self):
+        self.arm(composite=-5, trajectory="decelerating", accel="none", cagr=None)
+        out = self.service.get_full_fundamental_profile("INTC")
+        self.assertEqual(out["summary"]["overall_signal"], "bearish")
+
+    def test_imminent_earnings_overrides_to_caution(self):
+        self.arm(risk="HIGH", days_to_earnings=3)
+        out = self.service.get_full_fundamental_profile("INTC")
+        self.assertEqual(out["summary"]["overall_signal"], "caution")
+        self.assertIn("options risk", " ".join(out["summary"]["highlights"]))
+
+
+class TestTopRankings(FundamentalsServiceTestBase):
+    def test_coverage_filter_and_ordering(self):
+        self.repo.get_all_latest.return_value = [
+            {"symbol": "AAA", "composite_score": 5, "coverage": 0.9,
+             "fundamental_label": "good", "fetched_at": "t"},
+            {"symbol": "BBB", "composite_score": 9, "coverage": 0.8,
+             "fundamental_label": "great", "fetched_at": "t"},
+            {"symbol": "LOWCOV", "composite_score": 12, "coverage": 0.2,
+             "fundamental_label": "?", "fetched_at": "t"},
+            {"symbol": "NOSCORE", "composite_score": None, "coverage": 0.9},
+        ]
+        out = self.service.get_top_fundamental_stocks(n=10, min_coverage=0.5)
+        self.assertEqual(out["total_in_cache"], 4)
+        self.assertEqual(out["eligible_count"], 2)
+        self.assertEqual([r["symbol"] for r in out["rankings"]], ["BBB", "AAA"])
+        self.assertEqual(out["rankings"][0]["rank"], 1)
+
+
+# ---------------------------------------------------------------------------
+# _compute_* internals (wave 2) — full yfinance-statement-shaped fixtures
+# ---------------------------------------------------------------------------
+
+from datetime import date, timedelta  # noqa: E402
+
+
+def statement(rows: dict, dates):
+    return pd.DataFrame(
+        {pd.Timestamp(d): [float(rows[label][i]) for label in rows]
+         for i, d in enumerate(dates)},
+        index=list(rows),
+    )
+
+
+ANNUAL_DATES = ["2022-12-31", "2023-12-31", "2024-12-31", "2025-12-31"]
+
+FINANCIALS = statement(
+    {"Total Revenue": [100, 120, 150, 200],
+     "Operating Income": [25, 30, 37.5, 50]},   # constant 25% margin
+    ANNUAL_DATES,
+)
+CASHFLOW = statement(
+    {"Operating Cash Flow": [40, 48, 60, 80],   # 40% of revenue
+     "Capital Expenditure": [10, 12, 15, 20]},  # 10% -> FCF margin 30%
+    ANNUAL_DATES,
+)
+
+
+def momentum_history(n=300):
+    return pd.DataFrame(
+        {"Close": [float(100 + i * 0.1) for i in range(n)]},
+        index=pd.bdate_range(end="2026-07-14", periods=n),
+    )
+
+
+class TestComputeFundamentalScore(FundamentalsServiceTestBase):
+    def test_strong_compounder_composite(self):
+        yf = self.service._yf
+        yf.info.return_value = {"enterpriseToRevenue": 3.0,
+                                "sector": "Technology", "marketCap": 1_000}
+        yf.financials.return_value = FINANCIALS
+        yf.cashflow.return_value = CASHFLOW
+        yf.history.return_value = momentum_history()
+
+        out = self.service._compute_fundamental_score("INTC")
+
+        ms = out["metric_scores"]
+        self.assertEqual(ms["RevCAGR3Y"]["score"], 2)     # 26% CAGR
+        self.assertEqual(ms["RevAccel"]["score"], 1)      # +8.3pp acceleration
+        self.assertEqual(ms["OpMargin3Y"]["score"], 2)    # 25% margins
+        self.assertEqual(ms["OpMarginTrend"]["score"], 0) # flat
+        self.assertEqual(ms["FCFMargin3Y"]["score"], 2)   # 30% FCF margin
+        self.assertEqual(ms["ValMetric"]["score"], 2)     # log(3) cheap
+        self.assertEqual(ms["Mom12_1"]["score"], 2)       # ~22% 12-1 momentum
+        self.assertEqual(out["composite_score"], 11)
+        self.assertEqual(out["fundamental_label"], "strong_compounder")
+        self.assertEqual(out["coverage"], 1.0)
+        self.assertEqual(out["val_type"], "EV/Sales")
+        self.assertEqual(out["sector"], "Technology")
+
+    def test_no_data_degrades_to_average_zero_coverage(self):
+        yf = self.service._yf
+        yf.info.side_effect = RuntimeError("yahoo down")
+        yf.financials.return_value = pd.DataFrame()
+        yf.cashflow.return_value = pd.DataFrame()
+        yf.history.return_value = pd.DataFrame()
+
+        out = self.service._compute_fundamental_score("ZZZ")
+        self.assertEqual(out["composite_score"], 0)
+        self.assertEqual(out["coverage"], 0.0)
+        self.assertEqual(out["fundamental_label"], "average")
+        self.assertEqual(out["val_type"], "NA")
+
+
+QUARTER_DATES = ["2025-06-30", "2025-09-30", "2025-12-31", "2026-03-31", "2026-06-30"]
+
+
+class TestComputeRevenueGrowth(FundamentalsServiceTestBase):
+    def quarters(self, revenues):
+        return statement({"Total Revenue": revenues}, QUARTER_DATES)
+
+    def test_accelerating_quarters(self):
+        yf = self.service._yf
+        yf.quarterly_financials.return_value = self.quarters([100, 102, 105, 110, 120])
+        yf.financials.return_value = FINANCIALS
+        out = self.service._compute_revenue_growth("INTC")
+        self.assertEqual(out["trajectory"], "accelerating")
+        self.assertEqual(out["weighted_score"], 1.0)      # all-positive growth
+        self.assertEqual(len(out["quarterly_revenues"]), 5)
+        self.assertAlmostEqual(out["cagr_3y"], 2.0 ** (1 / 3) - 1, places=4)
+        self.assertAlmostEqual(out["rev_accel"], (200 / 150 - 1) - (150 / 120 - 1),
+                               places=4)
+
+    def test_positive_inflection(self):
+        yf = self.service._yf
+        # Last QoQ positive after a negative one -> inflecting_positive.
+        yf.quarterly_financials.return_value = self.quarters([100, 110, 104.5, 100, 103])
+        yf.financials.return_value = pd.DataFrame()
+        out = self.service._compute_revenue_growth("INTC")
+        self.assertEqual(out["trajectory"], "inflecting_positive")
+
+    def test_insufficient_quarters(self):
+        yf = self.service._yf
+        yf.quarterly_financials.return_value = statement(
+            {"Total Revenue": [100, 110]}, QUARTER_DATES[:2]
+        )
+        yf.financials.return_value = pd.DataFrame()
+        out = self.service._compute_revenue_growth("INTC")
+        self.assertEqual(out["trajectory"], "insufficient_data")
+        self.assertEqual(out["quarterly_revenues"], [])
+
+
+class TestComputeEarningsAccelerationService(FundamentalsServiceTestBase):
+    def test_strong_acceleration(self):
+        self.service._yf.quarterly_income_stmt.return_value = quarterly_income(
+            [100e6, 50e6, 30e6, 20e6, 15e6]
+        )
+        out = self.service._compute_earnings_acceleration("INTC")
+        self.assertEqual(out["acceleration_label"], "strong")
+        self.assertEqual(out["acceleration_score"], 2)
+        self.assertEqual(out["accel_count"], 3)
+        self.assertEqual(out["net_incomes_M"][0], 15.0)   # scaled to millions
+
+    def test_decelerating(self):
+        self.service._yf.quarterly_income_stmt.return_value = quarterly_income(
+            [50e6, 40e6, 30e6, 20e6, 10e6]
+        )
+        out = self.service._compute_earnings_acceleration("INTC")
+        self.assertEqual(out["acceleration_label"], "decelerating")
+        self.assertEqual(out["acceleration_score"], -1)
+
+    def test_gateway_failure_degrades(self):
+        self.service._yf.quarterly_income_stmt.side_effect = RuntimeError("nope")
+        out = self.service._compute_earnings_acceleration("INTC")
+        self.assertEqual(out["acceleration_label"], "insufficient_data")
+
+
+class TestComputeEarningsCalendar(FundamentalsServiceTestBase):
+    def arm_history(self):
+        yf = self.service._yf
+        yf.history.return_value = pd.DataFrame()
+        yf.earnings_dates.return_value = pd.DataFrame()
+
+    def calendar_at(self, days_out):
+        earn = date.today() + timedelta(days=days_out)
+        return pd.DataFrame(
+            {0: [pd.Timestamp(earn)]}, index=["Earnings Date"]
+        )
+
+    def test_risk_ladder(self):
+        self.arm_history()
+        for days_out, expected in ((3, "CRITICAL"), (10, "HIGH"),
+                                   (20, "MODERATE"), (45, "LOW")):
+            self.service._yf.calendar.return_value = self.calendar_at(days_out)
+            out = self.service._compute_earnings_calendar("INTC")
+            self.assertEqual(out["risk_level"], expected, days_out)
+            self.assertEqual(out["days_to_earnings"], days_out)
+        # MODERATE also flags the pre-earnings IV setup.
+        self.service._yf.calendar.return_value = self.calendar_at(20)
+        self.assertTrue(self.service._compute_earnings_calendar("INTC")["pre_earnings_setup"])
+
+    def test_dict_form_calendar(self):
+        self.arm_history()
+        earn = date.today() + timedelta(days=40)
+        self.service._yf.calendar.return_value = {"Earnings Date": [earn]}
+        out = self.service._compute_earnings_calendar("INTC")
+        self.assertEqual(out["risk_level"], "LOW")
+        self.assertEqual(out["earnings_date"], earn.isoformat())
+
+    def test_calendar_failure_stays_unknown(self):
+        self.arm_history()
+        self.service._yf.calendar.side_effect = RuntimeError("yahoo calendar down")
+        out = self.service._compute_earnings_calendar("INTC")
+        self.assertEqual(out["risk_level"], "UNKNOWN")
+        self.assertIsNone(out["days_to_earnings"])
+
+    def test_historical_earnings_move_measured(self):
+        yf = self.service._yf
+        yf.calendar.return_value = None
+        idx = pd.bdate_range(end="2026-07-14", periods=10)
+        closes = [100.0] * 10
+        closes[5] = 110.0                                  # +10% earnings pop
+        yf.history.return_value = pd.DataFrame({"Close": closes}, index=idx)
+        yf.earnings_dates.return_value = pd.DataFrame(
+            {"EPS Estimate": [1.0]}, index=[idx[5]]
+        )
+        out = self.service._compute_earnings_calendar("INTC")
+        self.assertEqual(out["historical_avg_move_pct"], 10.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_microstructure_service.py
+++ b/test_microstructure_service.py
@@ -1,0 +1,222 @@
+"""Unit tests for MicrostructureService (short interest, dark-pool proxy,
+bid/ask spread). Coverage uplift (July 2026): gateway/prices are Mocks and
+frames are engineered so each classification branch is provoked analytically.
+"""
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pandas as pd
+
+from quantcore.services.microstructure import (
+    MicrostructureService,
+    _safe_float,
+    _safe_int,
+)
+
+
+def frame(closes, volumes=None, opens=None, highs=None, lows=None):
+    closes = [float(c) for c in closes]
+    n = len(closes)
+    idx = pd.bdate_range(end="2026-06-30", periods=n)
+    opens = opens or [c for c in closes]
+    highs = highs or [c + 0.5 for c in closes]
+    lows = lows or [c - 0.5 for c in closes]
+    volumes = volumes or [1_000_000.0] * n
+    return pd.DataFrame(
+        {
+            "Open": [float(v) for v in opens],
+            "High": [float(v) for v in highs],
+            "Low": [float(v) for v in lows],
+            "Close": closes,
+            "Volume": [float(v) for v in volumes],
+        },
+        index=idx,
+    )
+
+
+class TestSafeCasts(unittest.TestCase):
+    def test_safe_float(self):
+        self.assertEqual(_safe_float("1.5"), 1.5)
+        self.assertEqual(_safe_float(None), 0.0)
+        self.assertEqual(_safe_float(float("nan")), 0.0)
+        self.assertEqual(_safe_float("x", default=7.0), 7.0)
+
+    def test_safe_int(self):
+        self.assertEqual(_safe_int(3.9), 3)
+        self.assertEqual(_safe_int(None), 0)
+        self.assertEqual(_safe_int(float("nan"), default=4), 4)
+
+
+class MicrostructureTestBase(unittest.TestCase):
+    def setUp(self):
+        self.yf = Mock()
+        self.prices = Mock()
+        self.service = MicrostructureService(
+            ohlcv_repository=Mock(), yfinance_gateway=self.yf, prices=self.prices
+        )
+
+
+class TestShortInterest(MicrostructureTestBase):
+    def test_high_squeeze_and_tight_borrow(self):
+        self.yf.ticker_info.return_value = {
+            "sharesShort": 30_000_000,
+            "sharesOutstanding": 200_000_000,
+            "floatShares": 100_000_000,
+            "averageVolume": 5_000_000,
+            "shortRatio": 6.0,
+            "shortPercentOfFloat": 0.30,
+            "dateShortInterest": 1_780_000_000,
+        }
+        out = self.service.get_short_interest("gme")
+        self.assertEqual(out["symbol"], "GME")
+        self.assertEqual(out["short_float_pct"], 30.0)
+        self.assertEqual(out["squeeze_potential"], "HIGH")
+        self.assertIn("TIGHT", out["borrow_note"])
+        self.assertRegex(out["short_interest_date"], r"^\d{4}-\d{2}-\d{2}$")
+
+    def test_missing_yahoo_fields_computed_manually(self):
+        self.yf.ticker_info.return_value = {
+            "sharesShort": 10_000_000,
+            "floatShares": 100_000_000,
+            "averageVolume": 2_500_000,
+            # no shortRatio / shortPercentOfFloat / dateShortInterest
+        }
+        out = self.service.get_short_interest("INTC")
+        self.assertEqual(out["short_float_pct"], 10.0)          # 10M / 100M
+        self.assertEqual(out["short_ratio_days"], 4.0)          # 10M / 2.5M
+        self.assertEqual(out["short_interest_date"], "unknown")
+        self.assertEqual(out["squeeze_potential"], "MEDIUM")    # ratio >= 3
+
+    def test_low_short_interest(self):
+        self.yf.ticker_info.return_value = {
+            "sharesShort": 1_000_000,
+            "floatShares": 500_000_000,
+            "averageVolume": 10_000_000,
+            "shortRatio": 0.4,
+        }
+        out = self.service.get_short_interest("WMT")
+        self.assertEqual(out["squeeze_potential"], "LOW")
+        self.assertIn("available", out["borrow_note"])
+
+    def test_timeout_degrades_to_error_payload(self):
+        self.yf.ticker_info.side_effect = TimeoutError("yahoo hung")
+        out = self.service.get_short_interest("INTC")
+        self.assertEqual(out["symbol"], "INTC")
+        self.assertIn("yahoo hung", out["error"])
+        self.assertIn("Retry", out["note"])
+
+
+class TestDarkPool(MicrostructureTestBase):
+    def test_invalid_interval_rejected(self):
+        with self.assertRaises(ValueError):
+            self.service.get_dark_pool("INTC", interval="5m")
+
+    def test_thin_history_rejected(self):
+        self.prices.get_history.return_value = frame([100] * 10)
+        with self.assertRaises(ValueError):
+            self.service.get_dark_pool("INTC")
+
+    def test_quiet_tape_reports_none(self):
+        self.prices.get_history.return_value = frame([100] * 60)
+        out = self.service.get_dark_pool("INTC")
+        self.assertEqual(out["net_signal"], "none")
+        self.assertEqual(out["absorption_count"], 0)
+
+    def test_down_day_absorption_reads_accumulation(self):
+        n = 60
+        closes = [100.0] * (n - 1) + [99.9]
+        opens = [100.0] * n
+        # Last bar: tiny range (0.1 vs 1.0 avg), 3x volume, closes red.
+        highs = [100.5] * (n - 1) + [100.02]
+        lows = [99.5] * (n - 1) + [99.88]
+        volumes = [1_000_000.0] * (n - 1) + [3_000_000.0]
+        self.prices.get_history.return_value = frame(
+            closes, volumes=volumes, opens=opens, highs=highs, lows=lows
+        )
+        out = self.service.get_dark_pool("INTC")
+        self.assertEqual(out["net_signal"], "accumulation")
+        self.assertEqual(out["absorption_count"], 1)
+        event = out["absorption_events"][0]
+        self.assertEqual(event["direction"], "down")
+        self.assertIn("accumulation", event["interpretation"])
+        self.assertIn("bullish", out["interpretation"])
+
+    def test_indecisive_high_volume_bar_reads_two_sided(self):
+        n = 60
+        closes = [100.0] * (n - 1) + [100.0]   # closes exactly at the midpoint
+        opens = [100.0] * n
+        highs = [100.5] * n                     # normal range keeps it out of absorption
+        lows = [99.5] * n
+        volumes = [1_000_000.0] * (n - 1) + [3_000_000.0]
+        self.prices.get_history.return_value = frame(
+            closes, volumes=volumes, opens=opens, highs=highs, lows=lows
+        )
+        out = self.service.get_dark_pool("INTC")
+        self.assertEqual(out["two_sided_count"], 1)
+        self.assertEqual(out["net_signal"], "mixed")
+
+
+class TestBidAskSpread(MicrostructureTestBase):
+    def arm(self, bid=99.0, ask=101.0, price=100.0, expirations=("2026-08-21",),
+            hist=None):
+        self.yf.fast_info.return_value = SimpleNamespace(
+            bid=bid, ask=ask, last_price=price
+        )
+        self.yf.expirations.return_value = tuple(expirations)
+        chain_df = pd.DataFrame({
+            "strike": [95.0, 100.0, 105.0],
+            "bid": [4.0, 2.0, 0.9],
+            "ask": [4.4, 2.2, 1.1],
+        })
+        self.yf.option_chain.return_value = SimpleNamespace(
+            calls=chain_df, puts=chain_df
+        )
+        self.prices.get_history.return_value = (
+            hist if hist is not None else frame([100.0] * 60)
+        )
+
+    def test_equity_and_options_spreads_measured(self):
+        self.arm()
+        out = self.service.get_bid_ask_spread("intc")
+        self.assertEqual(out["symbol"], "INTC")
+        self.assertEqual(out["equity_spread"], 2.0)
+        self.assertEqual(out["equity_spread_pct"], 2.0)   # 2 / 100 mid
+        self.assertIsNotNone(out["options_spread_pct"])
+        self.assertEqual(out["spread_vs_norm"], "normal")
+        self.assertEqual(len(out["spread_history"]), 10)
+
+    def test_wide_last_bar_reads_widening_and_bottom_forming(self):
+        n = 60
+        closes = [100.0] * n
+        highs = [100.5] * (n - 1) + [101.5]
+        lows = [99.5] * (n - 1) + [98.5]      # 3% range vs ~1% norm
+        self.arm(hist=frame(closes, highs=highs, lows=lows))
+        out = self.service.get_bid_ask_spread("INTC")
+        self.assertEqual(out["spread_vs_norm"], "widening")
+        self.assertEqual(out["bottom_signal"], "forming")
+
+    def test_narrow_last_bar_reads_narrowing_and_bottom_strong(self):
+        n = 60
+        closes = [100.0] * n
+        highs = [100.5] * (n - 1) + [100.05]
+        lows = [99.5] * (n - 1) + [99.95]
+        self.arm(hist=frame(closes, highs=highs, lows=lows))
+        out = self.service.get_bid_ask_spread("INTC")
+        self.assertEqual(out["spread_vs_norm"], "narrowing")
+        self.assertEqual(out["bottom_signal"], "strong")
+        self.assertIn("bounce", out["bottom_note"].lower())
+
+    def test_no_expirations_leaves_options_spread_null(self):
+        self.arm(expirations=())
+        out = self.service.get_bid_ask_spread("INTC")
+        self.assertIsNone(out["options_spread_pct"])
+
+    def test_crossed_quote_leaves_equity_spread_null(self):
+        self.arm(bid=101.0, ask=100.0)
+        out = self.service.get_bid_ask_spread("INTC")
+        self.assertIsNone(out["equity_spread"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_options_repository.py
+++ b/test_options_repository.py
@@ -1,0 +1,167 @@
+"""DB round-trip tests for OptionsStore's ATM-snapshot, P/C-history, IV-history
+and gamma-wall surfaces (wave 3 coverage — the full-chain paths are pinned in
+test_options_contract_tools.py). Runs against the test database only.
+"""
+import os
+import unittest
+from contextlib import closing
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+# Standard preamble: swap in the test DSN BEFORE quantcore.db is imported.
+_env_file = Path(__file__).parent / ".env"
+if _env_file.exists():
+    for _line in _env_file.read_text().splitlines():
+        if _line.strip().startswith("QUANTCORE_TEST_DB_DSN="):
+            os.environ["QUANTCORE_DB_DSN"] = _line.split("=", 1)[1].strip()
+            break
+
+from quantcore.db_safety import assert_not_production  # noqa: E402
+
+assert_not_production()
+
+from quantcore.db import get_connection  # noqa: E402
+from quantcore.repositories.options_repository import OptionsStore  # noqa: E402
+
+TEST_SYMBOL = "ZZOPTREPO"
+
+
+def iso(days_ago: float) -> str:
+    ts = datetime.now(timezone.utc) - timedelta(days=days_ago)
+    return ts.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def atm_side(iv_pct, strikes=(95.0, 100.0)):
+    return {
+        "total_open_interest": 1_000,
+        "total_volume": 500,
+        "avg_iv_pct": iv_pct,
+        "atm_contracts": [
+            {"strike": s, "last": 2.0, "bid": 1.9, "ask": 2.1, "iv": iv_pct,
+             "volume": 10, "open_interest": 100, "in_the_money": s < 100}
+            for s in strikes
+        ],
+    }
+
+
+def options_payload(pcr=1.2, call_iv=40.0, put_iv=50.0):
+    return {
+        "expiration": "2026-08-21",
+        "put_call_ratio": pcr,
+        "calls": atm_side(call_iv),
+        "puts": atm_side(put_iv),
+    }
+
+
+class OptionsRepositoryTest(unittest.TestCase):
+    def setUp(self):
+        self._purge()
+        self.addCleanup(self._purge)
+        self.store = OptionsStore()
+
+    def _purge(self):
+        with closing(get_connection()) as conn:
+            conn.execute("DELETE FROM options_snapshots WHERE symbol = %s",
+                         (TEST_SYMBOL,))
+            conn.execute("DELETE FROM gamma_wall_history WHERE symbol = %s",
+                         (TEST_SYMBOL,))
+            conn.commit()
+
+    def seed(self, days_ago=0.0, price=100.0, pcr=1.2, **payload_kw):
+        return self.store.save_snapshot(
+            symbol=TEST_SYMBOL,
+            price=price,
+            bollinger_bands={"upper": 110.0, "middle": 100.0, "lower": 90.0,
+                             "period": 20},
+            options=options_payload(pcr=pcr, **payload_kw),
+            captured_at=iso(days_ago),
+        )
+
+    # -- ATM snapshot round trips ----------------------------------------
+
+    def test_snapshot_roundtrip_and_duplicate_rejection(self):
+        ts = iso(0.0)
+        first = self.store.save_snapshot(
+            symbol=TEST_SYMBOL, price=101.5,
+            bollinger_bands={"upper": 110, "middle": 100, "lower": 90},
+            options=options_payload(), captured_at=ts,
+        )
+        self.assertIsNotNone(first)
+        # Same symbol+timestamp is a duplicate — must return None, not raise.
+        self.assertIsNone(self.store.save_snapshot(
+            symbol=TEST_SYMBOL, price=999.0,
+            bollinger_bands=None, options=options_payload(), captured_at=ts,
+        ))
+        snap = self.store.get_latest_snapshot(TEST_SYMBOL)
+        self.assertEqual(float(snap["price"]), 101.5)
+
+    def test_snapshot_without_options_still_persists(self):
+        sid = self.store.save_snapshot(
+            symbol=TEST_SYMBOL, price=55.0, bollinger_bands=None,
+            options=None, captured_at=iso(0.0),
+        )
+        self.assertIsNotNone(sid)
+        self.assertEqual(self.store.snapshot_count(TEST_SYMBOL), 1)
+
+    def test_symbols_dates_and_counts(self):
+        self.seed(days_ago=2.0)
+        self.seed(days_ago=1.0)
+        self.assertIn(TEST_SYMBOL, self.store.get_symbols())
+        self.assertEqual(self.store.snapshot_count(TEST_SYMBOL), 2)
+        self.assertEqual(len(self.store.get_snapshot_dates(TEST_SYMBOL)), 2)
+
+    # -- History surfaces ---------------------------------------------------
+
+    def test_pc_history_window_and_values(self):
+        self.seed(days_ago=2.0, price=98.0, pcr=1.5)
+        self.seed(days_ago=1.0, price=99.0, pcr=1.0)
+        self.seed(days_ago=45.0, price=90.0, pcr=3.0)   # outside 30d window
+        rows = self.store.get_pc_history(TEST_SYMBOL, days=30)
+        self.assertEqual(len(rows), 2)
+        pcrs = {round(float(r["put_call_ratio"]), 2) for r in rows}
+        self.assertEqual(pcrs, {1.5, 1.0})
+        for r in rows:
+            self.assertIn("captured_at", r)
+            self.assertIn("price", r)
+
+    def test_iv_history_composites_both_sides(self):
+        self.seed(days_ago=1.0, call_iv=40.0, put_iv=50.0)
+        rows = self.store.get_iv_history(TEST_SYMBOL, days=365)
+        self.assertEqual(len(rows), 1)
+        composite = rows[0]["composite_iv"]
+        self.assertIsNotNone(composite)
+        self.assertGreaterEqual(float(composite), 40.0)
+        self.assertLessEqual(float(composite), 50.0)
+
+    # -- Gamma wall history --------------------------------------------------
+
+    def daoi_result(self, price=100.0, wall=105.0):
+        return {
+            "price": price,
+            "gamma_wall_strike": wall,
+            "gamma_wall_method": "bs_gamma_oi",
+            "delta_flip_strike": 100.0,
+            "dist_to_flip_pct": 0.0,
+            "net_daoi_shares": -12_000.0,
+            "call_daoi_shares": 3_000.0,
+            "put_daoi_shares": -15_000.0,
+            "mm_hedge_bias": "buy_on_rally",
+            "signal": "strong",
+            "expirations_scanned": ["2026-08-21"],
+        }
+
+    def test_gamma_wall_last_write_of_day_wins(self):
+        self.store.save_gamma_wall(TEST_SYMBOL, self.daoi_result(price=100.0))
+        self.store.save_gamma_wall(TEST_SYMBOL, self.daoi_result(price=104.0,
+                                                                 wall=110.0))
+        rows = self.store.get_gamma_wall_history(TEST_SYMBOL, since_days=7)
+        self.assertEqual(len(rows), 1)                  # one row per calendar day
+        self.assertEqual(float(rows[0]["price"]), 104.0)
+        self.assertEqual(float(rows[0]["gamma_wall_strike"]), 110.0)
+
+    def test_gamma_wall_history_empty_for_unknown_symbol(self):
+        self.assertEqual(self.store.get_gamma_wall_history("ZZNOWALL"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_options_screening_service.py
+++ b/test_options_screening_service.py
@@ -16,16 +16,20 @@ import tempfile
 import unittest
 from pathlib import Path
 
+import pandas as pd
+
 from quantcore.services.options_screening import (
     OptionsScreeningService,
     SecurityAnalysis,
     BollingerBands,
     OptionsSummary,
     IVAnalysis,
+    PutCallAnalysis,
     CONVICTION_WEIGHT,
     ROI_WEIGHT,
     ROI_CAP_FOR_RANKING,
     MAX_PUT_SCORE,
+    _chain_pc,
 )
 
 
@@ -209,6 +213,179 @@ class WatchlistHelperTests(unittest.TestCase):
         self.assertEqual([e["symbol"] for e in entries], ["AAPL", "MSFT"])
         self.assertEqual(entries[0]["tags"], ["tech", "core"])
         self.assertEqual(entries[1]["name"], "MSFT")
+
+
+# ---------------------------------------------------------------------------
+# Wave 3 additions: band math, chain P/C helper, PutCallAnalysis-driven score
+# paths, and the trade builders (previously untested).
+# ---------------------------------------------------------------------------
+
+
+def _pc(**overrides) -> PutCallAnalysis:
+    data = dict(near_expiry="2026-07-17", near_oi_pc=1.0, near_vol_pc=1.0,
+                near_atm_pc=None, mid_expiry=None, mid_oi_pc=None,
+                term_skew=None, vol_oi_ratio=1.0,
+                put_unwinding=False, fresh_put_buying=False,
+                near_term_fear=False)
+    data.update(overrides)
+    return PutCallAnalysis(**data)
+
+
+class BandMathTests(unittest.TestCase):
+    def test_position_normalization_and_breakouts(self):
+        b = BollingerBands(upper=110.0, middle=100.0, lower=90.0)
+        self.assertEqual(b.position(90.0), 0.0)
+        self.assertEqual(b.position(100.0), 0.5)
+        self.assertEqual(b.position(110.0), 1.0)
+        self.assertGreater(b.position(115.0), 1.0)
+        self.assertAlmostEqual(b.pct_from_lower(94.5), 5.0)
+        self.assertAlmostEqual(b.pct_from_upper(104.5), -5.0)
+
+    def test_zero_width_bands_read_neutral(self):
+        b = BollingerBands(upper=100.0, middle=100.0, lower=100.0)
+        self.assertEqual(b.position(100.0), 0.5)
+
+
+class ChainPcTests(unittest.TestCase):
+    def test_oi_and_volume_ratios(self):
+        calls = pd.DataFrame({"strike": [95.0, 100.0], "openInterest": [100, 100],
+                              "volume": [10, 10]})
+        puts = pd.DataFrame({"strike": [95.0, 100.0], "openInterest": [200, 200],
+                             "volume": [40, 40]})
+        oi_pc, vol_pc, _ = _chain_pc(calls, puts, price=100.0)
+        self.assertEqual(oi_pc, 2.0)
+        self.assertEqual(vol_pc, 4.0)
+
+    def test_missing_or_empty_frames(self):
+        calls = pd.DataFrame({"strike": [100.0], "openInterest": [1], "volume": [1]})
+        self.assertEqual(_chain_pc(calls, pd.DataFrame(), 100.0), (None, None, None))
+        self.assertEqual(_chain_pc(None, None, 100.0), (None, None, None))
+
+
+class PutCallScorePathTests(unittest.TestCase):
+    def test_put_unwinding_and_fear_skew_add_long_points(self):
+        svc = _svc()
+        sec = _security(pc=_pc(
+            near_oi_pc=1.6, near_vol_pc=1.0,
+            put_unwinding=True,                          # +2
+            near_term_fear=True, mid_oi_pc=1.1, term_skew=0.5,   # +1
+            near_atm_pc=1.0,                             # < 0.85 x total: +1
+        ))
+        svc.score(sec)
+        self.assertEqual(sec.long_score, 4)
+        self.assertIn("put unwinding", sec.long_reason)
+        self.assertIn("near-term fear", sec.long_reason)
+        self.assertIn("near-money calls", sec.long_reason)
+
+    def test_fresh_put_buying_and_atm_hedging_add_put_points(self):
+        svc = _svc()
+        sec = _security(pc=_pc(
+            near_oi_pc=1.0, near_vol_pc=2.0,
+            fresh_put_buying=True,                       # +2
+            near_atm_pc=1.5,                             # > 1.2 x total: +1
+        ))
+        svc.score(sec)
+        self.assertEqual(sec.put_score, 3)
+        self.assertIn("fresh put buying", sec.put_reason)
+        self.assertIn("targeted hedging", sec.put_reason)
+
+
+ATM_PUT = {"strike": 100.0, "ask": 3.0, "iv": 40.0}
+ATM_CALL = {"strike": 100.0, "ask": 3.0, "iv": 40.0}
+
+
+class BuildPutTradeTests(unittest.TestCase):
+    def bearish(self, **overrides):
+        sec = _security(
+            options=_options(atm_puts=[dict(ATM_PUT)], put_call_ratio=2.2,
+                             total_put_oi=5_000),
+            **overrides,
+        )
+        sec.put_score = 8.0
+        return sec
+
+    def test_happy_path_targets_the_lower_band(self):
+        trade = _svc().build_put_trade(self.bearish())
+        self.assertEqual(trade["strike"], 100.0)
+        self.assertEqual(trade["total_cost"], 300.0)            # 1 x $3.00 x 100
+        self.assertEqual(trade["target_price"], 90.0)           # the lower band
+        self.assertEqual(trade["profit_at_target_per_contract"], 700.0)  # (10-3)x100
+        self.assertAlmostEqual(trade["roi_at_target_pct"], 233.3, places=1)
+        self.assertFalse(trade["suggest_spread"])
+
+    def test_breakdown_extends_target_below_the_band(self):
+        trade = _svc().build_put_trade(self.bearish(price=85.0))
+        self.assertEqual(trade["target_price"], 85.5)           # lower band x 0.95
+
+    def test_high_iv_suggests_a_spread(self):
+        sec = self.bearish()
+        sec.options.atm_puts[0]["iv"] = 70.0
+        self.assertTrue(_svc().build_put_trade(sec)["suggest_spread"])
+
+    def test_guardrails_veto_the_trade(self):
+        svc = _svc()
+        self.assertIsNone(svc.build_put_trade(self.bearish(days_to_earnings=5)))
+        self.assertIsNone(svc.build_put_trade(
+            self.bearish(recent_positive_catalyst=True)))
+        contradicted = self.bearish()
+        contradicted.long_score = 4.0
+        contradicted.put_score = 4.0
+        self.assertIsNone(svc.build_put_trade(contradicted))
+
+    def test_economic_vetoes(self):
+        svc = _svc()
+        rich = self.bearish()
+        rich.options.atm_puts[0]["ask"] = 15.0                  # $1500 > $1000 budget
+        self.assertIsNone(svc.build_put_trade(rich, total_budget=1000.0))
+
+        no_edge = self.bearish(
+            bands=BollingerBands(upper=110.0, middle=104.0, lower=98.0)
+        )
+        self.assertIsNone(svc.build_put_trade(no_edge))         # intrinsic 2 < ask 3
+
+        crossed = self.bearish()
+        crossed.options.atm_puts[0]["ask"] = 0.0
+        self.assertIsNone(svc.build_put_trade(crossed))
+
+        self.assertIsNone(svc.build_put_trade(_security()))     # no puts at all
+
+
+class BuildCallTradeTests(unittest.TestCase):
+    def bullish(self, **overrides):
+        sec = _security(
+            options=_options(atm_calls=[dict(ATM_CALL)], put_call_ratio=0.5),
+            **overrides,
+        )
+        sec.long_score = 8.0
+        return sec
+
+    def test_happy_path_targets_the_upper_band(self):
+        trade = _svc().build_call_trade(self.bullish())
+        self.assertEqual(trade["target_price"], 110.0)
+        self.assertEqual(trade["profit_at_target_per_contract"], 700.0)
+        self.assertEqual(trade["long_score"], 8.0)
+
+    def test_breakout_extends_target_above_the_band(self):
+        trade = _svc().build_call_trade(self.bullish(price=112.0))
+        self.assertEqual(trade["target_price"], 115.5)          # upper band x 1.05
+
+    def test_earnings_blackout_applies_but_catalyst_supports(self):
+        svc = _svc()
+        self.assertIsNone(svc.build_call_trade(self.bullish(days_to_earnings=3)))
+        # A positive catalyst SUPPORTS the call thesis — trade still builds.
+        self.assertIsNotNone(
+            svc.build_call_trade(self.bullish(recent_positive_catalyst=True))
+        )
+
+    def test_economic_vetoes(self):
+        svc = _svc()
+        rich = self.bullish()
+        rich.options.atm_calls[0]["ask"] = 15.0
+        self.assertIsNone(svc.build_call_trade(rich, total_budget=1000.0))
+        no_edge = self.bullish(
+            bands=BollingerBands(upper=102.0, middle=96.0, lower=90.0)
+        )
+        self.assertIsNone(svc.build_call_trade(no_edge))        # intrinsic 2 < ask 3
 
 
 if __name__ == "__main__":

--- a/test_options_service.py
+++ b/test_options_service.py
@@ -1,0 +1,295 @@
+"""Unit tests for OptionsService's analytics surfaces (wave 2 coverage).
+
+Everything is driven by literal chain fixtures with analytically known
+outcomes: a 2.5x vol/OI call filled at the ask 8% OTM MUST score a strong
+sweep; a put-heavy book MUST flip market makers to buy-on-rally; the ATM
+straddle at 100 with last prices 4 + 3.5 MUST read a 7.5% expected move.
+Gateway/repositories are Mocks; the Polygon-backed backfill and the
+refresh orchestrator are integration surfaces left to wave 3.
+"""
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pandas as pd
+
+from quantcore.services.options import OptionsService
+
+TODAY_EXP = "2026-08-14"  # ~30 days out from the July 2026 test runs
+
+
+def call_row(strike, volume, oi, last, bid, ask, iv=0.45, itm=False):
+    return {
+        "strike": float(strike), "volume": volume, "openInterest": oi,
+        "lastPrice": last, "bid": bid, "ask": ask,
+        "impliedVolatility": iv, "inTheMoney": itm,
+    }
+
+
+def chain_frames(calls_rows, puts_rows=()):
+    cols = ["strike", "volume", "openInterest", "lastPrice", "bid", "ask",
+            "impliedVolatility", "inTheMoney"]
+    calls = pd.DataFrame(list(calls_rows), columns=cols)
+    puts = pd.DataFrame(list(puts_rows), columns=cols)
+    return SimpleNamespace(calls=calls, puts=puts)
+
+
+class OptionsServiceTestBase(unittest.TestCase):
+    def setUp(self):
+        self.yf = Mock()
+        self.options = Mock()
+        self.service = OptionsService(
+            ohlcv_repository=Mock(),
+            yfinance_gateway=self.yf,
+            options_repository=self.options,
+            polygon_gateway=Mock(),
+            prices=Mock(),
+        )
+
+    def arm_price(self, price=100.0, expirations=(TODAY_EXP,)):
+        self.yf.fast_info.return_value = SimpleNamespace(last_price=price)
+        self.yf.expirations.return_value = tuple(expirations)
+
+
+class TestUnusualCalls(OptionsServiceTestBase):
+    def test_aggressive_otm_sweep_scores_strong(self):
+        self.arm_price()
+        self.yf.option_chain.return_value = chain_frames([
+            # 2.5x vol/OI (+3), last >= ask (+2), 8% OTM (+2) => score 7.
+            call_row(108, volume=500, oi=200, last=2.60, bid=2.40, ask=2.50),
+        ])
+        out = self.service.get_unusual_calls("intc")
+        self.assertEqual(out["sweep_signal"], "strong")
+        top = out["unusual_calls"][0]
+        self.assertEqual(top["sweep_score"], 7)
+        self.assertEqual(top["conviction"], "very high")
+        self.assertIn("aggressive sweep fill", " ".join(top["notes"]))
+
+    def test_itm_hedge_flow_reads_weak(self):
+        self.arm_price()
+        self.yf.option_chain.return_value = chain_frames([
+            # High vol/OI but ITM and filled below mid: hedge, not a sweep.
+            call_row(90, volume=300, oi=100, last=9.0, bid=9.5, ask=10.5, itm=True),
+        ])
+        out = self.service.get_unusual_calls("INTC")
+        self.assertEqual(out["sweep_signal"], "weak")
+        self.assertEqual(out["unusual_calls"][0]["conviction"], "low")
+        self.assertIn("hedge", " ".join(out["unusual_calls"][0]["notes"]))
+
+    def test_thresholds_filter_everything_out(self):
+        self.arm_price()
+        self.yf.option_chain.return_value = chain_frames([
+            call_row(105, volume=50, oi=1000, last=1.0, bid=0.9, ask=1.1),
+        ])
+        out = self.service.get_unusual_calls("INTC")
+        self.assertEqual(out["sweep_signal"], "none")
+        self.assertEqual(out["unusual_call_count"], 0)
+
+    def test_no_expirations_and_bad_price(self):
+        self.arm_price(expirations=())
+        out = self.service.get_unusual_calls("INTC")
+        self.assertEqual(out["sweep_signal"], "none")
+        self.yf.fast_info.return_value = SimpleNamespace(last_price=None)
+        with self.assertRaises(ValueError):
+            self.service.get_unusual_calls("INTC")
+
+
+class TestDeltaAdjustedOi(OptionsServiceTestBase):
+    def test_put_heavy_book_flips_mm_to_buy_on_rally_strong(self):
+        self.arm_price()
+        self.yf.option_chain.return_value = chain_frames(
+            calls_rows=[call_row(100, volume=0, oi=100, last=4, bid=3.9, ask=4.1, iv=0.3)],
+            puts_rows=[call_row(100, volume=0, oi=40_000, last=3.5, bid=3.4, ask=3.6, iv=0.3)],
+        )
+        out = self.service.get_delta_adjusted_oi("intc", max_expirations=1)
+        self.assertLess(out["net_daoi_shares"], 0)
+        self.assertEqual(out["mm_hedge_bias"], "buy_on_rally")
+        self.assertEqual(out["signal"], "strong")     # near flip (same strike) + big magnitude
+        self.assertEqual(out["delta_flip_strike"], 100.0)
+        self.assertEqual(out["gamma_wall_strike"], 100.0)
+        self.assertEqual(out["gamma_wall_method"], "bs_gamma_oi")
+        self.options.save_gamma_wall.assert_called_once()
+
+    def test_call_heavy_book_reads_sell_on_rally_none(self):
+        self.arm_price()
+        self.yf.option_chain.return_value = chain_frames(
+            calls_rows=[call_row(100, volume=0, oi=40_000, last=4, bid=3.9, ask=4.1, iv=0.3)],
+        )
+        out = self.service.get_delta_adjusted_oi("INTC", max_expirations=1)
+        self.assertEqual(out["mm_hedge_bias"], "sell_on_rally")
+        self.assertEqual(out["signal"], "none")
+
+    def test_no_expirations_short_circuits(self):
+        self.arm_price(expirations=())
+        out = self.service.get_delta_adjusted_oi("INTC")
+        self.assertEqual(out["signal"], "none")
+        self.options.save_gamma_wall.assert_not_called()
+
+
+class TestRepoBackedSurfaces(OptionsServiceTestBase):
+    def test_gamma_wall_history_notes(self):
+        self.options.get_gamma_wall_history.return_value = [{"d": 1}]
+        out = self.service.get_gamma_wall_history("intc")
+        self.assertEqual(out["data_points"], 1)
+        self.assertIn("One row per calendar day", out["note"])
+        self.options.get_gamma_wall_history.return_value = []
+        out = self.service.get_gamma_wall_history("INTC")
+        self.assertIn("No history yet", out["note"])
+
+    def test_options_latest(self):
+        self.options.get_latest_snapshot.return_value = None
+        self.assertIsNone(self.service.get_options_latest("intc")["snapshot"])
+        self.options.get_latest_snapshot.return_value = {"price": 1}
+        self.assertEqual(self.service.get_options_latest("INTC")["snapshot"], {"price": 1})
+
+    def test_options_history_collapses_intraday_rows(self):
+        self.options.get_pc_history.return_value = [
+            {"captured_at": "2026-07-14T10:00:00Z", "price": 99.0, "put_call_ratio": 1.0},
+            {"captured_at": "2026-07-14T15:00:00Z", "price": 101.0, "put_call_ratio": 2.0},
+            {"captured_at": "2026-07-13T15:00:00Z", "price": 98.0, "put_call_ratio": None},
+        ]
+        out = self.service.get_options_history("INTC")
+        self.assertEqual(len(out["history"]), 2)
+        d13, d14 = out["history"][0], out["history"][1]
+        self.assertIsNone(d13["put_call_ratio"])
+        self.assertEqual(d14["put_call_ratio"], 1.5)      # intraday average
+        self.assertEqual(d14["price"], 101.0)             # latest row wins
+        self.assertEqual(d14["captured_at"], "2026-07-14T15:00:00Z")
+
+    def full_chain_fixture(self):
+        contracts = [
+            {"kind": "call", "strike": 95.0, "open_interest": 100, "last_price": 7.0},
+            {"kind": "call", "strike": 100.0, "open_interest": 500, "last_price": 4.0},
+            {"kind": "call", "strike": 105.0, "open_interest": 100, "last_price": 2.0},
+            {"kind": "put", "strike": 95.0, "open_interest": 100, "last_price": 1.5},
+            {"kind": "put", "strike": 100.0, "open_interest": 500, "last_price": 3.5},
+            {"kind": "put", "strike": 105.0, "open_interest": 100, "last_price": 6.0},
+        ]
+        return {
+            "price": 100.0,
+            "captured_at": "2026-07-14T15:00:00Z",
+            "expirations": [{
+                "expiration": TODAY_EXP,
+                "contracts": contracts,
+                "total_call_oi": 700, "total_put_oi": 700, "put_call_ratio": 1.0,
+            }],
+        }
+
+    def test_options_analytics_max_pain_and_expected_move(self):
+        self.options.get_full_chain.return_value = self.full_chain_fixture()
+        out = self.service.get_options_analytics("intc")
+        row = out["analytics"][0]
+        self.assertEqual(row["max_pain"], 100.0)          # OI concentrated at 100
+        self.assertEqual(row["atm_strike"], 100.0)
+        self.assertEqual(row["expected_move_dollar"], 7.5)  # 4.0 + 3.5 straddle
+        self.assertEqual(row["expected_move_pct"], 7.5)
+        self.assertEqual(row["upper_bound"], 107.5)
+        self.assertEqual(row["lower_bound"], 92.5)
+        self.assertTrue(row["pain_curve"])
+
+    def test_options_analytics_without_chain(self):
+        self.options.get_full_chain.return_value = None
+        out = self.service.get_options_analytics("INTC")
+        self.assertIsNone(out["analytics"])
+
+    def test_options_chain_expiration_filter(self):
+        chain = self.full_chain_fixture()
+        chain["expirations"].append({"expiration": "2026-09-18", "contracts": []})
+        self.options.get_full_chain.return_value = chain
+        out = self.service.get_options_chain("INTC", expiration=TODAY_EXP)
+        self.assertEqual(len(out["chain"]["expirations"]), 1)
+        self.assertEqual(out["chain"]["expirations"][0]["expiration"], TODAY_EXP)
+
+    def test_iv_rank_math(self):
+        self.options.get_iv_history.return_value = [
+            {"composite_iv": 20.0}, {"composite_iv": 60.0},
+            {"composite_iv": None}, {"composite_iv": 40.0},
+        ]
+        out = self.service.get_iv_rank("intc")
+        self.assertEqual(out["current_iv"], 40.0)
+        self.assertEqual(out["iv_rank"], 50.0)            # (40-20)/(60-20)
+        self.assertEqual(out["iv_percentile"], 50.0)      # 1 of 2 past values below
+        self.assertEqual(out["iv_52w_high"], 60.0)
+        self.assertEqual(out["iv_52w_low"], 20.0)
+
+    def test_iv_rank_insufficient_history(self):
+        self.options.get_iv_history.return_value = [{"composite_iv": 33.0}]
+        out = self.service.get_iv_rank("INTC")
+        self.assertIsNone(out["iv_rank"])
+        self.assertEqual(out["current_iv"], 33.0)
+
+
+class TestFlowSignalsAndPortfolioDelta(OptionsServiceTestBase):
+    def test_flow_signals_isolate_failures(self):
+        ok = {"sweep_signal": "none"}
+        with unittest.mock.patch.object(self.service, "get_unusual_calls",
+                                        return_value=ok), \
+             unittest.mock.patch.object(self.service, "get_delta_adjusted_oi",
+                                        side_effect=RuntimeError("daoi boom")):
+            out = self.service.get_options_flow_signals("intc")
+        self.assertEqual(out["unusual_calls"], ok)
+        self.assertIsNone(out["delta_adjusted_oi"])
+        self.assertIn("daoi boom", out["_errors"]["delta_adjusted_oi"])
+
+    def test_portfolio_delta_exposure_put_heavy_position(self):
+        chain = {
+            "price": 100.0,
+            "captured_at": "t",
+            "expirations": [{
+                "expiration": TODAY_EXP,
+                "contracts": [
+                    {"kind": "put", "strike": 100.0, "open_interest": 10_000,
+                     "implied_vol": 30.0},   # percent form exercises normalization
+                ],
+            }],
+        }
+        self.options.get_full_chain.side_effect = lambda sym: (
+            chain if sym == "INTC" else None
+        )
+        out = self.service.get_portfolio_delta_exposure([
+            {"symbol": "INTC", "name": "Intel", "quantity": 500},
+            {"symbol": "NOCHAIN", "name": "Nothing", "quantity": 1},
+        ])
+        self.assertEqual(len(out["positions"]), 1)
+        pos = out["positions"][0]
+        self.assertEqual(pos["stock_delta"], 500.0)
+        self.assertLess(pos["net_daoi_shares"], 0)         # puts carry negative delta
+        self.assertEqual(pos["mm_hedge_bias"], "buy_on_rally")
+        self.assertEqual(out["portfolio_net_daoi"], pos["net_daoi_shares"])
+
+
+class TestFullChainFetch(OptionsServiceTestBase):
+    def test_full_chain_persists_and_summarizes(self):
+        self.arm_price()
+        prices = self.service._prices
+        prices.get_history.return_value = pd.DataFrame(
+            {"Close": [100.0] * 30},
+            index=pd.bdate_range(end="2026-07-14", periods=30),
+        )
+        self.yf.option_chain.return_value = chain_frames(
+            calls_rows=[call_row(100, volume=10, oi=100, last=4, bid=3.9, ask=4.1)],
+            puts_rows=[call_row(100, volume=10, oi=200, last=3.5, bid=3.4, ask=3.6)],
+        )
+        self.options.save_full_chain.return_value = 42
+        out = self.service.get_full_options_chain("intc")
+        self.assertEqual(out["snapshot_id"], 42)
+        self.assertTrue(out["persisted"])
+        self.assertEqual(out["expiration_count"], 1)
+        self.assertEqual(out["total_contracts"], 2)
+        self.assertEqual(out["expirations"], [TODAY_EXP])
+        self.assertIsNotNone(out["bollinger_bands"])
+
+    def test_full_chain_duplicate_snapshot_flagged(self):
+        self.arm_price(expirations=())
+        prices = self.service._prices
+        prices.get_history.return_value = pd.DataFrame(
+            {"Close": [100.0] * 10},
+            index=pd.bdate_range(end="2026-07-14", periods=10),
+        )
+        out = self.service.get_full_options_chain("INTC")
+        self.assertEqual(out["expiration_count"], 0)
+        self.assertEqual(out["total_contracts"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_prices_service.py
+++ b/test_prices_service.py
@@ -1,0 +1,584 @@
+"""Unit tests for PricesService's indicator/pattern/screening surface.
+
+Coverage uplift (July 2026): every method here follows the same testable
+shape — get_history() -> pure computation -> dict — so the suite patches
+``get_history`` with engineered OHLCV frames whose expected outcomes are
+known analytically (a monotonic rally MUST read RSI 100; an engineered
+hammer MUST classify as a hammer; a bar spanning a gap MUST fill it).
+No DB, no network: repositories and the gateway are Mocks.
+
+The get_history fetch-when-stale policy itself is pinned separately in
+test_prices_history_policy.py.
+"""
+import math
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import numpy as np
+import pandas as pd
+
+from quantcore.services.prices import PricesService, _safe_int, _summarize_options
+
+
+def bars(closes, volumes=None, opens=None, highs=None, lows=None, end="2026-06-30"):
+    """OHLCV frame from a close series; OHLC default to a tight bar around close."""
+    closes = [float(c) for c in closes]
+    n = len(closes)
+    idx = pd.bdate_range(end=end, periods=n)
+    opens = [float(o) for o in opens] if opens is not None else [c * 0.999 for c in closes]
+    highs = [float(h) for h in highs] if highs is not None else [
+        max(o, c) * 1.002 for o, c in zip(opens, closes)
+    ]
+    lows = [float(low) for low in lows] if lows is not None else [
+        min(o, c) * 0.998 for o, c in zip(opens, closes)
+    ]
+    volumes = [float(v) for v in volumes] if volumes is not None else [1_000_000.0] * n
+    return pd.DataFrame(
+        {"Open": opens, "High": highs, "Low": lows, "Close": closes, "Volume": volumes},
+        index=idx,
+    )
+
+
+def flat(n, price=100.0, **kw):
+    return bars([price] * n, **kw)
+
+
+class PricesServiceTestBase(unittest.TestCase):
+    def setUp(self):
+        self.ohlcv = Mock()
+        self.yf = Mock()
+        self.options = Mock()
+        self.sentiment = Mock()
+        self.service = PricesService(
+            ohlcv_repository=self.ohlcv,
+            yfinance_gateway=self.yf,
+            options_repository=self.options,
+            sentiment_repository=self.sentiment,
+        )
+
+    def with_history(self, df):
+        return patch.object(self.service, "get_history", return_value=df)
+
+
+# ---------------------------------------------------------------------------
+# Module helpers
+# ---------------------------------------------------------------------------
+
+class TestSafeInt(unittest.TestCase):
+    def test_conversions(self):
+        self.assertEqual(_safe_int(5.7), 5)
+        self.assertEqual(_safe_int(None), 0)
+        self.assertEqual(_safe_int(float("nan")), 0)
+        self.assertEqual(_safe_int("12"), 12)
+        self.assertEqual(_safe_int("garbage"), 0)
+
+
+class TestSummarizeOptions(unittest.TestCase):
+    def chain(self):
+        return pd.DataFrame({
+            "strike": [90.0, 95.0, 100.0, 105.0, 110.0, 150.0, 0.0],
+            "lastPrice": [11.0, 7.0, 4.0, 2.0, 1.0, 0.1, 0.0],
+            "bid": [10.8, 6.8, 3.9, 1.9, 0.9, 0.05, 0.0],
+            "ask": [11.2, 7.2, 4.1, 2.1, 1.1, 0.15, 0.0],
+            "impliedVolatility": [0.5, 0.48, 0.45, 0.47, 0.5, 0.9, 0.0],
+            "volume": [10, 20, 300, 40, 5, float("nan"), 0],
+            "openInterest": [100, 200, 3000, 400, 50, 1, 0],
+            "inTheMoney": [True, True, False, False, False, False, False],
+        })
+
+    def test_atm_selection_and_aggregates(self):
+        out = _summarize_options(self.chain(), price=101.0, kind="call")
+        strikes = [c["strike"] for c in out["atm_contracts"]]
+        self.assertEqual(strikes, sorted(strikes))
+        self.assertEqual(len(strikes), 5)
+        self.assertNotIn(150.0, strikes)  # far strike excluded from ATM-5
+        self.assertNotIn(0.0, strikes)    # zero strikes filtered entirely
+        self.assertEqual(out["total_open_interest"], 3751)
+        self.assertEqual(out["total_volume"], 375)  # NaN volume counted as 0
+        self.assertGreater(out["avg_iv_pct"], 0)
+
+
+# ---------------------------------------------------------------------------
+# Quote + options summary
+# ---------------------------------------------------------------------------
+
+class TestGetStockPrice(PricesServiceTestBase):
+    def arm_gateway(self, price=100.0, expirations=("2026-08-21",)):
+        self.yf.fast_info.return_value = SimpleNamespace(last_price=price, currency="USD")
+        self.yf.expirations.return_value = tuple(expirations)
+        chain_df = TestSummarizeOptions().chain()
+        self.yf.option_chain.return_value = SimpleNamespace(calls=chain_df, puts=chain_df)
+
+    def test_full_quote_with_bands_and_chain_snapshot_saved(self):
+        self.arm_gateway()
+        with self.with_history(flat(60, 100.0)):
+            out = self.service.get_stock_price("intc")
+        self.assertEqual(out["symbol"], "INTC")
+        self.assertEqual(out["price"], 100.0)
+        self.assertAlmostEqual(out["bollinger_bands"]["middle"], 100.0, places=2)
+        self.assertEqual(out["options"]["expiration"], "2026-08-21")
+        self.assertEqual(out["options"]["put_call_ratio"], 1.0)  # same df both sides
+        self.options.save_snapshot.assert_called_once()
+
+    def test_no_expirations_degrades_to_null_options(self):
+        self.arm_gateway(expirations=())
+        with self.with_history(flat(60)):
+            out = self.service.get_stock_price("INTC")
+        self.assertIsNone(out["options"])
+
+    def test_short_history_means_no_bands(self):
+        self.arm_gateway()
+        with self.with_history(flat(10)):
+            out = self.service.get_stock_price("INTC")
+        self.assertIsNone(out["bollinger_bands"])
+
+    def test_missing_price_raises(self):
+        self.yf.fast_info.return_value = SimpleNamespace(last_price=None)
+        with self.assertRaises(ValueError):
+            self.service.get_stock_price("ZZNONE")
+
+
+# ---------------------------------------------------------------------------
+# Momentum indicators
+# ---------------------------------------------------------------------------
+
+class TestGetRsi(PricesServiceTestBase):
+    def test_monotonic_rally_pins_rsi_at_100(self):
+        with self.with_history(bars(np.linspace(50, 150, 60))):
+            out = self.service.get_rsi("intc")
+        self.assertEqual(out["rsi"], 100.0)
+        self.assertEqual(out["signal"], "overbought")
+        self.assertEqual(out["symbol"], "INTC")
+
+    def test_monotonic_selloff_reads_oversold(self):
+        with self.with_history(bars(np.linspace(150, 50, 60))):
+            out = self.service.get_rsi("INTC")
+        self.assertLess(out["rsi"], 5)
+        self.assertEqual(out["signal"], "oversold")
+
+    def test_invalid_interval_rejected(self):
+        with self.assertRaises(ValueError):
+            self.service.get_rsi("INTC", interval="5m")
+
+    def test_insufficient_data_rejected(self):
+        with self.with_history(flat(10)):
+            with self.assertRaises(ValueError):
+                self.service.get_rsi("INTC", period=14)
+
+
+class TestGetMacd(PricesServiceTestBase):
+    def test_sustained_uptrend_reads_bullish(self):
+        with self.with_history(bars(np.linspace(80, 120, 80))):
+            out = self.service.get_macd("INTC")
+        self.assertTrue(out["crossover"].startswith("bullish"), out["crossover"])
+        self.assertGreater(out["macd"], out["signal"])
+
+    def test_sustained_downtrend_reads_bearish(self):
+        with self.with_history(bars(np.linspace(120, 80, 80))):
+            out = self.service.get_macd("INTC")
+        self.assertTrue(out["crossover"].startswith("bearish"), out["crossover"])
+
+    def test_v_bottom_produces_a_bullish_crossover_event(self):
+        closes = list(np.linspace(120, 90, 60)) + list(np.linspace(90, 112, 12))
+        with self.with_history(bars(closes)):
+            out = self.service.get_macd("INTC")
+        self.assertTrue(out["crossover"].startswith("bullish"), out["crossover"])
+
+    def test_insufficient_data_rejected(self):
+        with self.with_history(flat(20)):
+            with self.assertRaises(ValueError):
+                self.service.get_macd("INTC")
+
+
+class TestGetStochastic(PricesServiceTestBase):
+    def test_close_at_window_high_is_overbought(self):
+        closes = list(np.linspace(90, 100, 40))
+        df = bars(closes, highs=[c + 0.5 for c in closes], lows=[c - 0.5 for c in closes])
+        with self.with_history(df):
+            out = self.service.get_stochastic("INTC")
+        self.assertGreater(out["k"], 80)
+        self.assertEqual(out["signal"], "overbought")
+
+    def test_close_at_window_low_is_oversold(self):
+        closes = list(np.linspace(100, 90, 40))
+        df = bars(closes, highs=[c + 0.5 for c in closes], lows=[c - 0.5 for c in closes])
+        with self.with_history(df):
+            out = self.service.get_stochastic("INTC")
+        self.assertLess(out["k"], 20)
+        self.assertEqual(out["signal"], "oversold")
+
+    def test_insufficient_data_rejected(self):
+        with self.with_history(flat(10)):
+            with self.assertRaises(ValueError):
+                self.service.get_stochastic("INTC")
+
+
+# ---------------------------------------------------------------------------
+# Volume studies
+# ---------------------------------------------------------------------------
+
+class TestGetVolumeAnalysis(PricesServiceTestBase):
+    def test_quiet_tape_reports_no_signal(self):
+        with self.with_history(flat(60)):
+            out = self.service.get_volume_analysis("INTC")
+        self.assertEqual(out["climax_events"], [])
+        self.assertTrue(out["bottom_signal"].startswith("none"))
+
+    def test_capitulation_bar_with_quiet_follow_through_detected(self):
+        n = 60
+        closes = [100.0] * (n - 2) + [88.0, 88.5]
+        opens = [99.9] * (n - 2) + [100.0, 88.4]
+        highs = [100.2] * (n - 2) + [100.5, 88.9]
+        lows = [99.8] * (n - 2) + [87.0, 88.0]
+        volumes = [1_000_000.0] * (n - 2) + [3_500_000.0, 300_000.0]
+        df = bars(closes, volumes=volumes, opens=opens, highs=highs, lows=lows)
+        with self.with_history(df):
+            out = self.service.get_volume_analysis("INTC")
+        self.assertGreaterEqual(len(out["climax_events"]), 1)
+        event = out["climax_events"][0]
+        self.assertEqual(event["direction"], "down")
+        self.assertTrue(event["quiet_follow_through"])
+        self.assertIn("capitulation", out["bottom_signal"])
+
+
+class TestGetObv(PricesServiceTestBase):
+    def test_accumulation_under_falling_price_is_bullish_divergence(self):
+        closes, volumes = [], []
+        price = 100.0
+        for i in range(60):
+            if i % 2 == 0:
+                price -= 1.0   # down days: light volume
+                volumes.append(200_000.0)
+            else:
+                price += 0.4   # up days: heavy volume -> OBV rises
+                volumes.append(5_000_000.0)
+            closes.append(price)
+        with self.with_history(bars(closes, volumes=volumes)):
+            out = self.service.get_obv("INTC")
+        self.assertEqual(out["divergence"], "bullish")
+        self.assertEqual(out["obv_trend"], "rising")
+        self.assertEqual(out["price_trend"], "falling")
+        self.assertIn("divergence", out["interpretation"].lower())
+        self.assertEqual(len(out["recent_bars"]), 10)
+
+    def test_confirming_uptrend_reports_no_divergence(self):
+        with self.with_history(bars(np.linspace(90, 110, 60))):
+            out = self.service.get_obv("INTC")
+        self.assertEqual(out["divergence"], "none")
+        self.assertIn("confirming price uptrend", out["interpretation"])
+
+
+# ---------------------------------------------------------------------------
+# VWAP
+# ---------------------------------------------------------------------------
+
+class TestGetVwap(PricesServiceTestBase):
+    def test_constant_tape_sits_exactly_on_vwap(self):
+        df = flat(40, 100.0, opens=[100.0] * 40, highs=[100.0] * 40, lows=[100.0] * 40)
+        with self.with_history(df):
+            out = self.service.get_vwap("INTC")
+        self.assertEqual(out["vwap"], 100.0)
+        self.assertEqual(out["distance_pct"], 0.0)
+        self.assertEqual(out["position"], "above_vwap")  # close >= vwap
+
+    def test_high_volume_reclaim_held_two_bars_is_strong(self):
+        n = 40
+        closes = [90.0] * (n - 3) + [95.0, 95.5, 96.0]
+        volumes = [1_000_000.0] * (n - 3) + [2_500_000.0, 1_200_000.0, 1_100_000.0]
+        df = bars(closes, volumes=volumes,
+                  opens=closes, highs=[c + 0.2 for c in closes], lows=[c - 0.2 for c in closes])
+        with self.with_history(df):
+            out = self.service.get_vwap("INTC")
+        self.assertEqual(out["position"], "above_vwap")
+        self.assertTrue(out["reclaim_signal"])
+        self.assertEqual(out["reclaim_strength"], "strong")
+        self.assertGreaterEqual(out["consecutive_bars_above"], 2)
+        events = [e["type"] for e in out["crossover_events"]]
+        self.assertIn("reclaim", events)
+
+    def test_below_vwap_names_the_bounce_trigger(self):
+        n = 40
+        closes = [100.0] * (n - 5) + [92.0] * 5
+        df = bars(closes, opens=closes,
+                  highs=[c + 0.2 for c in closes], lows=[c - 0.2 for c in closes])
+        with self.with_history(df):
+            out = self.service.get_vwap("INTC")
+        self.assertEqual(out["position"], "below_vwap")
+        self.assertIn("below VWAP", out["interpretation"])
+
+
+class TestGetVwapHistory(PricesServiceTestBase):
+    def test_history_shape_and_positions(self):
+        with self.with_history(flat(80, 100.0)):
+            out = self.service.get_vwap_history("intc", since_days=30)
+        self.assertEqual(out["symbol"], "INTC")
+        self.assertEqual(out["data_points"], 30)
+        self.assertTrue(all(p["position"] == "above_vwap" for p in out["history"]))
+
+    def test_empty_cache_degrades_cleanly(self):
+        with self.with_history(pd.DataFrame()):
+            out = self.service.get_vwap_history("INTC")
+        self.assertEqual(out["history"], [])
+        self.assertIn("error", out)
+
+
+# ---------------------------------------------------------------------------
+# Pattern detection
+# ---------------------------------------------------------------------------
+
+class TestGetCandlestickPatterns(PricesServiceTestBase):
+    def test_flat_tape_finds_no_patterns(self):
+        # Bars with real bodies and no meaningful wicks: no doji/hammer family.
+        n = 60
+        closes = [100.0 + (i % 2) for i in range(n)]
+        opens = [c - 0.8 for c in closes]
+        df = bars(closes, opens=opens,
+                  highs=[max(o, c) + 0.05 for o, c in zip(opens, closes)],
+                  lows=[min(o, c) - 0.05 for o, c in zip(opens, closes)])
+        with self.with_history(df):
+            out = self.service.get_candlestick_patterns("INTC")
+        self.assertEqual(out["pattern_count"], 0)
+        self.assertIn("no reversal pattern", out["bounce_signal"])
+
+    def test_hammer_after_two_down_days_is_bullish(self):
+        n = 60
+        closes = [100.0] * (n - 3) + [97.0, 94.0, 102.0]
+        opens = [99.9] * (n - 3) + [100.0, 97.0, 100.5]
+        highs = [100.2] * (n - 3) + [100.3, 97.2, 102.5]
+        lows = [99.8] * (n - 3) + [96.8, 93.8, 92.5]  # last bar: long lower wick
+        df = bars(closes, opens=opens, highs=highs, lows=lows)
+        with self.with_history(df):
+            out = self.service.get_candlestick_patterns("INTC")
+        patterns = {p["pattern"]: p for p in out["patterns_found"]}
+        self.assertIn("hammer", patterns)
+        self.assertEqual(patterns["hammer"]["bias"], "bullish")
+        self.assertIn("bullish", out["bounce_signal"])
+
+
+class TestGetHigherLows(PricesServiceTestBase):
+    @staticmethod
+    def v_shapes(lows):
+        """Price path carving a V down to each given swing low."""
+        closes = []
+        for low_val in lows:
+            closes += [low_val + 4, low_val + 2, low_val, low_val + 2, low_val + 4]
+        closes += [lows[-1] + 5] * 6
+        return closes
+
+    def test_three_rising_swing_lows_form_the_pattern(self):
+        closes = self.v_shapes([90.0, 91.5, 93.0, 94.5])
+        df = bars(closes, opens=closes,
+                  highs=[c + 0.1 for c in closes], lows=[c - 0.1 for c in closes])
+        with self.with_history(df):
+            out = self.service.get_higher_lows("INTC", interval="1d")
+        self.assertTrue(out["higher_low_pattern"])
+        self.assertGreaterEqual(out["consecutive_higher_lows"], 2)
+        self.assertIn(out["pattern_strength"], {"moderate", "strong"})
+
+    def test_monotonic_tape_reports_insufficient_swings(self):
+        with self.with_history(bars(np.linspace(90, 120, 40))):
+            out = self.service.get_higher_lows("INTC", interval="1d")
+        self.assertFalse(out["higher_low_pattern"])
+        self.assertEqual(out["pattern_strength"], "none")
+
+    def test_invalid_interval_rejected(self):
+        with self.assertRaises(ValueError):
+            self.service.get_higher_lows("INTC", interval="1wk")
+
+
+class TestGetGapAnalysis(PricesServiceTestBase):
+    def test_gap_up_later_spanned_is_filled(self):
+        n = 70
+        closes = [100.0] * (n - 3) + [105.5, 99.0, 99.5]
+        opens = [100.0] * (n - 3) + [105.0, 105.2, 99.2]
+        highs = [100.1] * (n - 3) + [106.0, 105.4, 99.8]
+        lows = [99.9] * (n - 3) + [104.8, 98.5, 98.9]  # bar n-2 spans 100..105
+        df = bars(closes, opens=opens, highs=highs, lows=lows)
+        with self.with_history(df):
+            out = self.service.get_gap_analysis("INTC", min_gap_pct=0.5)
+        self.assertEqual(out["total_gaps_found"], 1)
+        self.assertEqual(out["filled_count"], 1)
+        gap = out["all_gaps"][0]
+        self.assertEqual(gap["direction"], "gap_up")
+        self.assertEqual(gap["fill_status"], "filled")
+
+    def test_unfilled_gap_down_above_price_is_the_bounce_target(self):
+        n = 70
+        closes = [100.0] * (n - 2) + [92.0, 91.5]
+        opens = [100.0] * (n - 2) + [92.5, 91.9]
+        highs = [100.1] * (n - 2) + [93.0, 92.2]
+        lows = [99.9] * (n - 2) + [91.8, 91.2]
+        df = bars(closes, opens=opens, highs=highs, lows=lows)
+        with self.with_history(df):
+            out = self.service.get_gap_analysis("INTC", min_gap_pct=0.5)
+        self.assertEqual(out["unfilled_count"], 1)
+        self.assertIsNotNone(out["nearest_gap_above"])
+        self.assertEqual(out["nearest_gap_above"]["direction"], "gap_down")
+        levels = [t["level"] for t in out["bounce_targets"]]
+        self.assertIn("nearest_unfilled_gap_above", levels)
+
+
+# ---------------------------------------------------------------------------
+# Drawdown / stops
+# ---------------------------------------------------------------------------
+
+class TestGetHistoricalDrawdown(PricesServiceTestBase):
+    def test_engineered_worst_days_measured_exactly(self):
+        closes = [100.0] * 100
+        closes[50] = 92.0            # -8% close-to-close
+        closes[51:56] = [90, 88, 86, 85, 85]
+        df = bars(closes, opens=closes,
+                  highs=[c + 0.1 for c in closes], lows=[c - 0.1 for c in closes])
+        with self.with_history(df):
+            out = self.service.get_historical_drawdown("INTC", lookback_days=100)
+        self.assertEqual(out["max_1day_drawdown_pct"], -8.0)
+        self.assertLessEqual(out["max_5day_drawdown_pct"], -15.0)
+        self.assertGreater(out["trailing_stop_pct"], 8.0)
+        self.assertIn("trailing stop", out["stop_width_note"])
+
+    def test_insufficient_data_rejected(self):
+        with self.with_history(flat(5)):
+            with self.assertRaises(ValueError):
+                self.service.get_historical_drawdown("INTC")
+
+
+# ---------------------------------------------------------------------------
+# REST surfaces
+# ---------------------------------------------------------------------------
+
+class TestRestSurfaces(PricesServiceTestBase):
+    def test_ohlcv_bars_shape(self):
+        with self.with_history(flat(20, 123.4567)):
+            out = self.service.get_ohlcv_bars("intc", days=10)
+        self.assertEqual(out["ticker"], "INTC")
+        self.assertEqual(len(out["bars"]), 10)
+        self.assertEqual(out["bars"][-1]["close"], 123.4567)
+        self.assertEqual(set(out["bars"][0]), {"date", "open", "high", "low", "close", "volume"})
+
+    def test_ohlcv_bars_empty(self):
+        with self.with_history(pd.DataFrame()):
+            self.assertEqual(self.service.get_ohlcv_bars("INTC")["bars"], [])
+
+    def test_technicals_table_carries_indicator_columns(self):
+        # Ramp + oscillation: rsi_series needs both gains AND losses present
+        # (a pure ramp has zero average loss -> NaN RSI by construction).
+        ramp = np.linspace(80, 120, 260) + 2 * np.sin(np.arange(260) / 3)
+        with self.with_history(bars(ramp)):
+            out = self.service.get_technicals_table("INTC", days=250)
+        self.assertEqual(len(out["indicators"]), 250)
+        last = out["indicators"][-1]
+        for key in ("ma10", "ma50", "ma200", "bb_upper", "rsi", "macd", "macd_hist"):
+            self.assertIsNotNone(last[key], key)
+
+    def test_risk_signals_compose_drawdown_and_vwap(self):
+        with patch.object(self.service, "get_historical_drawdown",
+                          return_value={"trailing_stop_pct": 9.9}), \
+             patch.object(self.service, "get_vwap",
+                          return_value={"vwap": 101.0, "position": "above_vwap"}):
+            out = self.service.get_risk_signals("intc")
+        self.assertEqual(out["drawdown"]["trailing_stop_pct"], 9.9)
+        self.assertEqual(out["vwap_position"], "above_vwap")
+
+    def test_risk_signals_degrade_when_drawdown_fails(self):
+        with patch.object(self.service, "get_historical_drawdown",
+                          side_effect=ValueError("thin history")):
+            out = self.service.get_risk_signals("INTC")
+        self.assertIsNone(out["drawdown"])
+        self.assertIn("thin history", out["error"])
+
+    def test_technical_signals_aggregate_and_error_isolation(self):
+        ok = {"fine": True}
+        with patch.object(self.service, "get_stochastic", return_value=ok), \
+             patch.object(self.service, "get_vwap", return_value=ok), \
+             patch.object(self.service, "get_obv", return_value=ok), \
+             patch.object(self.service, "get_volume_analysis", return_value=ok), \
+             patch.object(self.service, "get_candlestick_patterns", return_value=ok), \
+             patch.object(self.service, "get_higher_lows", return_value=ok), \
+             patch.object(self.service, "get_gap_analysis",
+                          side_effect=RuntimeError("gap boom")):
+            out = self.service.get_technical_signals("intc")
+        self.assertEqual(out["ticker"], "INTC")
+        self.assertEqual(out["stochastic"], ok)
+        self.assertIsNone(out["gap_analysis"])
+        self.assertIn("gap boom", out["_errors"]["gap_analysis"])
+
+
+# ---------------------------------------------------------------------------
+# Screener
+# ---------------------------------------------------------------------------
+
+def screener_rows(symbol, closes):
+    return [
+        {"symbol": symbol, "close": float(c), "volume": 1_000_000}
+        for c in closes
+    ]
+
+
+class TestScreenSecurities(PricesServiceTestBase):
+    PORTFOLIO = [{"symbol": "UPP", "source": "portfolio", "tags": []}]
+    WATCHLIST = [
+        {"symbol": "DWN", "source": "watchlist", "tags": ["dip"]},
+        {"symbol": "UPP", "source": "watchlist", "tags": ["both-tag"]},
+    ]
+
+    def arm(self):
+        self.sentiment.get_all_latest.return_value = {
+            "DWN": {"overall_sentiment": "negative"},
+        }
+        self.ohlcv.daily_bars_for_symbols.return_value = (
+            screener_rows("UPP", np.linspace(80, 120, 60))
+            + screener_rows("DWN", np.linspace(120, 80, 60))
+        )
+
+    def test_rsi_filter_selects_the_oversold_name(self):
+        self.arm()
+        out = self.service.screen_securities(
+            {"rsi_max": 40}, self.PORTFOLIO, [dict(s) for s in self.WATCHLIST]
+        )
+        self.assertEqual(out["count"], 1)
+        row = out["results"][0]
+        self.assertEqual(row["symbol"], "DWN")
+        self.assertLess(row["rsi"], 40)
+        self.assertEqual(row["news_sentiment"], "negative")
+
+    def test_above_ma50_selects_the_uptrend_and_marks_dual_source(self):
+        self.arm()
+        out = self.service.screen_securities(
+            {"above_ma50": True}, self.PORTFOLIO, [dict(s) for s in self.WATCHLIST]
+        )
+        self.assertEqual(out["count"], 1)
+        row = out["results"][0]
+        self.assertEqual(row["symbol"], "UPP")
+        self.assertEqual(row["source"], "both")
+        self.assertGreater(row["last_close"], row["ma50"])
+
+    def test_source_filter_watchlist_only(self):
+        self.arm()
+        out = self.service.screen_securities(
+            {"source": "watchlist"}, self.PORTFOLIO, [dict(s) for s in self.WATCHLIST]
+        )
+        self.assertEqual({r["symbol"] for r in out["results"]}, {"UPP", "DWN"})
+
+    def test_sentiment_filter(self):
+        self.arm()
+        out = self.service.screen_securities(
+            {"news_sentiment": "negative"}, self.PORTFOLIO, [dict(s) for s in self.WATCHLIST]
+        )
+        self.assertEqual([r["symbol"] for r in out["results"]], ["DWN"])
+
+    def test_thin_history_symbols_are_skipped(self):
+        self.sentiment.get_all_latest.return_value = {}
+        self.ohlcv.daily_bars_for_symbols.return_value = screener_rows(
+            "UPP", np.linspace(80, 120, 10)  # < 30 bars
+        )
+        out = self.service.screen_securities({}, self.PORTFOLIO, [])
+        self.assertEqual(out["count"], 0)
+
+    def test_no_symbols_short_circuits(self):
+        out = self.service.screen_securities({"source": "portfolio"}, [], [])
+        self.assertEqual(out, {"results": [], "count": 0})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_sentiment_service.py
+++ b/test_sentiment_service.py
@@ -1,0 +1,267 @@
+"""Unit tests for SentimentService / NewsCollector / feed parsers.
+
+Coverage uplift (July 2026). No network and no model loads: the FinBERT
+lazy-loader globals are pinned per-test (transformers IS installed in dev,
+so an unpatched probe would download the real model), RSS bytes are served
+from an in-memory XML document, and yfinance payloads are literal dicts in
+both the new nested-content and legacy flat shapes.
+"""
+import unittest
+from unittest.mock import Mock, patch
+
+from quantcore.services import sentiment as sentiment_mod
+from quantcore.services.sentiment import (
+    NewsCollector,
+    SentimentService,
+    _fetch_rss,
+    _fetch_yfinance_news,
+    _text_for_scoring,
+)
+
+RSS_XML = b"""<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"><channel>
+  <title>Yahoo! Finance: INTC News</title>
+  <item>
+    <title>Intel wins foundry deal</title>
+    <link>https://example.com/a1</link>
+    <description>Big contract.</description>
+    <pubDate>Mon, 13 Jul 2026 12:00:00 GMT</pubDate>
+  </item>
+  <item>
+    <title>Chips rally</title>
+    <link>https://example.com/a2</link>
+  </item>
+</channel></rss>
+"""
+
+
+def finbert_pinned(available: bool):
+    """Pin the lazy-loader verdict so no test can trigger a real model load."""
+    return patch.object(sentiment_mod, "_finbert_available", available)
+
+
+class TestTextForScoring(unittest.TestCase):
+    def test_title_and_summary_joined(self):
+        self.assertEqual(
+            _text_for_scoring({"title": "T", "summary": "S"}), "T. S"
+        )
+
+    def test_title_only(self):
+        self.assertEqual(_text_for_scoring({"title": "T", "summary": None}), "T")
+
+
+class TestFetchRss(unittest.TestCase):
+    def test_parses_feed_items(self):
+        fake_resp = Mock()
+        fake_resp.read.return_value = RSS_XML
+        fake_resp.__enter__ = lambda s: fake_resp
+        fake_resp.__exit__ = lambda s, *a: False
+        with patch.object(sentiment_mod, "urlopen", return_value=fake_resp):
+            articles = _fetch_rss("INTC")
+        self.assertEqual(len(articles), 2)
+        first = articles[0]
+        self.assertEqual(first["title"], "Intel wins foundry deal")
+        self.assertEqual(first["url"], "https://example.com/a1")
+        self.assertEqual(first["source"], "rss")
+        self.assertIn("2026-07-13", first["published_at"])
+        self.assertIn("INTC", first["publisher"])
+        # Second item has no pubDate — survives with published_at=None.
+        self.assertIsNone(articles[1]["published_at"])
+
+    def test_network_failure_returns_empty(self):
+        with patch.object(sentiment_mod, "urlopen", side_effect=OSError("down")):
+            self.assertEqual(_fetch_rss("INTC"), [])
+
+
+class TestFetchYfinanceNews(unittest.TestCase):
+    def test_new_style_payload(self):
+        gateway = Mock()
+        gateway.news.return_value = [{
+            "id": "x",
+            "content": {
+                "title": "Headline",
+                "summary": "Body",
+                "pubDate": "2026-07-10T09:00:00Z",
+                "clickThroughUrl": {"url": "https://example.com/n1"},
+                "provider": {"displayName": "Reuters"},
+            },
+        }]
+        out = _fetch_yfinance_news("INTC", gateway)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0]["url"], "https://example.com/n1")
+        self.assertEqual(out[0]["publisher"], "Reuters")
+        self.assertEqual(out[0]["published_at"], "2026-07-10T09:00:00Z")
+        self.assertEqual(out[0]["source"], "yfinance")
+
+    def test_legacy_payload_and_unix_timestamp(self):
+        gateway = Mock()
+        gateway.news.return_value = [{
+            "title": "Old style",
+            "link": "https://example.com/legacy",
+            "providerPublishTime": 1_750_000_000,
+        }]
+        out = _fetch_yfinance_news("INTC", gateway)
+        self.assertEqual(out[0]["url"], "https://example.com/legacy")
+        self.assertTrue(out[0]["published_at"].startswith("2025-06-15"))
+
+    def test_urlless_items_skipped_and_gateway_errors_swallowed(self):
+        gateway = Mock()
+        gateway.news.return_value = [{"content": {"title": "no url"}}]
+        self.assertEqual(_fetch_yfinance_news("INTC", gateway), [])
+        gateway.news.side_effect = RuntimeError("boom")
+        self.assertEqual(_fetch_yfinance_news("INTC", gateway), [])
+
+
+class TestNewsCollector(unittest.TestCase):
+    def make(self):
+        store = Mock()
+        store.save_articles.return_value = 3
+        return NewsCollector(store=store, gateway=Mock()), store
+
+    def test_collect_merges_sources_and_counts_inserts(self):
+        collector, store = self.make()
+        with patch.object(sentiment_mod, "_fetch_rss", return_value=[{"t": 1}]), \
+             patch.object(sentiment_mod, "_fetch_yfinance_news", return_value=[{"t": 2}]), \
+             patch.object(collector, "score_unscored") as score:
+            totals = collector.collect(["intc"], score=False)
+        self.assertEqual(totals, {"INTC": 3})
+        args, _ = store.save_articles.call_args
+        self.assertEqual(args[0], "INTC")
+        self.assertEqual(len(args[1]), 2)  # rss + yfinance merged
+        score.assert_not_called()
+
+    def test_collect_scores_when_asked(self):
+        collector, _ = self.make()
+        with patch.object(sentiment_mod, "_fetch_rss", return_value=[]), \
+             patch.object(sentiment_mod, "_fetch_yfinance_news", return_value=[]), \
+             patch.object(collector, "score_unscored") as score:
+            collector.collect(["INTC"], score=True)
+        score.assert_called_once()
+
+    def test_score_unscored_no_articles(self):
+        collector, store = self.make()
+        store.get_unscored_articles.return_value = []
+        self.assertEqual(collector.score_unscored(), 0)
+
+    def test_score_unscored_finbert_unavailable(self):
+        collector, store = self.make()
+        store.get_unscored_articles.return_value = [{"article_id": 1, "title": "x"}]
+        with finbert_pinned(False):
+            self.assertEqual(collector.score_unscored(), 0)
+        store.update_sentiment.assert_not_called()
+
+    def test_score_unscored_scores_and_survives_update_failures(self):
+        collector, store = self.make()
+        store.get_unscored_articles.return_value = [
+            {"article_id": 1, "title": "good news", "summary": "s"},
+            {"article_id": 2, "title": "  ", "summary": ""},   # empty text: skipped
+            {"article_id": 3, "title": "bad db row", "summary": "s"},
+        ]
+        store.update_sentiment.side_effect = [None, RuntimeError("db hiccup")]
+        result = {
+            "sentiment": "positive", "sentiment_score": 0.9,
+            "positive_score": 0.9, "negative_score": 0.05, "neutral_score": 0.05,
+        }
+        with finbert_pinned(True), \
+             patch.object(sentiment_mod, "_score_text", return_value=result):
+            scored = collector.score_unscored()
+        self.assertEqual(scored, 1)  # one clean, one skipped, one failed update
+        self.assertEqual(store.update_sentiment.call_count, 2)
+
+
+class SentimentServiceTestBase(unittest.TestCase):
+    def setUp(self):
+        self.news = Mock()
+        self.snapshots = Mock()
+        self.yf = Mock()
+        self.service = SentimentService(
+            news_repository=self.news,
+            sentiment_repository=self.snapshots,
+            yfinance_gateway=self.yf,
+        )
+
+
+class TestServiceSurfaces(SentimentServiceTestBase):
+    def test_collect_news_reports_counts_and_capabilities(self):
+        self.news.article_count.return_value = 12
+        with patch.object(self.service._collector, "collect", return_value={"INTC": 4}):
+            out = self.service.collect_news("intc", score=False)
+        self.assertEqual(out["symbol"], "INTC")
+        self.assertEqual(out["new_articles"], 4)
+        self.assertEqual(out["total_articles"], 12)
+        self.assertTrue(out["rss_available"])       # feedparser installed in dev
+        self.assertIn("finbert_available", out)
+
+    def test_get_news_sentiment_slims_articles(self):
+        self.news.get_sentiment_summary.return_value = {"symbol": "INTC", "signal": "neutral"}
+        self.news.get_articles.return_value = [{
+            "article_id": 1, "title": "T", "publisher": "P",
+            "published_at": "2026-07-10", "url": "u",
+            "sentiment": "positive", "sentiment_score": 0.8,
+            "raw_blob": "should not leak",
+        }]
+        out = self.service.get_news_sentiment("intc")
+        self.assertEqual(out["signal"], "neutral")
+        self.assertEqual(
+            set(out["articles"][0]),
+            {"article_id", "title", "publisher", "published_at", "url",
+             "sentiment", "sentiment_score"},
+        )
+
+    def test_trend_and_symbol_listing(self):
+        self.news.get_sentiment_trend.return_value = [{"date": "2026-07-10"}]
+        out = self.service.get_sentiment_trend("intc", days=14)
+        self.assertEqual(out["days"], 14)
+        self.assertEqual(len(out["trend"]), 1)
+
+        self.news.get_symbols.return_value = ["INTC", "WMT"]
+        listing = self.service.list_news_symbols()
+        self.assertEqual(listing["total_symbols"], 2)
+
+
+NEW_STYLE_ITEM = {
+    "content": {
+        "title": "Great quarter",
+        "summary": "Beats estimates",
+        "pubDate": "2026-07-10T09:00:00Z",
+        "provider": {"displayName": "Bloomberg"},
+        "canonicalUrl": {"url": "https://example.com/gq"},
+    }
+}
+
+
+class TestGetNews(SentimentServiceTestBase):
+    def test_without_finbert_notes_the_gap(self):
+        self.yf.news.return_value = [NEW_STYLE_ITEM]
+        with finbert_pinned(False):
+            out = self.service.get_news("intc")
+        self.assertEqual(out["article_count"], 1)
+        self.assertEqual(out["articles"][0]["publisher"], "Bloomberg")
+        self.assertNotIn("sentiment_summary", out)
+        self.assertIn("sentiment_note", out)
+
+    def test_with_finbert_builds_the_summary(self):
+        self.yf.news.return_value = [NEW_STYLE_ITEM, NEW_STYLE_ITEM]
+        scored = {"sentiment": "positive", "sentiment_score": 0.91}
+        with finbert_pinned(True), \
+             patch.object(sentiment_mod, "_score_sentiment", return_value=scored):
+            out = self.service.get_news("INTC")
+        summary = out["sentiment_summary"]
+        self.assertEqual(summary["overall"], "positive")
+        self.assertEqual(summary["positive_count"], 2)
+        self.assertEqual(summary["scored_count"], 2)
+
+    def test_get_security_news_persists_snapshot_best_effort(self):
+        with patch.object(self.service, "get_news", return_value={"symbol": "INTC"}):
+            out = self.service.get_security_news("intc")
+        self.snapshots.save_snapshot.assert_called_once()
+        self.assertEqual(out["symbol"], "INTC")
+
+        self.snapshots.save_snapshot.side_effect = RuntimeError("db away")
+        with patch.object(self.service, "get_news", return_value={"symbol": "INTC"}):
+            out = self.service.get_security_news("INTC")  # must not raise
+        self.assertEqual(out["symbol"], "INTC")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_support_tools_adapters.py
+++ b/test_support_tools_adapters.py
@@ -7,14 +7,28 @@ service and ships the dict verbatim (or the plain ``{"error": str}`` 500), and
 the MCP wrapper translates a tool call into a single ``rest_client.get``.
 No network, no DB — the service registry and REST client are patched.
 """
-import unittest
-from unittest.mock import Mock, patch
+import os
+from pathlib import Path
 
-from fastapi import FastAPI
-from fastapi.testclient import TestClient
+# Swap in the test DSN BEFORE quantcore.db is imported transitively (DB_DSN
+# freezes at import time). This module sorts ahead of the DB-backed suites in
+# unittest discovery, so freezing the prod DSN here would trip db_safety's
+# guard in every one of them (local runs only — CI has no .env).
+_env_file = Path(__file__).parent / ".env"
+if _env_file.exists():
+    for _line in _env_file.read_text().splitlines():
+        if _line.strip().startswith("QUANTCORE_TEST_DB_DSN="):
+            os.environ["QUANTCORE_DB_DSN"] = _line.split("=", 1)[1].strip()
+            break
 
-from api.routers import prices as prices_router
-from fastMCPTest import stock_price_server
+import unittest  # noqa: E402
+from unittest.mock import Mock, patch  # noqa: E402
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from api.routers import prices as prices_router  # noqa: E402
+from fastMCPTest import stock_price_server  # noqa: E402
 
 
 def make_client():


### PR DESCRIPTION
## What happened

Two independent issues from yesterday's merge session, both invisible in CI:

1. **The coverage waves never reached main.** #90/#91/#92 show *Merged* — but into their stacked **base branches**, which outlived #89's merge (GitHub only retargets child PRs when the base branch is deleted). The 184 wave tests and the floor ratchets have been sitting in orphaned branches; main still had floor 37 and none of the suites. This PR restores the seven test files verbatim from `test/coverage-uplift-wave3` — **all 420 tests pass** against current main, including #94's `find_swings` refactor of `get_higher_lows` (nice regression-safety validation for both sides).

2. **#94's new test modules trip `db_safety` locally.** `test_anchored_vwap` sorts ahead of `test_api_smoke` in unittest discovery and imports `PricesService` at module scope, freezing `quantcore.db`'s DSN at prod before any override runs — the guard then correctly refuses to load every DB-backed suite (5 module errors, 213 of ~420 tests running). CI can't see it (no `.env`); every local `unittest discover` was broken. Fixed with the standard test-DSN preamble in all three files.

## Numbers

Combined main + waves + #94: **66.5%** backend coverage → floor set to **65** (was 37).

## Process note for the team

When merging stacked PRs: **merge top-down, or enable/perform base-branch deletion on each merge** so GitHub retargets the children to main. Otherwise a child "merges" into a dead branch and the work silently vanishes from main while showing purple in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)