### PR TITLE
BYOK packet 1a: envelope crypto v1 (Python) + keypair script + shared vectors

### DIFF
--- a/docs/proposals/byok-key-proxy-plan.md
+++ b/docs/proposals/byok-key-proxy-plan.md
@@ -723,8 +723,8 @@ the context):
 
 | Packet | What | Status | Commit |
 |--------|------|--------|--------|
-| 0 | This proposal doc + GitHub issue #100 with the phase checklist (rides with packet 1a's commit) | ☐ | |
-| 1a | Python envelope crypto + keypair script + shared test vectors (`keyproxy/crypto.py`, `scripts/generate_keyproxy_keypair.py`, `tests/vectors/keyproxy_envelope_v1.json`) | ☐ | |
+| 0 | This proposal doc + GitHub issue #100 with the phase checklist (rides with packet 1a's commit) | ✅ 2026-07-16 | PR #101 (`b74c651`) |
+| 1a | Python envelope crypto + keypair script + shared test vectors (`keyproxy/crypto.py`, `scripts/generate_keyproxy_keypair.py`, `tests/vectors/keyproxy_envelope_v1.json`) | ✅ 2026-07-17 | (this packet's PR) |
 | 1b | TypeScript envelope crypto proven against the same vectors (`frontend/src/vault/envelope.ts`, SPKI pin check) | ☐ | |
 | 2a | Keyproxy core modules: `auth.py`, `replay.py`, `sessions.py`, `scopes.py` + unit tests (incl. `test_replay_race`, budget exhaustion) | ☐ | |
 | 2b | Keyproxy app: factory, publickey/validate/sessions endpoints, Anthropic provider (taxonomy), correlation ids, never-log test | ☐ | |

--- a/keyproxy/__init__.py
+++ b/keyproxy/__init__.py
@@ -1,0 +1,5 @@
+"""BYOK Key Proxy — the only service that ever sees a plaintext user API key.
+
+See docs/proposals/byok-key-proxy-plan.md. Packet 1a ships the envelope
+crypto (crypto.py); the FastAPI app and provider modules land in Phase 2+.
+"""

--- a/keyproxy/crypto.py
+++ b/keyproxy/crypto.py
@@ -1,0 +1,333 @@
+"""Envelope crypto (v1) for the BYOK Key Proxy.
+
+Implements the load-bearing contract in docs/proposals/byok-key-proxy-plan.md
+("Envelope spec (v1)"): ephemeral-static ECDH on P-256 -> HKDF-SHA256 ->
+AES-256-GCM, with the envelope's ``aad`` object bound into the GCM tag as
+canonical JSON.
+
+The browser (``frontend/src/vault/envelope.ts``, packet 1b) is the production
+encryptor; the encrypt path in this module exists to generate and verify the
+shared test vectors (``tests/vectors/keyproxy_envelope_v1.json``) that pin the
+two implementations to byte-identical output.
+
+Cross-runtime canonicalization contract (pinned by the vectors):
+  * canonical JSON = keys sorted, separators ``,``/``:`` with no whitespace,
+    minimal escaping (``ensure_ascii=False`` / plain ``JSON.stringify``),
+    encoded as UTF-8
+  * object keys must be ASCII — JS sorts keys by UTF-16 code unit and Python
+    by code point, which diverge above the BMP, so non-ASCII keys are rejected
+  * numbers must be integers — float formatting diverges between the runtimes
+  * HKDF salt is empty, which per RFC 5869 both ``cryptography`` (salt=None)
+    and WebCrypto (empty ArrayBuffer) expand to HashLen zero bytes
+
+Logging policy (see the plan's "Logging policy" section): nothing in this
+module logs, and every rejection raises :class:`EnvelopeError` with the same
+constant, generic message — which check failed, AAD values, envelope contents,
+and plaintext keys never appear in exception text.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import hmac
+import json
+import os
+import time
+from typing import Mapping, Optional
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+ENVELOPE_VERSION = 1
+ENVELOPE_ALG = "ECDH-ES-P256+HKDF-SHA256+A256GCM"
+HKDF_INFO_PREFIX = "quantcore-keyproxy-v1|"
+IV_LENGTH = 12
+GCM_TAG_LENGTH = 16
+UNCOMPRESSED_POINT_LENGTH = 65  # 0x04 || X (32 bytes) || Y (32 bytes)
+DEFAULT_MAX_IAT_SKEW_SECONDS = 60
+
+_ENVELOPE_KEYS = frozenset({"v", "alg", "kid", "epk", "iv", "ct", "aad"})
+_AAD_KEYS = frozenset({"sub", "provider", "iat", "jti", "scope_hash"})
+
+# Single generic rejection message: a failed decrypt must not reveal which
+# check failed (the plan mandates a generic 400 with no body logging).
+_REJECT = "invalid envelope"
+
+
+class EnvelopeError(ValueError):
+    """Any envelope rejection. The message is always the same generic text."""
+
+
+# --- b64url (unpadded, strict) ----------------------------------------------
+
+def b64url_encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def b64url_decode(value: str) -> bytes:
+    if (
+        not isinstance(value, str)
+        or "=" in value
+        or "+" in value
+        or "/" in value
+    ):
+        raise EnvelopeError(_REJECT)
+    padding = -len(value) % 4
+    try:
+        return base64.urlsafe_b64decode(value + "=" * padding)
+    except (ValueError, binascii.Error):
+        raise EnvelopeError(_REJECT) from None
+
+
+# --- canonical JSON + scope hashing ------------------------------------------
+
+def canonical_json(obj: object) -> bytes:
+    """Canonical JSON bytes, byte-identical to the TS canonicalizer.
+
+    Rejects (fail closed) anything the cross-runtime contract cannot carry:
+    non-ASCII object keys, floats/NaN/Infinity, and non-JSON types.
+    """
+    _check_canonical_value(obj)
+    return json.dumps(
+        obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _check_canonical_value(value: object) -> None:
+    if value is None or isinstance(value, (bool, str)):
+        return
+    if isinstance(value, int):
+        return
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if not isinstance(key, str) or not key.isascii():
+                raise EnvelopeError(_REJECT)
+            _check_canonical_value(item)
+        return
+    if isinstance(value, list):
+        for item in value:
+            _check_canonical_value(item)
+        return
+    raise EnvelopeError(_REJECT)  # floats and any non-JSON type
+
+
+def compute_scope_hash(scope: dict) -> str:
+    """b64url SHA-256 of the scope's canonical JSON (the ``aad.scope_hash``)."""
+    return b64url_encode(hashlib.sha256(canonical_json(scope)).digest())
+
+
+# --- P-256 key material -------------------------------------------------------
+
+def generate_private_key() -> ec.EllipticCurvePrivateKey:
+    return ec.generate_private_key(ec.SECP256R1())
+
+
+def private_key_to_pem(private_key: ec.EllipticCurvePrivateKey) -> str:
+    return private_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode("ascii")
+
+
+def load_private_key_pem(pem: str) -> ec.EllipticCurvePrivateKey:
+    key = serialization.load_pem_private_key(pem.encode("ascii"), password=None)
+    if not isinstance(key, ec.EllipticCurvePrivateKey) or not isinstance(
+        key.curve, ec.SECP256R1
+    ):
+        raise EnvelopeError(_REJECT)
+    return key
+
+
+def public_key_to_pem(public_key: ec.EllipticCurvePublicKey) -> str:
+    return public_key.public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode("ascii")
+
+
+def public_key_spki_der(public_key: ec.EllipticCurvePublicKey) -> bytes:
+    return public_key.public_bytes(
+        serialization.Encoding.DER,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+
+def spki_fingerprint(public_key: ec.EllipticCurvePublicKey) -> str:
+    """b64url SHA-256 of the SPKI DER — the ``VITE_KEYPROXY_SPKI_PINS`` format."""
+    return b64url_encode(hashlib.sha256(public_key_spki_der(public_key)).digest())
+
+
+def public_key_to_uncompressed_point(public_key: ec.EllipticCurvePublicKey) -> bytes:
+    return public_key.public_bytes(
+        serialization.Encoding.X962,
+        serialization.PublicFormat.UncompressedPoint,
+    )
+
+
+# JWK helpers: WebCrypto's native key format, used by the shared vectors so
+# packet 1b can import the exact same pinned keys with crypto.subtle.
+
+def private_key_to_jwk(private_key: ec.EllipticCurvePrivateKey) -> dict:
+    numbers = private_key.private_numbers()
+    public = numbers.public_numbers
+    return {
+        "kty": "EC",
+        "crv": "P-256",
+        "d": b64url_encode(numbers.private_value.to_bytes(32, "big")),
+        "x": b64url_encode(public.x.to_bytes(32, "big")),
+        "y": b64url_encode(public.y.to_bytes(32, "big")),
+    }
+
+
+def private_key_from_jwk(jwk: dict) -> ec.EllipticCurvePrivateKey:
+    if jwk.get("kty") != "EC" or jwk.get("crv") != "P-256":
+        raise EnvelopeError(_REJECT)
+    secret = int.from_bytes(b64url_decode(jwk["d"]), "big")
+    return ec.derive_private_key(secret, ec.SECP256R1())
+
+
+def public_key_from_jwk(jwk: dict) -> ec.EllipticCurvePublicKey:
+    if jwk.get("kty") != "EC" or jwk.get("crv") != "P-256":
+        raise EnvelopeError(_REJECT)
+    x = int.from_bytes(b64url_decode(jwk["x"]), "big")
+    y = int.from_bytes(b64url_decode(jwk["y"]), "big")
+    return ec.EllipticCurvePublicNumbers(x, y, ec.SECP256R1()).public_key()
+
+
+# --- envelope encrypt / decrypt ----------------------------------------------
+
+def _derive_key(shared_secret: bytes, kid: str) -> bytes:
+    return HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=None,  # RFC 5869 empty salt == HashLen zeros; matches WebCrypto
+        info=(HKDF_INFO_PREFIX + kid).encode("utf-8"),
+    ).derive(shared_secret)
+
+
+def _validate_aad(aad: object) -> dict:
+    if not isinstance(aad, dict) or set(aad.keys()) != _AAD_KEYS:
+        raise EnvelopeError(_REJECT)
+    if not all(
+        isinstance(aad[field], str)
+        for field in ("sub", "provider", "jti", "scope_hash")
+    ):
+        raise EnvelopeError(_REJECT)
+    if not isinstance(aad["iat"], int) or isinstance(aad["iat"], bool):
+        raise EnvelopeError(_REJECT)
+    return aad
+
+
+def encrypt_envelope(
+    api_key: str,
+    recipient_public_key: ec.EllipticCurvePublicKey,
+    *,
+    kid: str,
+    aad: dict,
+    ephemeral_private_key: Optional[ec.EllipticCurvePrivateKey] = None,
+    iv: Optional[bytes] = None,
+) -> dict:
+    """Build a v1 envelope.
+
+    Production encryption happens in the browser; this path exists for the
+    shared test vectors and round-trip tests. ``ephemeral_private_key`` and
+    ``iv`` are injectable ONLY so vectors are deterministic — production
+    callers must let both default to fresh random values.
+    """
+    _validate_aad(aad)
+    ephemeral = ephemeral_private_key or generate_private_key()
+    if iv is None:
+        iv = os.urandom(IV_LENGTH)
+    if len(iv) != IV_LENGTH:
+        raise EnvelopeError(_REJECT)
+    shared_secret = ephemeral.exchange(ec.ECDH(), recipient_public_key)
+    key = _derive_key(shared_secret, kid)
+    ciphertext = AESGCM(key).encrypt(
+        iv, api_key.encode("utf-8"), canonical_json(aad)
+    )
+    return {
+        "v": ENVELOPE_VERSION,
+        "alg": ENVELOPE_ALG,
+        "kid": kid,
+        "epk": b64url_encode(public_key_to_uncompressed_point(ephemeral.public_key())),
+        "iv": b64url_encode(iv),
+        "ct": b64url_encode(ciphertext),
+        "aad": dict(aad),
+    }
+
+
+def _timing_safe_equal(a: str, b: str) -> bool:
+    return hmac.compare_digest(a.encode("utf-8"), b.encode("utf-8"))
+
+
+def decrypt_envelope(
+    envelope: object,
+    private_keys: Mapping[str, ec.EllipticCurvePrivateKey],
+    *,
+    expected_sub: str,
+    expected_provider: str,
+    scope: dict,
+    now: Optional[int] = None,
+    max_iat_skew: int = DEFAULT_MAX_IAT_SKEW_SECONDS,
+) -> str:
+    """Verify and decrypt a v1 envelope; returns the plaintext API key.
+
+    Every failure — malformed structure, unknown ``kid``, stale ``iat``,
+    ``sub``/``provider`` mismatch, ``scope_hash`` not matching the
+    accompanying ``scope``, invalid point, GCM authentication failure —
+    raises :class:`EnvelopeError` with the same generic message.
+
+    ``jti`` single-use burning is session-layer state (packet 2a): the caller
+    must burn ``envelope["aad"]["jti"]`` only after this returns successfully.
+    """
+    try:
+        if not isinstance(envelope, dict) or set(envelope.keys()) != _ENVELOPE_KEYS:
+            raise EnvelopeError(_REJECT)
+        if envelope["v"] != ENVELOPE_VERSION or envelope["alg"] != ENVELOPE_ALG:
+            raise EnvelopeError(_REJECT)
+        kid = envelope["kid"]
+        if not isinstance(kid, str):
+            raise EnvelopeError(_REJECT)
+        private_key = private_keys.get(kid)
+        if private_key is None:
+            raise EnvelopeError(_REJECT)
+
+        aad = _validate_aad(envelope["aad"])
+        current = int(time.time()) if now is None else now
+        if abs(current - aad["iat"]) > max_iat_skew:
+            raise EnvelopeError(_REJECT)
+        if not _timing_safe_equal(aad["sub"], expected_sub):
+            raise EnvelopeError(_REJECT)
+        if not _timing_safe_equal(aad["provider"], expected_provider):
+            raise EnvelopeError(_REJECT)
+        if not _timing_safe_equal(aad["scope_hash"], compute_scope_hash(scope)):
+            raise EnvelopeError(_REJECT)
+
+        epk = b64url_decode(envelope["epk"])
+        if len(epk) != UNCOMPRESSED_POINT_LENGTH or epk[0] != 0x04:
+            raise EnvelopeError(_REJECT)
+        iv = b64url_decode(envelope["iv"])
+        if len(iv) != IV_LENGTH:
+            raise EnvelopeError(_REJECT)
+        ciphertext = b64url_decode(envelope["ct"])
+        if len(ciphertext) <= GCM_TAG_LENGTH:
+            raise EnvelopeError(_REJECT)
+
+        peer = ec.EllipticCurvePublicKey.from_encoded_point(ec.SECP256R1(), epk)
+        shared_secret = private_key.exchange(ec.ECDH(), peer)
+        key = _derive_key(shared_secret, kid)
+        plaintext = AESGCM(key).decrypt(iv, ciphertext, canonical_json(aad))
+        return plaintext.decode("utf-8")
+    except EnvelopeError:
+        raise
+    except Exception:
+        # Fail closed on anything unexpected (bad point encoding, InvalidTag,
+        # type errors from hostile input). `from None` drops the original
+        # exception so no library detail about the envelope leaks upward.
+        raise EnvelopeError(_REJECT) from None

--- a/keyproxy/requirements.txt
+++ b/keyproxy/requirements.txt
@@ -1,0 +1,10 @@
+# Key Proxy service dependencies. Dockerfile.keyproxy (packet 2c) installs
+# THIS file only — the proxy container does not get requirements-base.txt,
+# and quantcore-api never gains `cryptography` (the envelope private-key
+# material and the code that can touch it stay confined to this service).
+fastapi>=0.110.0
+uvicorn[standard]>=0.29.0
+httpx>=0.27.0
+PyJWT>=2.8.0
+cryptography>=42.0.0
+anthropic>=0.40.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,7 @@
 -r requirements-base.txt
 coverage
 diff-cover
+# test_keyproxy_crypto.py needs the envelope crypto's `cryptography` lib; the
+# keyproxy service pins it in keyproxy/requirements.txt, and quantcore-api's
+# image never gains it (requirements-base.txt stays cryptography-free).
+cryptography>=42.0.0

--- a/scripts/generate_keyproxy_keypair.py
+++ b/scripts/generate_keyproxy_keypair.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Generate a Key Proxy P-256 keypair and print it — this script NEVER writes.
+
+The private key must exist in exactly two places: this terminal (briefly) and
+Secret Manager. Pipe it straight in, per the runbook in
+docs/proposals/byok-key-proxy-plan.md (packet 8b):
+
+    python scripts/generate_keyproxy_keypair.py            # random kid
+    python scripts/generate_keyproxy_keypair.py --kid kp-2026-07-a
+
+The output contains:
+  * the private key PEM (PKCS8)   -> `gcloud secrets versions add keyproxy-private-key`
+  * the public key PEM            -> served by GET /v1/publickey
+  * the kid                       -> names the key in envelopes' `kid` field
+  * the SPKI fingerprint          -> add to the frontend pin list
+                                     (VITE_KEYPROXY_SPKI_PINS, packet 1b+)
+
+Rotation is dual-pin: ship a frontend release carrying old+new fingerprints,
+add the new PEM to the secret bundle, drop the old pin in the next release.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from keyproxy.crypto import (  # noqa: E402
+    generate_private_key,
+    private_key_to_pem,
+    public_key_to_pem,
+    spki_fingerprint,
+)
+
+
+def default_kid() -> str:
+    stamp = datetime.date.today().strftime("%Y-%m")
+    return f"kp-{stamp}-{os.urandom(2).hex()}"
+
+
+def render(kid: str | None = None) -> str:
+    """Build the full output text. Pure — generates a keypair, writes nothing."""
+    kid = kid or default_kid()
+    private_key = generate_private_key()
+    public_key = private_key.public_key()
+    return "\n".join(
+        [
+            f"kid: {kid}",
+            f"spki_fingerprint (VITE_KEYPROXY_SPKI_PINS entry): {spki_fingerprint(public_key)}",
+            "",
+            "public key (served by GET /v1/publickey):",
+            public_key_to_pem(public_key).rstrip(),
+            "",
+            "PRIVATE key — pipe into Secret Manager, do not save to disk:",
+            "  (e.g. rerun as: python scripts/generate_keyproxy_keypair.py \\",
+            "        | gcloud secrets versions add keyproxy-private-key --data-file=-)",
+            private_key_to_pem(private_key).rstrip(),
+        ]
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--kid",
+        default=None,
+        help="key id to print alongside the pair (default: kp-YYYY-MM-<4 hex>)",
+    )
+    args = parser.parse_args(argv)
+    print(render(args.kid))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test_keyproxy_crypto.py
+++ b/test_keyproxy_crypto.py
@@ -1,0 +1,316 @@
+"""Packet 1a tests: envelope crypto v1 (keyproxy/crypto.py).
+
+Covers the shared vector file (tests/vectors/keyproxy_envelope_v1.json) that
+packet 1b's TypeScript implementation must match byte-exactly, the tamper
+cases from the plan's Verify contract (flipped AAD byte, wrong kid, stale
+iat, altered scope vs scope_hash), and the never-log policy: every rejection
+carries the same generic message with no envelope or key material in it.
+"""
+
+import copy
+import json
+import os
+import subprocess
+import sys
+import unittest
+
+from keyproxy import crypto
+
+VECTORS_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "tests", "vectors", "keyproxy_envelope_v1.json",
+)
+
+with open(VECTORS_PATH, encoding="utf-8") as _fh:
+    VECTORS = json.load(_fh)
+
+RECIPIENT_KEY = crypto.private_key_from_jwk(VECTORS["recipient"]["private_jwk"])
+KID = VECTORS["recipient"]["kid"]
+PRIVATE_KEYS = {KID: RECIPIENT_KEY}
+
+
+_VECTOR_ENVELOPE = object()  # sentinel: "use the case's own envelope"
+
+
+def decrypt_vector(env_case, envelope=_VECTOR_ENVELOPE, **overrides):
+    kwargs = dict(
+        expected_sub=env_case["expected_sub"],
+        expected_provider=env_case["expected_provider"],
+        scope=env_case["scope"],
+        now=env_case["aad"]["iat"],
+    )
+    kwargs.update(overrides)
+    if envelope is _VECTOR_ENVELOPE:
+        envelope = env_case["envelope"]
+    return crypto.decrypt_envelope(envelope, PRIVATE_KEYS, **kwargs)
+
+
+class TestCanonicalJson(unittest.TestCase):
+    def test_vector_canonical_forms(self):
+        for case in VECTORS["canonicalization"]:
+            with self.subTest(case["name"]):
+                self.assertEqual(
+                    crypto.canonical_json(case["input"]).decode("utf-8"),
+                    case["canonical"],
+                )
+                self.assertEqual(
+                    crypto.compute_scope_hash(case["input"]), case["scope_hash"]
+                )
+
+    def test_key_order_is_irrelevant(self):
+        a = {"b": 1, "a": {"y": 2, "x": 3}}
+        b = {"a": {"x": 3, "y": 2}, "b": 1}
+        self.assertEqual(crypto.canonical_json(a), crypto.canonical_json(b))
+
+    def test_rejects_floats(self):
+        with self.assertRaises(crypto.EnvelopeError):
+            crypto.canonical_json({"ttl": 300.0})
+
+    def test_rejects_non_ascii_keys(self):
+        # JS sorts keys by UTF-16 code unit, Python by code point; they
+        # diverge above the BMP, so the contract bans non-ASCII keys.
+        with self.assertRaises(crypto.EnvelopeError):
+            crypto.canonical_json({"clé": 1})
+
+    def test_rejects_non_json_types(self):
+        with self.assertRaises(crypto.EnvelopeError):
+            crypto.canonical_json({"raw": b"bytes"})
+
+    def test_non_ascii_values_stay_literal_utf8(self):
+        canon = crypto.canonical_json({"k": "ünïcödé 💹"})
+        self.assertEqual(canon, '{"k":"ünïcödé 💹"}'.encode("utf-8"))
+
+
+class TestB64Url(unittest.TestCase):
+    def test_round_trip(self):
+        blob = os.urandom(37)
+        self.assertEqual(crypto.b64url_decode(crypto.b64url_encode(blob)), blob)
+
+    def test_no_padding_emitted(self):
+        self.assertNotIn("=", crypto.b64url_encode(b"\x00"))
+
+    def test_rejects_padded_or_standard_alphabet(self):
+        for bad in ("AA==", "a+b", "a/b"):
+            with self.subTest(bad):
+                with self.assertRaises(crypto.EnvelopeError):
+                    crypto.b64url_decode(bad)
+
+
+class TestVectorEnvelopes(unittest.TestCase):
+    def test_reencryption_reproduces_pinned_ciphertext(self):
+        # The determinism proof: pinned ephemeral key + iv + aad must yield
+        # the exact epk/ct in the file — the same bar packet 1b must clear.
+        for case in VECTORS["envelopes"]:
+            with self.subTest(case["name"]):
+                rebuilt = crypto.encrypt_envelope(
+                    case["api_key"],
+                    RECIPIENT_KEY.public_key(),
+                    kid=KID,
+                    aad=case["aad"],
+                    ephemeral_private_key=crypto.private_key_from_jwk(
+                        case["ephemeral_private_jwk"]
+                    ),
+                    iv=crypto.b64url_decode(case["iv"]),
+                )
+                self.assertEqual(rebuilt, case["envelope"])
+
+    def test_decrypt_recovers_api_key(self):
+        for case in VECTORS["envelopes"]:
+            with self.subTest(case["name"]):
+                self.assertEqual(decrypt_vector(case), case["api_key"])
+
+    def test_fresh_random_round_trip(self):
+        scope = VECTORS["envelopes"][0]["scope"]
+        aad = {
+            "sub": "alice", "provider": "anthropic", "iat": 1752570000,
+            "jti": "11111111-2222-4333-8444-555555555555",
+            "scope_hash": crypto.compute_scope_hash(scope),
+        }
+        envelope = crypto.encrypt_envelope(
+            "sk-ant-round-trip", RECIPIENT_KEY.public_key(), kid=KID, aad=aad
+        )
+        got = crypto.decrypt_envelope(
+            envelope, PRIVATE_KEYS, expected_sub="alice",
+            expected_provider="anthropic", scope=scope, now=aad["iat"],
+        )
+        self.assertEqual(got, "sk-ant-round-trip")
+
+    def test_iat_boundary_accepted(self):
+        case = VECTORS["envelopes"][0]
+        for skew in (-60, 60):
+            with self.subTest(skew=skew):
+                self.assertEqual(
+                    decrypt_vector(case, now=case["aad"]["iat"] + skew),
+                    case["api_key"],
+                )
+
+
+class TestTamperFailsClosed(unittest.TestCase):
+    """Every case must raise EnvelopeError — and nothing else."""
+
+    def setUp(self):
+        self.case = VECTORS["envelopes"][0]
+
+    def assert_rejected(self, envelope=_VECTOR_ENVELOPE, **overrides):
+        with self.assertRaises(crypto.EnvelopeError) as ctx:
+            decrypt_vector(self.case, envelope=envelope, **overrides)
+        return ctx.exception
+
+    def tampered(self, **changes):
+        envelope = copy.deepcopy(self.case["envelope"])
+        for key, value in changes.items():
+            envelope[key] = value
+        return envelope
+
+    def test_flipped_aad_byte(self):
+        envelope = copy.deepcopy(self.case["envelope"])
+        envelope["aad"]["sub"] = "johm"  # one byte off
+        # AAD no longer matches expected_sub *and* breaks the GCM tag;
+        # also verify pure AAD/GCM failure with expected_sub matching the lie.
+        self.assert_rejected(envelope=envelope)
+        self.assert_rejected(envelope=envelope, expected_sub="johm")
+
+    def test_flipped_ciphertext_byte(self):
+        raw = bytearray(crypto.b64url_decode(self.case["envelope"]["ct"]))
+        raw[0] ^= 0x01
+        self.assert_rejected(envelope=self.tampered(ct=crypto.b64url_encode(bytes(raw))))
+
+    def test_truncated_tag(self):
+        raw = crypto.b64url_decode(self.case["envelope"]["ct"])[:-1]
+        self.assert_rejected(envelope=self.tampered(ct=crypto.b64url_encode(raw)))
+
+    def test_wrong_kid_unknown(self):
+        self.assert_rejected(envelope=self.tampered(kid="kp-9999-01-nope"))
+
+    def test_wrong_kid_known_but_different_key(self):
+        # A registered second key must still fail: kid feeds the HKDF info
+        # string and selects the wrong private scalar.
+        other = crypto.generate_private_key()
+        envelope = self.tampered(kid="kp-other")
+        with self.assertRaises(crypto.EnvelopeError):
+            crypto.decrypt_envelope(
+                envelope, {KID: RECIPIENT_KEY, "kp-other": other},
+                expected_sub=self.case["expected_sub"],
+                expected_provider=self.case["expected_provider"],
+                scope=self.case["scope"], now=self.case["aad"]["iat"],
+            )
+
+    def test_stale_iat(self):
+        for skew in (61, -61, 3600):
+            with self.subTest(skew=skew):
+                self.assert_rejected(now=self.case["aad"]["iat"] + skew)
+
+    def test_altered_scope_vs_scope_hash(self):
+        scope = copy.deepcopy(self.case["scope"])
+        scope["budget"]["max_tokens"] = 10**9  # privilege escalation attempt
+        self.assert_rejected(scope=scope)
+
+    def test_sub_mismatch(self):
+        self.assert_rejected(expected_sub="mallory")
+
+    def test_provider_mismatch(self):
+        self.assert_rejected(expected_provider="openai")
+
+    def test_wrong_version_or_alg(self):
+        self.assert_rejected(envelope=self.tampered(v=2))
+        self.assert_rejected(envelope=self.tampered(alg="ECDH-ES-X25519"))
+
+    def test_structure_violations(self):
+        extra = self.tampered()
+        extra["extra"] = "field"
+        self.assert_rejected(envelope=extra)
+        missing = self.tampered()
+        del missing["iv"]
+        self.assert_rejected(envelope=missing)
+        self.assert_rejected(envelope="not-a-dict")
+        self.assert_rejected(envelope=None)
+
+    def test_aad_violations(self):
+        for aad_change in (
+            {"iat": "1752570000"},   # string, not int
+            {"iat": True},           # bool masquerading as int
+            {"sub": 42},
+            {"scope_hash": None},
+        ):
+            aad = dict(self.case["aad"], **aad_change)
+            with self.subTest(aad_change=aad_change):
+                self.assert_rejected(envelope=self.tampered(aad=aad))
+        no_jti = dict(self.case["aad"])
+        del no_jti["jti"]
+        self.assert_rejected(envelope=self.tampered(aad=no_jti))
+        extra_key = dict(self.case["aad"], hacker="yes")
+        self.assert_rejected(envelope=self.tampered(aad=extra_key))
+
+    def test_bad_epk(self):
+        self.assert_rejected(envelope=self.tampered(epk=crypto.b64url_encode(b"\x04" + b"\x00" * 64)))
+        self.assert_rejected(envelope=self.tampered(epk=crypto.b64url_encode(b"\x02" + os.urandom(64))))
+        self.assert_rejected(envelope=self.tampered(epk=crypto.b64url_encode(os.urandom(32))))
+        self.assert_rejected(envelope=self.tampered(epk="not base64url!!"))
+
+    def test_bad_iv_length(self):
+        self.assert_rejected(envelope=self.tampered(iv=crypto.b64url_encode(os.urandom(16))))
+
+
+class TestNeverLogPolicy(unittest.TestCase):
+    """Rejections must be generic: no key material, no envelope contents,
+    no hint of which check failed, no chained library exception."""
+
+    def collect_failures(self):
+        case = VECTORS["envelopes"][0]
+        failures = []
+        tampered = copy.deepcopy(case["envelope"])
+        tampered["aad"]["sub"] = "evil"
+        for kwargs in (
+            dict(envelope=tampered),
+            dict(now=case["aad"]["iat"] + 999),
+            dict(expected_provider="openai"),
+            dict(scope={"v": 1, "altered": True}),
+        ):
+            try:
+                decrypt_vector(case, **kwargs)
+                self.fail("expected rejection")
+            except crypto.EnvelopeError as exc:
+                failures.append(exc)
+        return case, failures
+
+    def test_all_rejections_are_generic_and_unchained(self):
+        case, failures = self.collect_failures()
+        for exc in failures:
+            self.assertEqual(str(exc), "invalid envelope")
+            self.assertIsNone(exc.__cause__)
+            text = repr(exc) + str(exc.args)
+            self.assertNotIn(case["api_key"], text)
+            self.assertNotIn(case["envelope"]["ct"], text)
+            self.assertNotIn(case["envelope"]["epk"], text)
+            self.assertNotIn("sk-ant", text)
+
+
+class TestKeypairScript(unittest.TestCase):
+    def test_prints_pair_and_writes_nothing(self):
+        repo_root = os.path.dirname(os.path.abspath(__file__))
+        before = set(os.listdir(repo_root))
+        proc = subprocess.run(
+            [sys.executable, os.path.join("scripts", "generate_keyproxy_keypair.py"),
+             "--kid", "kp-test-unit"],
+            cwd=repo_root, capture_output=True, text=True, check=True,
+        )
+        self.assertEqual(set(os.listdir(repo_root)), before)
+        out = proc.stdout
+        self.assertIn("kid: kp-test-unit", out)
+        self.assertIn("spki_fingerprint", out)
+        self.assertIn("BEGIN PUBLIC KEY", out)
+        self.assertIn("BEGIN PRIVATE KEY", out)
+
+    def test_render_generates_fresh_keys_each_call(self):
+        sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "scripts"))
+        try:
+            import generate_keyproxy_keypair as script
+        finally:
+            sys.path.pop(0)
+        first, second = script.render("kp-a"), script.render("kp-a")
+        self.assertNotEqual(first, second)
+        self.assertTrue(script.default_kid().startswith("kp-"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/vectors/keyproxy_envelope_v1.json
+++ b/tests/vectors/keyproxy_envelope_v1.json
@@ -1,0 +1,247 @@
+{
+  "description": "Shared envelope-v1 test vectors for the BYOK Key Proxy (docs/proposals/byok-key-proxy-plan.md). keyproxy/crypto.py and frontend/src/vault/envelope.ts must both reproduce every value here byte-exactly. API keys are fake vector strings, never real secrets.",
+  "alg": "ECDH-ES-P256+HKDF-SHA256+A256GCM",
+  "hkdf_info_prefix": "quantcore-keyproxy-v1|",
+  "iat": 1752570000,
+  "recipient": {
+    "kid": "kp-2026-07-vector",
+    "private_jwk": {
+      "kty": "EC",
+      "crv": "P-256",
+      "d": "sQj5VzZ5yhsrseCjcyaCnHcXO56QGz3VoFi8zluPYhs",
+      "x": "zcoKS8PKgA1pnQPADT_Mzvj1yvCdRD3cz2bzm7uwadQ",
+      "y": "PJY_j_Yv7ocF539UF7Tpyi7yQ5K_PIn2NOklEEUoWEs"
+    },
+    "public_jwk": {
+      "kty": "EC",
+      "crv": "P-256",
+      "x": "zcoKS8PKgA1pnQPADT_Mzvj1yvCdRD3cz2bzm7uwadQ",
+      "y": "PJY_j_Yv7ocF539UF7Tpyi7yQ5K_PIn2NOklEEUoWEs"
+    },
+    "spki_fingerprint": "KFV3qFhY6qvtDXmib9V0MADtU03NjivNq2a-mGGZCL8"
+  },
+  "canonicalization": [
+    {
+      "name": "chat-turn-default-scope",
+      "input": {
+        "v": 1,
+        "provider": "anthropic",
+        "action": "chat.turn",
+        "params": {},
+        "budget": {
+          "max_calls": 20,
+          "max_mutations": 0,
+          "max_tokens": 250000,
+          "ttl": 300
+        }
+      },
+      "canonical": "{\"action\":\"chat.turn\",\"budget\":{\"max_calls\":20,\"max_mutations\":0,\"max_tokens\":250000,\"ttl\":300},\"params\":{},\"provider\":\"anthropic\",\"v\":1}",
+      "scope_hash": "4QuJH0p9u69yTHNWJELTPB9rsdpqAc_KhxlVOmscDQY"
+    },
+    {
+      "name": "unsorted-and-nested-keys",
+      "input": {
+        "zeta": {
+          "b": 2,
+          "a": 1
+        },
+        "alpha": [
+          1,
+          2,
+          {
+            "y": true,
+            "x": null
+          }
+        ],
+        "Mid": "m"
+      },
+      "canonical": "{\"Mid\":\"m\",\"alpha\":[1,2,{\"x\":null,\"y\":true}],\"zeta\":{\"a\":1,\"b\":2}}",
+      "scope_hash": "PndLB5ksnS3HIPYqieoWT1scqOX6jp7na4IvMb25lKM"
+    },
+    {
+      "name": "non-ascii-values",
+      "input": {
+        "label": "jöhn's naïve ünïcödé key ✓",
+        "emoji": "💹📈 non-BMP",
+        "cjk": "株式ポートフォリオ",
+        "seps": "line and paragraph separators stay literal"
+      },
+      "canonical": "{\"cjk\":\"株式ポートフォリオ\",\"emoji\":\"💹📈 non-BMP\",\"label\":\"jöhn's naïve ünïcödé key ✓\",\"seps\":\"line and paragraph separators stay literal\"}",
+      "scope_hash": "AAZ6--t-hsTt3WaFRI3zvwBmI9qpywofad3_j_0fhKU"
+    },
+    {
+      "name": "escape-sequences",
+      "input": {
+        "quotes": "she said \"hi\" \\ backslash / slash",
+        "controls": "tab\there\nnewline\rcr\bbs\fff",
+        "low-controls": "nul\u0000unitsep\u001f"
+      },
+      "canonical": "{\"controls\":\"tab\\there\\nnewline\\rcr\\bbs\\fff\",\"low-controls\":\"nul\\u0000unitsep\\u001f\",\"quotes\":\"she said \\\"hi\\\" \\\\ backslash / slash\"}",
+      "scope_hash": "FmRuRQux9uEgad9VbIqKue9wSgbdBGkriWrddYs4-Og"
+    },
+    {
+      "name": "empty-and-scalar-edges",
+      "input": {
+        "empty_str": "",
+        "empty_obj": {},
+        "empty_list": [],
+        "null": null,
+        "true": true,
+        "false": false,
+        "big_int": 9007199254740991
+      },
+      "canonical": "{\"big_int\":9007199254740991,\"empty_list\":[],\"empty_obj\":{},\"empty_str\":\"\",\"false\":false,\"null\":null,\"true\":true}",
+      "scope_hash": "cd7GMmKlPa-9c3ZTS_JqVN_uEgONXgKVeDXpU0iYg1s"
+    }
+  ],
+  "envelopes": [
+    {
+      "name": "basic-chat-turn",
+      "api_key": "sk-ant-api03-TEST-VECTOR-not-a-real-key-0000000000000000",
+      "expected_sub": "john",
+      "expected_provider": "anthropic",
+      "scope": {
+        "v": 1,
+        "provider": "anthropic",
+        "action": "chat.turn",
+        "params": {},
+        "budget": {
+          "max_calls": 20,
+          "max_mutations": 0,
+          "max_tokens": 250000,
+          "ttl": 300
+        }
+      },
+      "ephemeral_private_jwk": {
+        "kty": "EC",
+        "crv": "P-256",
+        "d": "zG6lEAIkrpA9ir5pyU5TBKa4ol46yCCut6ds8HL2Q4I",
+        "x": "enVBZYd3WR2SnxfeCVp1LtAECz0FIxwjfBs76LNEMb0",
+        "y": "n4I1cDD_fRhEbTv5FhFbivPEtZk6Lc6YBYX3oOH74Jg"
+      },
+      "iv": "kUK8765pdWB3APBk",
+      "aad": {
+        "sub": "john",
+        "provider": "anthropic",
+        "iat": 1752570000,
+        "jti": "5f0d3b1c-9a52-4e0f-8f0e-2f4f6a1c9d10",
+        "scope_hash": "4QuJH0p9u69yTHNWJELTPB9rsdpqAc_KhxlVOmscDQY"
+      },
+      "envelope": {
+        "v": 1,
+        "alg": "ECDH-ES-P256+HKDF-SHA256+A256GCM",
+        "kid": "kp-2026-07-vector",
+        "epk": "BHp1QWWHd1kdkp8X3gladS7QBAs9BSMcI3wbO-izRDG9n4I1cDD_fRhEbTv5FhFbivPEtZk6Lc6YBYX3oOH74Jg",
+        "iv": "kUK8765pdWB3APBk",
+        "ct": "k4AHxYQ_BY5FYt6ljYmK-9OzyZajFdVMcB7TZ2dRf8Vdu9plGQ1oFUsvoSCE9BsLHfQKuuogSxmnw39SSue6oRaeDEG75mKr",
+        "aad": {
+          "sub": "john",
+          "provider": "anthropic",
+          "iat": 1752570000,
+          "jti": "5f0d3b1c-9a52-4e0f-8f0e-2f4f6a1c9d10",
+          "scope_hash": "4QuJH0p9u69yTHNWJELTPB9rsdpqAc_KhxlVOmscDQY"
+        }
+      }
+    },
+    {
+      "name": "non-ascii-scope-and-sub",
+      "api_key": "sk-ant-api03-TEST-VECTOR-ünïcödé-💹-0000000000000000",
+      "expected_sub": "jöhn@ünïcöde.example",
+      "expected_provider": "anthropic",
+      "scope": {
+        "v": 1,
+        "provider": "anthropic",
+        "action": "chat.turn",
+        "params": {
+          "note": "非ASCII ✓ 💹 sep"
+        },
+        "budget": {
+          "max_calls": 8,
+          "max_mutations": 0,
+          "max_tokens": 100000,
+          "ttl": 300
+        }
+      },
+      "ephemeral_private_jwk": {
+        "kty": "EC",
+        "crv": "P-256",
+        "d": "3h0MIVGxkahIugr9mKIBhlFgFxNcOvL0L9xxp3f40o8",
+        "x": "Zv35nLe3XxC8e6jDLiReHR0HIg2FXR0qc8ZlGhdPJPk",
+        "y": "OKJ1yMyBP_UpClIxUGjw34jb6chmpxRwTn9enoBh_oQ"
+      },
+      "iv": "tnNDyhcmT-npvguP",
+      "aad": {
+        "sub": "jöhn@ünïcöde.example",
+        "provider": "anthropic",
+        "iat": 1752570000,
+        "jti": "0b7a9c44-6a1d-4d2b-b7f3-9d8e5c3a2b19",
+        "scope_hash": "dibMwgVXD7uE9lwgk-SKlXSevHS5zfrhPVa2vkxf8q8"
+      },
+      "envelope": {
+        "v": 1,
+        "alg": "ECDH-ES-P256+HKDF-SHA256+A256GCM",
+        "kid": "kp-2026-07-vector",
+        "epk": "BGb9-Zy3t18QvHuowy4kXh0dByINhV0dKnPGZRoXTyT5OKJ1yMyBP_UpClIxUGjw34jb6chmpxRwTn9enoBh_oQ",
+        "iv": "tnNDyhcmT-npvguP",
+        "ct": "LrVXdNN-l_AyceLVA0BwKmfIkVE_JAiU9BupmGkWuoImYjyQs2knstHDV7DBaOOLgRiA4Or2P7YKpGsLcUl5Qym0ZN05aDQfr8Y",
+        "aad": {
+          "sub": "jöhn@ünïcöde.example",
+          "provider": "anthropic",
+          "iat": 1752570000,
+          "jti": "0b7a9c44-6a1d-4d2b-b7f3-9d8e5c3a2b19",
+          "scope_hash": "dibMwgVXD7uE9lwgk-SKlXSevHS5zfrhPVa2vkxf8q8"
+        }
+      }
+    },
+    {
+      "name": "escape-heavy-scope",
+      "api_key": "sk-ant-api03-TEST-VECTOR-escapes-0000000000000000",
+      "expected_sub": "john",
+      "expected_provider": "anthropic",
+      "scope": {
+        "v": 1,
+        "provider": "anthropic",
+        "action": "chat.turn",
+        "params": {
+          "memo": "quote \" backslash \\ newline \n tab \t nul \u0000 esc \u001b"
+        },
+        "budget": {
+          "max_calls": 20,
+          "max_mutations": 0,
+          "max_tokens": 250000,
+          "ttl": 300
+        }
+      },
+      "ephemeral_private_jwk": {
+        "kty": "EC",
+        "crv": "P-256",
+        "d": "y9bwlVbVgZYu7k7_hJRgS7YQRO60mYuw1fBLyiNYVf8",
+        "x": "vMRyA5p4XZB6x1oKgqUjVSh6ReiEZTgQPQKenGJltUo",
+        "y": "2K9vSRtSvnhSyC4LppJyWKF1V_IovP5Rw7xdAVVhwtQ"
+      },
+      "iv": "oleKrfISTFAK22Vz",
+      "aad": {
+        "sub": "john",
+        "provider": "anthropic",
+        "iat": 1752570000,
+        "jti": "e2c1a0f9-3d4b-45c6-a7d8-1b2c3d4e5f60",
+        "scope_hash": "yAB60s9ROfwSSSO-LFKARGHKfQo_lUwGtD4mtnr2P4Y"
+      },
+      "envelope": {
+        "v": 1,
+        "alg": "ECDH-ES-P256+HKDF-SHA256+A256GCM",
+        "kid": "kp-2026-07-vector",
+        "epk": "BLzEcgOaeF2QesdaCoKlI1UoekXohGU4ED0CnpxiZbVK2K9vSRtSvnhSyC4LppJyWKF1V_IovP5Rw7xdAVVhwtQ",
+        "iv": "oleKrfISTFAK22Vz",
+        "ct": "oXYuZ_DGE0JsziUNNPNnXVaMIieAC0fsAjneKKRvCGl9l0juUuz84-6ANgelF5ib6Q7CrxIcFC_ohZDkUXaLpxM",
+        "aad": {
+          "sub": "john",
+          "provider": "anthropic",
+          "iat": 1752570000,
+          "jti": "e2c1a0f9-3d4b-45c6-a7d8-1b2c3d4e5f60",
+          "scope_hash": "yAB60s9ROfwSSSO-LFKARGHKfQo_lUwGtD4mtnr2P4Y"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
First implementation packet of the BYOK key-proxy plan (#100), per the plan's session protocol (one packet, one commit).

## What

- **`keyproxy/crypto.py`** — envelope spec v1: ephemeral-static **ECDH P-256 → HKDF-SHA256 → AES-256-GCM**, with the `aad` object (`sub`/`provider`/`iat`/`jti`/`scope_hash`) bound into the GCM tag as canonical JSON. `decrypt_envelope` enforces the full rejection list (structure/alg/version, unknown `kid`, `|now−iat| > 60s`, `sub`/`provider` mismatch, `scope_hash` vs the accompanying scope, invalid point, GCM auth) — every failure is the same generic `EnvelopeError("invalid envelope")`, per the never-log policy. `jti` burning is session-layer state and lands in packet 2a.
- **Cross-runtime canonicalization contract** (the part packet 1b must match byte-exactly): sorted keys, no whitespace, minimal escaping, UTF-8; **ASCII-only object keys** (JS sorts by UTF-16 code unit, Python by code point — they diverge above the BMP, so non-ASCII keys are rejected outright) and **integers only** (float formatting diverges). Both constraints fail closed.
- **`tests/vectors/keyproxy_envelope_v1.json`** — pinned recipient + ephemeral JWKs, ivs, aads → expected ciphertexts, including the review-mandated non-ASCII (emoji/CJK/U+2028/U+2029) and escape-sequence (quotes, backslash, control chars, NUL) edge cases in scope/AAD string fields. All API keys in the file are fake vector strings.
- **`scripts/generate_keyproxy_keypair.py`** — prints (never writes) the private/public PEM, `kid`, and SPKI fingerprint for the frontend pin list; designed to be piped straight into `gcloud secrets versions add`.
- **`test_keyproxy_crypto.py`** — 30 tests: vector reproduction (re-encrypting with the pinned ephemeral key + iv reproduces the pinned `epk`/`ct` exactly), decrypt recovery, fresh round-trip, iat boundary, and the Verify contract's tamper cases (flipped AAD byte, wrong kid — both unknown and known-but-different, stale iat, altered scope vs `scope_hash`, flipped/truncated ciphertext, bad points/iv/structure/AAD types), plus a never-log test asserting rejections are generic, unchained, and contain no key or envelope material.

## Deviation flagged (one file outside the packet list)

`requirements-dev.txt` gains `cryptography` — CI's gate job installs only that chain (base has no `cryptography`), so the new test would fail CI without it. It's dev/CI-only: **quantcore-api's image is unchanged** (`requirements-base.txt` stays cryptography-free, per decision that only the keyproxy holds envelope-crypto capability); the keyproxy service pins its own deps in `keyproxy/requirements.txt`.

## Verify (packet 1a exit contract)

- `python -m unittest test_keyproxy_crypto` — 30/30 green.
- Tamper cases fail closed with the generic message.
- Full `unittest discover` shows the **same 34 pre-existing errors as `main`** locally (DB-backed tests needing the local Postgres on :5434, which isn't running); CI provides its own Postgres service. No regressions introduced.
- Vectors file committed with the packet; `keyproxy` is not yet in `.coveragerc` scope (suggest adding it when the service lands in Phase 2).

Next packet: **1b** — TypeScript `envelope.ts` proven byte-exact against these vectors. Issue #100 gets its progress comment when Phase 1 completes (after 1b), per the session protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)