### PR TITLE
BYOK packet 1b: TypeScript envelope crypto proven byte-exact against the shared vectors

### DIFF
--- a/docs/proposals/byok-key-proxy-plan.md
+++ b/docs/proposals/byok-key-proxy-plan.md
@@ -724,8 +724,8 @@ the context):
 | Packet | What | Status | Commit |
 |--------|------|--------|--------|
 | 0 | This proposal doc + GitHub issue #100 with the phase checklist (rides with packet 1a's commit) | ✅ 2026-07-16 | PR #101 (`b74c651`) |
-| 1a | Python envelope crypto + keypair script + shared test vectors (`keyproxy/crypto.py`, `scripts/generate_keyproxy_keypair.py`, `tests/vectors/keyproxy_envelope_v1.json`) | ✅ 2026-07-17 | (this packet's PR) |
-| 1b | TypeScript envelope crypto proven against the same vectors (`frontend/src/vault/envelope.ts`, SPKI pin check) | ☐ | |
+| 1a | Python envelope crypto + keypair script + shared test vectors (`keyproxy/crypto.py`, `scripts/generate_keyproxy_keypair.py`, `tests/vectors/keyproxy_envelope_v1.json`) | ✅ 2026-07-17 | PR #102 (`de85cfb`) |
+| 1b | TypeScript envelope crypto proven against the same vectors (`frontend/src/vault/envelope.ts`, SPKI pin check) | ✅ 2026-07-17 | (this packet's PR) |
 | 2a | Keyproxy core modules: `auth.py`, `replay.py`, `sessions.py`, `scopes.py` + unit tests (incl. `test_replay_race`, budget exhaustion) | ☐ | |
 | 2b | Keyproxy app: factory, publickey/validate/sessions endpoints, Anthropic provider (taxonomy), correlation ids, never-log test | ☐ | |
 | 2c | `Dockerfile.keyproxy` + compose wiring | ☐ | |

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,6 +25,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
+        "@types/node": "^26.1.1",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.3.0",
@@ -2529,6 +2530,16 @@
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
@@ -4744,6 +4755,13 @@
       "engines": {
         "node": ">=20.18.1"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
+    "@types/node": "^26.1.1",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,4 +1,12 @@
 import '@testing-library/jest-dom/vitest';
+import { webcrypto } from 'node:crypto';
+
+// jsdom 29 has no WebCrypto (crypto.subtle); the BYOK envelope crypto in
+// src/vault/envelope.ts is pure crypto.subtle, so tests borrow Node's
+// spec-compliant implementation.
+if (!globalThis.crypto?.subtle) {
+  Object.defineProperty(globalThis, 'crypto', { value: webcrypto, configurable: true });
+}
 
 // jsdom 29 does not provide window.localStorage; the app relies on it for
 // chat/theme/filter persistence, so give tests a spec-faithful in-memory one.

--- a/frontend/src/vault/envelope.test.ts
+++ b/frontend/src/vault/envelope.test.ts
@@ -1,0 +1,304 @@
+/**
+ * BYOK envelope crypto v1 — TypeScript side of the cross-runtime contract.
+ *
+ * Driven by tests/vectors/keyproxy_envelope_v1.json (shared with
+ * test_keyproxy_crypto.py): re-encrypting with each vector's pinned
+ * ephemeral key + IV must reproduce the pinned envelope byte-exactly,
+ * proving TS-encrypt → Python-decrypt without any cross-language plumbing.
+ * All API keys in the vectors are fake strings, never real secrets.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import vectorsRaw from '../../../tests/vectors/keyproxy_envelope_v1.json?raw';
+
+import {
+  ENVELOPE_ALG,
+  ENVELOPE_VERSION,
+  EnvelopeError,
+  HKDF_INFO_PREFIX,
+  IV_LENGTH,
+  UNCOMPRESSED_POINT_LENGTH,
+  b64urlDecode,
+  b64urlEncode,
+  canonicalJson,
+  computeScopeHash,
+  encryptEnvelope,
+  importPinnedPublicKey,
+  pinnedFingerprints,
+  spkiFingerprint,
+  type Envelope,
+  type EnvelopeAad,
+} from './envelope';
+
+interface CanonicalizationVector {
+  name: string;
+  input: unknown;
+  canonical: string;
+  scope_hash: string;
+}
+
+interface EnvelopeVector {
+  name: string;
+  api_key: string;
+  scope: unknown;
+  ephemeral_private_jwk: JsonWebKey;
+  iv: string;
+  aad: EnvelopeAad;
+  envelope: Envelope;
+}
+
+interface Vectors {
+  alg: string;
+  hkdf_info_prefix: string;
+  recipient: {
+    kid: string;
+    private_jwk: JsonWebKey;
+    public_jwk: JsonWebKey;
+    spki_fingerprint: string;
+  };
+  canonicalization: CanonicalizationVector[];
+  envelopes: EnvelopeVector[];
+}
+
+const vectors = JSON.parse(vectorsRaw) as Vectors;
+
+const EC_PARAMS: EcKeyImportParams = { name: 'ECDH', namedCurve: 'P-256' };
+const encoder = new TextEncoder();
+
+async function importRecipientPublicJwk(): Promise<CryptoKey> {
+  return crypto.subtle.importKey('jwk', vectors.recipient.public_jwk, EC_PARAMS, true, []);
+}
+
+async function recipientSpki(): Promise<Uint8Array> {
+  return new Uint8Array(await crypto.subtle.exportKey('spki', await importRecipientPublicJwk()));
+}
+
+/**
+ * Test-only decrypt (mirrors keyproxy/crypto.py) so the random-ephemeral
+ * path can be proven round-trippable inside this suite. Production decrypt
+ * lives exclusively in the Key Proxy.
+ */
+async function decryptWithPrivateJwk(privateJwk: JsonWebKey, envelope: Envelope): Promise<string> {
+  const privateKey = await crypto.subtle.importKey('jwk', privateJwk, EC_PARAMS, false, [
+    'deriveBits',
+  ]);
+  const epkBytes = b64urlDecode(envelope.epk);
+  const epk = await crypto.subtle.importKey('raw', epkBytes as BufferSource, EC_PARAMS, false, []);
+  const sharedSecret = await crypto.subtle.deriveBits({ name: 'ECDH', public: epk }, privateKey, 256);
+  const hkdfKey = await crypto.subtle.importKey('raw', sharedSecret, 'HKDF', false, ['deriveBits']);
+  const aesKeyBits = await crypto.subtle.deriveBits(
+    {
+      name: 'HKDF',
+      hash: 'SHA-256',
+      salt: new Uint8Array(0),
+      info: encoder.encode(HKDF_INFO_PREFIX + envelope.kid) as BufferSource,
+    },
+    hkdfKey,
+    256,
+  );
+  const aesKey = await crypto.subtle.importKey('raw', aesKeyBits, { name: 'AES-GCM' }, false, [
+    'decrypt',
+  ]);
+  const plaintext = await crypto.subtle.decrypt(
+    {
+      name: 'AES-GCM',
+      iv: b64urlDecode(envelope.iv) as BufferSource,
+      additionalData: encoder.encode(canonicalJson(envelope.aad)) as BufferSource,
+    },
+    aesKey,
+    b64urlDecode(envelope.ct) as BufferSource,
+  );
+  return new TextDecoder().decode(plaintext);
+}
+
+describe('canonicalJson', () => {
+  it.each(vectors.canonicalization)('matches the pinned vector: $name', async (vector) => {
+    expect(canonicalJson(vector.input)).toBe(vector.canonical);
+    expect(await computeScopeHash(vector.input)).toBe(vector.scope_hash);
+  });
+
+  it('is independent of key insertion order', () => {
+    expect(canonicalJson({ b: 2, a: 1 })).toBe(canonicalJson({ a: 1, b: 2 }));
+  });
+
+  it('rejects non-integer numbers fail-closed', () => {
+    for (const bad of [1.5, 0.1, NaN, Infinity, -Infinity, 2 ** 53]) {
+      expect(() => canonicalJson({ n: bad })).toThrow(EnvelopeError);
+    }
+  });
+
+  it('rejects non-ASCII object keys fail-closed', () => {
+    expect(() => canonicalJson({ café: 1 })).toThrow(EnvelopeError);
+    expect(() => canonicalJson({ outer: { '💹': 1 } })).toThrow(EnvelopeError);
+  });
+
+  it('rejects non-JSON types fail-closed', () => {
+    expect(() => canonicalJson(undefined)).toThrow(EnvelopeError);
+    expect(() => canonicalJson({ v: undefined })).toThrow(EnvelopeError);
+    expect(() => canonicalJson({ v: 1n })).toThrow(EnvelopeError);
+    expect(() => canonicalJson({ v: () => 1 })).toThrow(EnvelopeError);
+    expect(() => canonicalJson({ v: new Date(0) })).toThrow(EnvelopeError);
+    expect(() => canonicalJson(new Map())).toThrow(EnvelopeError);
+  });
+
+  it('rejects lone surrogates (which cannot UTF-8 encode on the Python side)', () => {
+    expect(() => canonicalJson({ v: '\ud800' })).toThrow(EnvelopeError);
+    expect(() => canonicalJson({ v: 'tail\udc00' })).toThrow(EnvelopeError);
+  });
+});
+
+describe('b64url', () => {
+  it('round-trips arbitrary bytes', () => {
+    const bytes = crypto.getRandomValues(new Uint8Array(41));
+    expect(b64urlDecode(b64urlEncode(bytes))).toEqual(bytes);
+    expect(b64urlEncode(new Uint8Array(0))).toBe('');
+    expect(b64urlDecode('')).toEqual(new Uint8Array(0));
+  });
+
+  it('decodes the vector epk to a 65-byte uncompressed point', () => {
+    const epk = b64urlDecode(vectors.envelopes[0].envelope.epk);
+    expect(epk.length).toBe(UNCOMPRESSED_POINT_LENGTH);
+    expect(epk[0]).toBe(0x04);
+  });
+
+  it('rejects padding, standard-alphabet characters, and bad lengths', () => {
+    for (const bad of ['AA==', 'A+', 'A/', 'A', '!!!']) {
+      expect(() => b64urlDecode(bad)).toThrow(EnvelopeError);
+    }
+  });
+});
+
+describe('SPKI pinning', () => {
+  it('fingerprints the vector recipient key to the pinned value', async () => {
+    expect(await spkiFingerprint(await recipientSpki())).toBe(vectors.recipient.spki_fingerprint);
+  });
+
+  it('parses the comma-separated pin list', () => {
+    expect(pinnedFingerprints(' a , b ,, ')).toEqual(['a', 'b']);
+    expect(pinnedFingerprints('')).toEqual([]);
+    expect(pinnedFingerprints(undefined)).toEqual([]);
+  });
+
+  it('imports a pinned public key and refuses an unpinned one', async () => {
+    const spki = await recipientSpki();
+    const key = await importPinnedPublicKey(spki, [vectors.recipient.spki_fingerprint]);
+    expect(key.type).toBe('public');
+    await expect(importPinnedPublicKey(spki, ['not-the-fingerprint'])).rejects.toThrow(/pin/);
+    await expect(importPinnedPublicKey(spki, [])).rejects.toThrow(EnvelopeError);
+  });
+
+  it('reads pins from VITE_KEYPROXY_SPKI_PINS by default', async () => {
+    const spki = await recipientSpki();
+    vi.stubEnv('VITE_KEYPROXY_SPKI_PINS', `other-pin, ${vectors.recipient.spki_fingerprint}`);
+    try {
+      const key = await importPinnedPublicKey(spki);
+      expect(key.type).toBe('public');
+    } finally {
+      vi.unstubAllEnvs();
+    }
+    // With no env pins configured, everything is refused.
+    await expect(importPinnedPublicKey(spki)).rejects.toThrow(/pin/);
+  });
+});
+
+describe('envelope vectors (the TS-encrypt → Py-decrypt proof)', () => {
+  it.each(vectors.envelopes)(
+    'reproduces the pinned envelope byte-exactly: $name',
+    async (vector) => {
+      expect(await computeScopeHash(vector.scope)).toBe(vector.aad.scope_hash);
+
+      const recipientKey = await importRecipientPublicJwk();
+      const envelope = await encryptEnvelope(vector.api_key, recipientKey, {
+        kid: vectors.recipient.kid,
+        aad: vector.aad,
+        pins: [vectors.recipient.spki_fingerprint],
+        ephemeralPrivateJwk: vector.ephemeral_private_jwk,
+        iv: b64urlDecode(vector.iv),
+      });
+      expect(envelope).toEqual(vector.envelope);
+    },
+  );
+});
+
+describe('encryptEnvelope', () => {
+  const aad: EnvelopeAad = vectors.envelopes[0].aad;
+
+  it('refuses to encrypt to an unpinned recipient key, even a CryptoKey handed in directly', async () => {
+    const recipientKey = await importRecipientPublicJwk();
+    const attempt = (pins: string[] | undefined) =>
+      encryptEnvelope('sk-ant-api03-TEST-unpinned', recipientKey, {
+        kid: vectors.recipient.kid,
+        aad,
+        pins,
+      });
+    await expect(attempt([])).rejects.toThrow(/pin/);
+    await expect(attempt(['not-the-fingerprint'])).rejects.toThrow(/pin/);
+    // No pins option and no VITE_KEYPROXY_SPKI_PINS → refused.
+    await expect(attempt(undefined)).rejects.toThrow(/pin/);
+    // Errors never carry the API key.
+    const error = await attempt([]).catch((e: unknown) => e);
+    expect(String(error)).not.toContain('sk-ant');
+  });
+
+  it('produces a well-formed envelope on the random-ephemeral path, decryptable by the recipient', async () => {
+    const apiKey = 'sk-ant-api03-TEST-VECTOR-random-path-0000000000000000';
+    const recipientKey = await importRecipientPublicJwk();
+    const options = {
+      kid: vectors.recipient.kid,
+      aad,
+      pins: [vectors.recipient.spki_fingerprint],
+    };
+    const envelope = await encryptEnvelope(apiKey, recipientKey, options);
+
+    expect(envelope.v).toBe(ENVELOPE_VERSION);
+    expect(envelope.alg).toBe(ENVELOPE_ALG);
+    expect(envelope.kid).toBe(vectors.recipient.kid);
+    const epk = b64urlDecode(envelope.epk);
+    expect(epk.length).toBe(UNCOMPRESSED_POINT_LENGTH);
+    expect(epk[0]).toBe(0x04);
+    expect(b64urlDecode(envelope.iv).length).toBe(IV_LENGTH);
+    expect(b64urlDecode(envelope.ct).length).toBe(encoder.encode(apiKey).length + 16);
+    expect(envelope.aad).toEqual(aad);
+    expect(envelope.aad).not.toBe(aad);
+
+    // Fresh ephemeral + IV every call — no reuse across envelopes.
+    const second = await encryptEnvelope(apiKey, recipientKey, options);
+    expect(second.epk).not.toBe(envelope.epk);
+    expect(second.iv).not.toBe(envelope.iv);
+    expect(second.ct).not.toBe(envelope.ct);
+
+    expect(await decryptWithPrivateJwk(vectors.recipient.private_jwk, envelope)).toBe(apiKey);
+  });
+
+  it('rejects malformed aad fail-closed', async () => {
+    const recipientKey = await importRecipientPublicJwk();
+    const attempt = (badAad: unknown) =>
+      encryptEnvelope('sk-ant-api03-TEST-aad', recipientKey, {
+        kid: vectors.recipient.kid,
+        aad: badAad as EnvelopeAad,
+        pins: [vectors.recipient.spki_fingerprint],
+      });
+    const { scope_hash: _dropped, ...missingKey } = aad;
+    await expect(attempt(missingKey)).rejects.toThrow(EnvelopeError);
+    await expect(attempt({ ...aad, extra: 'x' })).rejects.toThrow(EnvelopeError);
+    await expect(attempt({ ...aad, iat: 1.5 })).rejects.toThrow(EnvelopeError);
+    await expect(attempt({ ...aad, iat: '1752570000' })).rejects.toThrow(EnvelopeError);
+    await expect(attempt({ ...aad, iat: true })).rejects.toThrow(EnvelopeError);
+    await expect(attempt({ ...aad, sub: 42 })).rejects.toThrow(EnvelopeError);
+    await expect(attempt({ ...aad, jti: null })).rejects.toThrow(EnvelopeError);
+    await expect(attempt(null)).rejects.toThrow(EnvelopeError);
+    await expect(attempt([aad])).rejects.toThrow(EnvelopeError);
+  });
+
+  it('rejects an empty api key, empty kid, and wrong-length iv', async () => {
+    const recipientKey = await importRecipientPublicJwk();
+    const options = { kid: vectors.recipient.kid, aad, pins: [vectors.recipient.spki_fingerprint] };
+    await expect(encryptEnvelope('', recipientKey, options)).rejects.toThrow(EnvelopeError);
+    await expect(
+      encryptEnvelope('sk-ant-api03-TEST', recipientKey, { ...options, kid: '' }),
+    ).rejects.toThrow(EnvelopeError);
+    await expect(
+      encryptEnvelope('sk-ant-api03-TEST', recipientKey, { ...options, iv: new Uint8Array(11) }),
+    ).rejects.toThrow(EnvelopeError);
+  });
+});

--- a/frontend/src/vault/envelope.ts
+++ b/frontend/src/vault/envelope.ts
@@ -1,0 +1,376 @@
+/**
+ * BYOK envelope crypto v1 — the browser (encrypt) half of the cross-runtime
+ * contract in docs/proposals/byok-key-proxy-plan.md ("Envelope spec (v1)").
+ *
+ * The decrypt half lives in keyproxy/crypto.py; both sides are pinned
+ * byte-exact by tests/vectors/keyproxy_envelope_v1.json. Anything that could
+ * make the two runtimes serialize the same value differently is rejected
+ * fail-closed rather than papered over:
+ *
+ *  - object keys must be ASCII (JS sorts keys by UTF-16 code unit, Python by
+ *    code point — they diverge above the BMP);
+ *  - numbers must be integers within the JS safe range (float formatting
+ *    diverges between the runtimes);
+ *  - strings must be well-formed Unicode (lone surrogates cannot UTF-8
+ *    encode on the Python side).
+ *
+ * Pure crypto.subtle — no dependencies. ECDH P-256 → HKDF-SHA256 (empty
+ * salt, per RFC 5869 equal to HashLen zero bytes — WebCrypto's empty
+ * ArrayBuffer matches Python cryptography's salt=None) → AES-256-GCM, with
+ * the canonical AAD JSON as GCM additional data.
+ *
+ * SPKI pinning: the proxy public key reaches the browser through
+ * quantcore-api, so encryptEnvelope refuses any recipient key whose SPKI
+ * fingerprint is not in the build-time pin list (VITE_KEYPROXY_SPKI_PINS) —
+ * a substituted key would otherwise silently collapse the "application sees
+ * ciphertext only" boundary.
+ *
+ * Never-log policy: no error thrown here may carry the API key, envelope
+ * contents, or key material — messages describe structure only.
+ */
+
+export const ENVELOPE_VERSION = 1;
+export const ENVELOPE_ALG = 'ECDH-ES-P256+HKDF-SHA256+A256GCM';
+export const HKDF_INFO_PREFIX = 'quantcore-keyproxy-v1|';
+export const IV_LENGTH = 12;
+export const UNCOMPRESSED_POINT_LENGTH = 65;
+
+const EC_PARAMS: EcKeyImportParams = { name: 'ECDH', namedCurve: 'P-256' };
+const COORDINATE_LENGTH = 32;
+
+/** Thrown for every contract violation; never carries key material. */
+export class EnvelopeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'EnvelopeError';
+  }
+}
+
+export interface EnvelopeAad {
+  sub: string;
+  provider: string;
+  iat: number;
+  jti: string;
+  scope_hash: string;
+}
+
+export interface Envelope {
+  v: number;
+  alg: string;
+  kid: string;
+  epk: string;
+  iv: string;
+  ct: string;
+  aad: EnvelopeAad;
+}
+
+const encoder = new TextEncoder();
+
+// ---------------------------------------------------------------------------
+// b64url (unpadded, strict)
+// ---------------------------------------------------------------------------
+
+export function b64urlEncode(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+export function b64urlDecode(value: string): Uint8Array {
+  if (!/^[A-Za-z0-9_-]*$/.test(value)) {
+    throw new EnvelopeError('b64url value contains invalid characters');
+  }
+  if (value.length % 4 === 1) {
+    throw new EnvelopeError('b64url value has invalid length');
+  }
+  const padded = value.replace(/-/g, '+').replace(/_/g, '/') + '='.repeat((4 - (value.length % 4)) % 4);
+  let binary: string;
+  try {
+    binary = atob(padded);
+  } catch {
+    throw new EnvelopeError('b64url value is not decodable');
+  }
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+// ---------------------------------------------------------------------------
+// Canonical JSON — must produce byte-identical output to
+// keyproxy/crypto.py's canonical_json() for every accepted value.
+// ---------------------------------------------------------------------------
+
+function isWellFormedString(value: string): boolean {
+  for (let i = 0; i < value.length; i++) {
+    const unit = value.charCodeAt(i);
+    if (unit >= 0xd800 && unit <= 0xdbff) {
+      const next = value.charCodeAt(i + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        return false;
+      }
+      i++;
+    } else if (unit >= 0xdc00 && unit <= 0xdfff) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function serializeCanonical(value: unknown, out: string[]): void {
+  if (value === null) {
+    out.push('null');
+    return;
+  }
+  switch (typeof value) {
+    case 'boolean':
+      out.push(value ? 'true' : 'false');
+      return;
+    case 'number':
+      if (!Number.isSafeInteger(value)) {
+        throw new EnvelopeError('canonical JSON numbers must be integers within the safe range');
+      }
+      out.push(JSON.stringify(value));
+      return;
+    case 'string':
+      if (!isWellFormedString(value)) {
+        throw new EnvelopeError('canonical JSON strings must be well-formed Unicode');
+      }
+      out.push(JSON.stringify(value));
+      return;
+    case 'object': {
+      if (Array.isArray(value)) {
+        out.push('[');
+        value.forEach((item, index) => {
+          if (index > 0) out.push(',');
+          serializeCanonical(item, out);
+        });
+        out.push(']');
+        return;
+      }
+      const proto = Object.getPrototypeOf(value);
+      if (proto !== Object.prototype && proto !== null) {
+        throw new EnvelopeError('canonical JSON objects must be plain objects');
+      }
+      const keys = Object.keys(value).sort();
+      out.push('{');
+      keys.forEach((key, index) => {
+        // eslint-disable-next-line no-control-regex
+        if (!/^[\x00-\x7F]*$/.test(key)) {
+          throw new EnvelopeError('canonical JSON object keys must be ASCII');
+        }
+        if (index > 0) out.push(',');
+        out.push(JSON.stringify(key), ':');
+        serializeCanonical((value as Record<string, unknown>)[key], out);
+      });
+      out.push('}');
+      return;
+    }
+    default:
+      throw new EnvelopeError(`canonical JSON cannot contain a ${typeof value}`);
+  }
+}
+
+export function canonicalJson(value: unknown): string {
+  const out: string[] = [];
+  serializeCanonical(value, out);
+  return out.join('');
+}
+
+async function sha256(bytes: Uint8Array): Promise<Uint8Array> {
+  return new Uint8Array(await crypto.subtle.digest('SHA-256', bytes as BufferSource));
+}
+
+/** b64url SHA-256 of the scope's canonical JSON — the aad.scope_hash value. */
+export async function computeScopeHash(scope: unknown): Promise<string> {
+  return b64urlEncode(await sha256(encoder.encode(canonicalJson(scope))));
+}
+
+// ---------------------------------------------------------------------------
+// SPKI pinning
+// ---------------------------------------------------------------------------
+
+/** b64url SHA-256 of a public key's SPKI DER — the VITE_KEYPROXY_SPKI_PINS format. */
+export async function spkiFingerprint(spkiDer: Uint8Array): Promise<string> {
+  return b64urlEncode(await sha256(spkiDer));
+}
+
+/** Parse the comma-separated build-time pin list (default: VITE_KEYPROXY_SPKI_PINS). */
+export function pinnedFingerprints(
+  raw: string | undefined = import.meta.env.VITE_KEYPROXY_SPKI_PINS as string | undefined,
+): string[] {
+  return (raw ?? '')
+    .split(',')
+    .map((pin) => pin.trim())
+    .filter((pin) => pin.length > 0);
+}
+
+/**
+ * Import the Key Proxy public key (SPKI DER, as served by /v1/publickey),
+ * refusing any key whose fingerprint is not pinned. Imported extractable so
+ * encryptEnvelope can independently re-verify the pin.
+ */
+export async function importPinnedPublicKey(
+  spkiDer: Uint8Array,
+  pins: string[] = pinnedFingerprints(),
+): Promise<CryptoKey> {
+  const fingerprint = await spkiFingerprint(spkiDer);
+  if (!pins.includes(fingerprint)) {
+    throw new EnvelopeError('recipient public key is not in the SPKI pin list; refusing to encrypt');
+  }
+  try {
+    return await crypto.subtle.importKey('spki', spkiDer as BufferSource, EC_PARAMS, true, []);
+  } catch {
+    throw new EnvelopeError('recipient public key is not a valid P-256 SPKI key');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Envelope encryption
+// ---------------------------------------------------------------------------
+
+const AAD_KEYS = ['iat', 'jti', 'provider', 'scope_hash', 'sub'] as const;
+
+function validateAad(aad: EnvelopeAad): void {
+  if (typeof aad !== 'object' || aad === null || Array.isArray(aad)) {
+    throw new EnvelopeError('aad must be an object');
+  }
+  const keys = Object.keys(aad).sort();
+  if (keys.length !== AAD_KEYS.length || keys.some((key, i) => key !== AAD_KEYS[i])) {
+    throw new EnvelopeError('aad must contain exactly sub, provider, iat, jti, scope_hash');
+  }
+  for (const field of ['sub', 'provider', 'jti', 'scope_hash'] as const) {
+    if (typeof aad[field] !== 'string') {
+      throw new EnvelopeError(`aad.${field} must be a string`);
+    }
+  }
+  if (typeof aad.iat !== 'number' || !Number.isSafeInteger(aad.iat)) {
+    throw new EnvelopeError('aad.iat must be an integer');
+  }
+}
+
+function concatBytes(...parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((sum, part) => sum + part.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}
+
+function jwkCoordinate(jwk: JsonWebKey, field: 'x' | 'y'): Uint8Array {
+  const value = jwk[field];
+  if (typeof value !== 'string') {
+    throw new EnvelopeError(`ephemeral JWK is missing the ${field} coordinate`);
+  }
+  const bytes = b64urlDecode(value);
+  if (bytes.length !== COORDINATE_LENGTH) {
+    throw new EnvelopeError(`ephemeral JWK ${field} coordinate has the wrong length`);
+  }
+  return bytes;
+}
+
+export interface EncryptEnvelopeOptions {
+  kid: string;
+  aad: EnvelopeAad;
+  /** Overrides the VITE_KEYPROXY_SPKI_PINS pin list (tests). */
+  pins?: string[];
+  /** Deterministic ephemeral key — TEST VECTORS ONLY, never in production. */
+  ephemeralPrivateJwk?: JsonWebKey;
+  /** Deterministic IV — TEST VECTORS ONLY, never in production. */
+  iv?: Uint8Array;
+}
+
+/**
+ * Encrypt an API key to the pinned Key Proxy public key, producing an
+ * envelope-v1 object that keyproxy/crypto.py's decrypt_envelope accepts.
+ */
+export async function encryptEnvelope(
+  apiKey: string,
+  recipientKey: CryptoKey,
+  options: EncryptEnvelopeOptions,
+): Promise<Envelope> {
+  const { kid, aad } = options;
+  if (typeof apiKey !== 'string' || apiKey.length === 0) {
+    throw new EnvelopeError('apiKey must be a non-empty string');
+  }
+  if (typeof kid !== 'string' || kid.length === 0) {
+    throw new EnvelopeError('kid must be a non-empty string');
+  }
+  validateAad(aad);
+
+  // Structural pin check: even a CryptoKey handed in directly is verified,
+  // so there is no code path that encrypts to an unpinned key.
+  const spkiDer = new Uint8Array(await crypto.subtle.exportKey('spki', recipientKey));
+  const fingerprint = await spkiFingerprint(spkiDer);
+  const pins = options.pins ?? pinnedFingerprints();
+  if (!pins.includes(fingerprint)) {
+    throw new EnvelopeError('recipient public key is not in the SPKI pin list; refusing to encrypt');
+  }
+
+  let ephemeralPrivateKey: CryptoKey;
+  let epkBytes: Uint8Array;
+  if (options.ephemeralPrivateJwk !== undefined) {
+    const jwk = options.ephemeralPrivateJwk;
+    try {
+      ephemeralPrivateKey = await crypto.subtle.importKey('jwk', jwk, EC_PARAMS, false, ['deriveBits']);
+    } catch {
+      throw new EnvelopeError('ephemeral JWK is not a valid P-256 private key');
+    }
+    epkBytes = concatBytes(new Uint8Array([0x04]), jwkCoordinate(jwk, 'x'), jwkCoordinate(jwk, 'y'));
+  } else {
+    const pair = await crypto.subtle.generateKey(EC_PARAMS, false, ['deriveBits']);
+    ephemeralPrivateKey = pair.privateKey;
+    epkBytes = new Uint8Array(await crypto.subtle.exportKey('raw', pair.publicKey));
+  }
+  if (epkBytes.length !== UNCOMPRESSED_POINT_LENGTH || epkBytes[0] !== 0x04) {
+    throw new EnvelopeError('ephemeral public key is not an uncompressed P-256 point');
+  }
+
+  const iv = options.iv ?? crypto.getRandomValues(new Uint8Array(IV_LENGTH));
+  if (iv.length !== IV_LENGTH) {
+    throw new EnvelopeError(`iv must be exactly ${IV_LENGTH} bytes`);
+  }
+
+  const sharedSecret = await crypto.subtle.deriveBits(
+    { name: 'ECDH', public: recipientKey },
+    ephemeralPrivateKey,
+    256,
+  );
+  const hkdfKey = await crypto.subtle.importKey('raw', sharedSecret, 'HKDF', false, ['deriveBits']);
+  const aesKeyBits = await crypto.subtle.deriveBits(
+    {
+      name: 'HKDF',
+      hash: 'SHA-256',
+      salt: new Uint8Array(0),
+      info: encoder.encode(HKDF_INFO_PREFIX + kid) as BufferSource,
+    },
+    hkdfKey,
+    256,
+  );
+  const aesKey = await crypto.subtle.importKey('raw', aesKeyBits, { name: 'AES-GCM' }, false, ['encrypt']);
+
+  const aadBytes = encoder.encode(canonicalJson(aad));
+  const ciphertext = new Uint8Array(
+    await crypto.subtle.encrypt(
+      { name: 'AES-GCM', iv: iv as BufferSource, additionalData: aadBytes as BufferSource },
+      aesKey,
+      encoder.encode(apiKey) as BufferSource,
+    ),
+  );
+
+  return {
+    v: ENVELOPE_VERSION,
+    alg: ENVELOPE_ALG,
+    kid,
+    epk: b64urlEncode(epkBytes),
+    iv: b64urlEncode(iv),
+    ct: b64urlEncode(ciphertext),
+    aad: { ...aad },
+  };
+}


### PR DESCRIPTION
Implements **packet 1b** of the BYOK plan ([docs/proposals/byok-key-proxy-plan.md](../blob/main/docs/proposals/byok-key-proxy-plan.md), issue #100). With this, **Phase 1 (envelope crypto, both sides) is complete**.

## What's in it

- **`frontend/src/vault/envelope.ts`** — the browser (encrypt) half of the envelope-v1 contract, pure `crypto.subtle`, zero dependencies:
  - ECDH P-256 → HKDF-SHA256 (empty salt, `info = "quantcore-keyproxy-v1|" + kid`) → AES-256-GCM with the canonical AAD JSON as GCM additional data — mirroring `keyproxy/crypto.py` exactly.
  - Canonical JSON identical to the Python side, with the cross-runtime divergence classes rejected fail-closed: non-ASCII object keys (JS/Python sort divergence above the BMP), non-integer numbers (float formatting divergence), lone-surrogate strings (cannot UTF-8 encode in Python).
  - Strict unpadded b64url helpers; `computeScopeHash` for `aad.scope_hash`.
  - **SPKI pinning**: `encryptEnvelope` exports and re-fingerprints the recipient `CryptoKey` itself against `VITE_KEYPROXY_SPKI_PINS` (or an explicit pin list), so there is **no code path that encrypts to an unpinned key** — plus `importPinnedPublicKey` for the fetch path.
- **`frontend/src/vault/envelope.test.ts`** — 24 tests driven by the shared `tests/vectors/keyproxy_envelope_v1.json` (all API keys are fake vector strings).
- **`setupTests.ts`** — WebCrypto polyfill from `node:crypto` (jsdom 29 has no `crypto.subtle`), guarded so real browser crypto is untouched.
- Checkpoint log rows 1a/1b ticked in the plan doc.

## Verify (packet exit contract)

- ✅ Re-encrypting each of the 3 envelope vectors with its pinned ephemeral key + IV reproduces the pinned envelope **byte-exactly** — the TS-encrypt → Py-decrypt proof, no cross-language test plumbing needed.
- ✅ All 5 canonicalization vectors (non-ASCII, escape-heavy, scalar edges) produce identical canonical bytes and `scope_hash` values in TS and Python.
- ✅ Unpinned public keys are refused (empty pin list, wrong pin, missing env), including a `CryptoKey` handed to `encryptEnvelope` directly; errors never carry key material.
- ✅ Random-ephemeral path: well-formed envelope (65-byte `0x04` point, 12-byte IV, ct = plaintext+16), fresh ephemeral/IV per call, round-trip decrypted in-test with the vector recipient private key.
- ✅ `cd frontend && npx vitest run --coverage`: 99 tests green, coverage **rose** (lines 28.7% vs 22 floor). `tsc -b` clean.
- ✅ Python side untouched; `python -m unittest test_keyproxy_crypto` still 30/30.

## Flagged deviation (one dev-only dependency)

`@types/node` added to `frontend/package.json` `devDependencies` — required for the `node:crypto` import in the test polyfill. Nothing ships in the bundle; `tsc -b` verified clean against the existing app code (the sole `setTimeout` usage is inference-safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)