### PR TITLE
BYOK: browser key vault + key-redemption proxy (phases 2–8a, issue #100)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,9 @@
 # Phase 3 Step 10 — CI/CD for the QuantCore platform (architectural standard v2 §10).
 #
-# PRs + pushes run the gate (tests + wrapper smoke + OpenAPI surface diff). Pushes to
-# main additionally build the 4 images (Cloud Build, native amd64) and roll them out to
+# PRs + pushes run the gate (tests + wrapper smoke + OpenAPI surface diff) plus a
+# gitleaks secret scan (BYOK packet 8a — a pasted API key or PEM in a diff fails CI
+# before it ever lands; allowlist in .gitleaks.toml). Pushes to main additionally build
+# the 5 images (Cloud Build, native amd64) and roll them out to
 # the Cloud Run services + the report Job in the TEST project. Deploys carry ONLY the
 # image tag — every service's env/secrets/Cloud-SQL binding is preserved from its last
 # manual deploy (Steps 8–9), so CI never needs the DB DSN or JWT secret.
@@ -148,6 +150,27 @@ jobs:
           name: frontend-coverage-html
           path: frontend/coverage/
           retention-days: 14
+      # BYOK packet 8a: the Express proxy's auth tests (IAP-assertion verify +
+      # per-user ES256 mint, packet 7b) — a separate npm package with its own
+      # lockfile, run with node's built-in test runner.
+      - name: QuantUI server tests (frontend/server)
+        working-directory: frontend/server
+        run: |
+          npm ci
+          npm test
+
+  secret-scan:
+    name: Secret scan (gitleaks)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so the scan covers every commit in the push/PR range.
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml
 
   preflight:
     name: Check deploy credentials are configured
@@ -175,7 +198,7 @@ jobs:
 
   deploy:
     name: Build + roll out to Cloud Run (test project)
-    needs: [gate, frontend-gate, preflight]
+    needs: [gate, frontend-gate, secret-scan, preflight]
     if: needs.preflight.outputs.has_creds == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -189,7 +212,7 @@ jobs:
           workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
           service_account: ${{ secrets.GCP_DEPLOY_SA }}
       - uses: google-github-actions/setup-gcloud@v2
-      - name: Build + push the 4 images (Cloud Build, amd64)
+      - name: Build + push the 5 images (Cloud Build, amd64)
         run: |
           gcloud builds submit --project "$PROJECT_ID" \
             --config cloudbuild.yaml \
@@ -219,4 +242,17 @@ jobs:
               --image "$REGION-docker.pkg.dev/$PROJECT_ID/$AR_REPO/quantcore-ui:${GITHUB_SHA::7}"
           else
             echo "quantui service not found — first deploy is the manual --iap step; skipping image roll-out."
+          fi
+      - name: Deploy quantcore-keyproxy (image-only; SA/secrets/IAM lock preserved)
+        # The keyproxy's FIRST deploy is the manual packet-8b runbook (dedicated
+        # runtime SA, keyproxy-private-key + quantui-signing-pub secrets,
+        # --no-allow-unauthenticated with run.invoker granted only to
+        # quantcore-api's SA). That config persists across image-only redeploys.
+        # Until that one-time deploy exists, skip rather than fail.
+        run: |
+          if gcloud run services describe quantcore-keyproxy --project "$PROJECT_ID" --region "$REGION" >/dev/null 2>&1; then
+            gcloud run deploy quantcore-keyproxy --project "$PROJECT_ID" --region "$REGION" \
+              --image "$REGION-docker.pkg.dev/$PROJECT_ID/$AR_REPO/quantcore-keyproxy:${GITHUB_SHA::7}"
+          else
+            echo "quantcore-keyproxy service not found — first deploy is the manual packet-8b runbook; skipping image roll-out."
           fi

--- a/.github/workflows/prod-rollout.yml
+++ b/.github/workflows/prod-rollout.yml
@@ -118,10 +118,16 @@ jobs:
           gcloud auth configure-docker "$REGION-docker.pkg.dev" --quiet
           TAG="${{ github.event.inputs.image_tag || github.event.release.tag_name }}"
           echo "Promoting tag '$TAG' from $TEST_PROJECT -> $PROD_PROJECT"
-          for img in quantcore-api quantcore-mcp quantcore-report quantcore-ui; do
+          for img in quantcore-api quantcore-mcp quantcore-report quantcore-ui quantcore-keyproxy; do
             SRC_TAGGED="$REGION-docker.pkg.dev/$TEST_PROJECT/$AR_REPO/$img:$TAG"
             # Resolve the immutable source-manifest digest so the copy + deploy reference
-            # exact bytes.
+            # exact bytes. quantcore-keyproxy (BYOK packet 8a) tolerates an absent source
+            # image so tags built before 8a landed stay promotable; the others stay strict.
+            if [ "$img" = "quantcore-keyproxy" ] && ! gcloud artifacts docker images describe \
+                "$SRC_TAGGED" --format='value(image_summary.digest)' >/dev/null 2>&1; then
+              echo "quantcore-keyproxy:$TAG not in the test AR (pre-8a tag) — skipping its promotion."
+              continue
+            fi
             DIGEST="$(gcloud artifacts docker images describe "$SRC_TAGGED" \
               --format='value(image_summary.digest)')"
             echo "$img @ $DIGEST"
@@ -166,3 +172,18 @@ jobs:
         run: |
           gcloud run deploy quantui --project "$PROD_PROJECT" --region "$REGION" \
             --image "$REGION-docker.pkg.dev/$PROD_PROJECT/$AR_REPO/quantcore-ui@$QUANTCORE_UI_DIGEST"
+
+      - name: Deploy quantcore-keyproxy (prod, image-only)
+        # First prod deploy is the manual packet-8b runbook (dedicated runtime SA,
+        # keyproxy-private-key + quantui-signing-pub secrets, IAM-locked invoker).
+        # Image-only redeploys preserve that config. Skips while the digest wasn't
+        # promoted (pre-8a tag) or the service doesn't exist yet (pre-8b prod).
+        run: |
+          if [ -z "${QUANTCORE_KEYPROXY_DIGEST:-}" ]; then
+            echo "no promoted keyproxy digest for this tag — skipping."
+          elif gcloud run services describe quantcore-keyproxy --project "$PROD_PROJECT" --region "$REGION" >/dev/null 2>&1; then
+            gcloud run deploy quantcore-keyproxy --project "$PROD_PROJECT" --region "$REGION" \
+              --image "$REGION-docker.pkg.dev/$PROD_PROJECT/$AR_REPO/quantcore-keyproxy@$QUANTCORE_KEYPROXY_DIGEST"
+          else
+            echo "quantcore-keyproxy service not found in prod — first deploy is the manual packet-8b runbook; skipping."
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ api.log
 frontend.log
 backups/
 .env.docker
+.keyproxy-dev-keys.txt
 .coverage
 coverage.xml
 htmlcov/

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,30 @@
+# Gitleaks config for the secret-scan CI job (BYOK packet 8a, plan issue #100).
+#
+# Extends the default ruleset — the point is to fail CI if a real API key or
+# private-key PEM ever lands in a diff. The allowlist below is deliberately
+# NARROW: it exempts specific known-clean matches, never whole test suites,
+# so a real credential pasted into a test file still trips the scan.
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Known-clean matches: PEM-marker string literals in parsing code, dummy test values, and code identifiers the generic rule trips on"
+paths = [
+  # PEM *marker* string literals only (bundle parsing / awk extraction) —
+  # neither file contains key material.
+  '''keyproxy/main\.py''',
+  '''runUI-CONTAINERS\.sh''',
+]
+regexes = [
+  # The dummy Anthropic-shaped key used across unit tests and docs. Real keys
+  # are sk-ant-api03-... with ~100 chars of payload and would not match this.
+  '''sk-ant-test-key-[A-Za-z0-9-]*''',
+  # The dummy HS256 signing secret shared by the auth test suites — its own
+  # value states it is a test secret.
+  '''test-secret-key-at-least-32-bytes-long-000''',
+  # generic-api-key false positives on code identifiers (an EC curve constant
+  # next to the word "key", and a HuggingFace model name after "tokenizer=").
+  '''ec\.SECP256R1''',
+  '''ProsusAI/finbert''',
+]

--- a/Dockerfile.keyproxy
+++ b/Dockerfile.keyproxy
@@ -1,0 +1,40 @@
+# Dockerfile.keyproxy — the Key Proxy (keyproxy/main.py).
+#
+# The BYOK credential-isolation boundary: the ONLY image that may hold the
+# envelope decryption key (KEYPROXY_PRIVATE_KEYS via Secret Manager), so it
+# carries ONLY the keyproxy package and its lean deps (keyproxy/requirements.txt)
+# — no quantcore code, no DB driver, no ML stack. Multi-stage + non-root,
+# mirroring Dockerfile.api.
+
+# ---- builder: install deps into an isolated venv ----
+FROM python:3.12-slim AS builder
+
+ENV PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+COPY keyproxy/requirements.txt ./
+RUN pip install --upgrade pip && pip install -r requirements.txt
+
+# ---- final: slim runtime with only the venv + the keyproxy package ----
+FROM python:3.12-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PATH="/opt/venv/bin:$PATH" \
+    PORT=5002
+
+RUN useradd --create-home --uid 1000 appuser
+COPY --from=builder /opt/venv /opt/venv
+
+WORKDIR /app
+COPY keyproxy/ keyproxy/
+
+USER appuser
+EXPOSE 5002
+
+# Shell form so $PORT is expanded (Cloud Run injects its own PORT).
+CMD uvicorn keyproxy.main:app --host 0.0.0.0 --port ${PORT}

--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -31,7 +31,7 @@ ENV NODE_ENV=production \
     PORT=8080
 WORKDIR /app
 
-# Server deps only (express + http-proxy-middleware), installed reproducibly.
+# Server deps only (express + http-proxy-middleware + jose), installed reproducibly.
 COPY server/package.json server/package-lock.json ./server/
 RUN cd server && npm ci --omit=dev
 

--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -10,9 +10,15 @@
 # Express server (server/server.mjs) that reverse-proxies /api/* to quantcore-api,
 # injecting the bearer token server-side. No VITE_* secrets are baked at build
 # time — the app calls /api same-origin and the token is added at runtime.
+# Exception (BYOK packet 6): VITE_KEYPROXY_SPKI_PINS is a public-key
+# FINGERPRINT list, not a secret — it must be baked into the bundle so the
+# SPA refuses to seal envelopes to an unpinned key proxy. Empty (the default)
+# means no pins, and envelope encryption fails closed.
 
 # ---- builder: compile the Vite SPA ----
 FROM node:22-slim AS builder
+ARG VITE_KEYPROXY_SPKI_PINS=""
+ENV VITE_KEYPROXY_SPKI_PINS=$VITE_KEYPROXY_SPKI_PINS
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci

--- a/api/auth.py
+++ b/api/auth.py
@@ -21,12 +21,29 @@ call, so route code is identical in both modes.
 Configuration (env, read at call time so compose/tests can toggle it)
 ---------------------------------------------------------------------
     QUANTCORE_JWT_SECRET     shared secret for HS* algorithms (presence → auth ON)
-    QUANTCORE_JWT_PUBLIC_KEY PEM public key for RS*/ES* algorithms (presence → auth ON)
+    QUANTCORE_JWT_PUBLIC_KEY PEM public key for ES256 user tokens (presence → auth ON)
     AUTH_DISABLED            truthy ("1"/"true"/"yes"/"on") → force auth OFF (local/compose)
-    QUANTCORE_JWT_ALGORITHMS comma list of accepted algs (default "HS256")
+    QUANTCORE_JWT_ALGORITHMS comma list of accepted HS* algs (default "HS256")
     QUANTCORE_JWT_ISSUER     optional expected ``iss`` claim
-    QUANTCORE_JWT_AUDIENCE   optional expected ``aud`` claim
+    QUANTCORE_JWT_AUDIENCE   optional expected ``aud`` claim (HS path only)
     QUANTCORE_JWT_LEEWAY     clock-skew tolerance in seconds (default 0)
+
+Dual-mode verification (BYOK packet 7a, decision #13)
+-----------------------------------------------------
+Two token populations coexist and are routed by the token's declared ``alg``:
+
+* **ES256 user tokens** — short-lived, minted by the quantui Express server
+  from a private key only it holds. Verified against
+  ``QUANTCORE_JWT_PUBLIC_KEY`` with this service's own name
+  (``"quantcore-api"``) required in ``aud``. Asymmetric on purpose: this
+  verifier cannot mint identities.
+* **HS* service tokens** — the MCP wrappers' long-lived tokens, verified
+  against ``QUANTCORE_JWT_SECRET`` exactly as before.
+
+Each branch is pinned to its own key *and* algorithm family — the HS branch
+never sees the public key and the ES branch never sees the secret — so the
+classic algorithm-confusion attack (an HS token signed with the public key
+as its HMAC secret) fails closed.
 """
 
 from __future__ import annotations
@@ -53,9 +70,21 @@ def _auth_active() -> bool:
     return _verification_key() is not None
 
 
+# The audience this service requires in ES256 user tokens. Hardcoded, not
+# env-driven: a token minted for another service must not authenticate here.
+_ES256_AUDIENCE = "quantcore-api"
+
+
 def _algorithms() -> list[str]:
+    """Accepted algorithms for the shared-secret path — HS family only.
+
+    Anything non-HS in ``QUANTCORE_JWT_ALGORITHMS`` is dropped: asymmetric
+    verification is the ES256 branch's job, and letting an attacker-chosen
+    ``alg`` pair with the wrong key is exactly the confusion attack.
+    """
     raw = os.environ.get("QUANTCORE_JWT_ALGORITHMS", "HS256")
-    return [a.strip() for a in raw.split(",") if a.strip()] or ["HS256"]
+    algs = [a.strip() for a in raw.split(",") if a.strip().upper().startswith("HS")]
+    return algs or ["HS256"]
 
 
 def _leeway() -> float:
@@ -128,16 +157,37 @@ def _decode(token: str) -> dict[str, Any]:
             detail="authentication is enabled but no JWT verification key is configured",
         )
 
-    options: dict[str, Any] = {}
-    audience = os.environ.get("QUANTCORE_JWT_AUDIENCE") or None
     issuer = os.environ.get("QUANTCORE_JWT_ISSUER") or None
-    if audience is None:
-        options["verify_aud"] = False
 
     try:
+        alg = str(jwt.get_unverified_header(token).get("alg", ""))
+
+        if alg == "ES256":
+            # User-token branch: public key only, own name required in aud.
+            public_key = os.environ.get("QUANTCORE_JWT_PUBLIC_KEY")
+            if not public_key:
+                raise jwt.InvalidKeyError("ES256 verification is not configured")
+            return jwt.decode(
+                token,
+                public_key,
+                algorithms=["ES256"],
+                audience=_ES256_AUDIENCE,
+                issuer=issuer,
+                leeway=_leeway(),
+            )
+
+        # Service-token branch: shared secret only, HS-family algorithms only.
+        # The public key must never reach HMAC verification (confusion attack).
+        secret = os.environ.get("QUANTCORE_JWT_SECRET")
+        if not secret:
+            raise jwt.InvalidKeyError("shared-secret verification is not configured")
+        options: dict[str, Any] = {}
+        audience = os.environ.get("QUANTCORE_JWT_AUDIENCE") or None
+        if audience is None:
+            options["verify_aud"] = False
         return jwt.decode(
             token,
-            key,
+            secret,
             algorithms=_algorithms(),
             audience=audience,
             issuer=issuer,

--- a/api/main.py
+++ b/api/main.py
@@ -58,6 +58,7 @@ def create_app() -> FastAPI:
         chat,
         dashboard,
         fundamentals,
+        keyproxy,
         microstructure,
         options,
         plans,
@@ -90,6 +91,7 @@ def create_app() -> FastAPI:
         microstructure,
         recommendations,
         chat,
+        keyproxy,
     ):
         app.include_router(module.router, dependencies=[protected])
 

--- a/api/routers/chat.py
+++ b/api/routers/chat.py
@@ -3,12 +3,21 @@
 The one endpoint that must NOT use QuantCoreJSONResponse: it serves
 Server-Sent Events via StreamingResponse (see api/sse.py for the protocol).
 Exactly one service call deep per the architectural standard.
+
+BYOK (packet 3c): the route builds a TurnContext from the request's optional
+sealed envelope/scope plus the caller's principal, and hands it to the
+service opaquely. ``require_principal`` here is the same dependency the app
+already applies router-wide, so FastAPI's per-request dependency cache means
+the token is verified once, not twice.
 """
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from fastapi.responses import StreamingResponse
 
+from quantcore.services.chat import TurnContext
+
+from ..auth import Principal, require_principal
 from ..deps import services
 from ..schemas.chat import ChatRequest
 from ..sse import event_stream
@@ -22,10 +31,19 @@ _SSE_HEADERS = {
 
 
 @router.post("")
-def chat(body: ChatRequest) -> StreamingResponse:
+def chat(
+    body: ChatRequest, principal: Principal = Depends(require_principal)
+) -> StreamingResponse:
+    context = TurnContext(
+        key_envelope=body.key_envelope.model_dump() if body.key_envelope else None,
+        scope=body.scope.model_dump() if body.scope else None,
+        auth_token=principal.token,
+        subject=principal.subject,
+    )
     events = services().chat.stream_chat(
         [{"role": m.role, "content": m.content} for m in body.messages],
         interactions=[i.model_dump(exclude_none=True) for i in body.interactions],
+        context=context,
     )
     return StreamingResponse(
         event_stream(events),

--- a/api/routers/keyproxy.py
+++ b/api/routers/keyproxy.py
@@ -1,0 +1,44 @@
+"""/api/keyproxy — pubkey discovery + key validation relays (BYOK 3c).
+
+Exactly one service call deep; the KeyProxyService is itself a pure relay to
+the keyproxy gateway. Nothing here logs — envelopes and tokens pass through
+opaquely, and KeyProxyError messages are safe user-facing copy by the
+gateway's error policy.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from quantcore.gateways.keyproxy_gateway import KeyProxyError
+
+from ..auth import Principal, require_principal
+from ..deps import services
+from ..schemas.keyproxy import ValidateRequest
+
+router = APIRouter(prefix="/api/keyproxy", tags=["keyproxy"])
+
+
+@router.get("/publickey")
+def publickey(principal: Principal = Depends(require_principal)) -> dict:
+    """Relay the keyproxy's envelope-encryption keys, plus the caller's
+    subject — the UI seals envelopes with ``aad.sub`` set to exactly this."""
+    try:
+        keys = services().keyproxy.get_public_keys()
+    except KeyProxyError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from None
+    return {"keys": keys, "sub": principal.subject}
+
+
+@router.post("/validate")
+def validate(
+    body: ValidateRequest, principal: Principal = Depends(require_principal)
+) -> dict:
+    """Relay a Settings-flow key validation to the keyproxy."""
+    try:
+        return services().keyproxy.validate_key(
+            envelope=body.envelope.model_dump(),
+            scope=body.scope.model_dump(),
+            auth_token=principal.token or "",
+        )
+    except KeyProxyError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from None

--- a/api/schemas/chat.py
+++ b/api/schemas/chat.py
@@ -5,6 +5,8 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+from .keyproxy import KeyEnvelope, KeyScope
+
 
 class ChatMessage(BaseModel):
     role: Literal["user", "assistant"]
@@ -26,3 +28,7 @@ class ChatInteraction(BaseModel):
 class ChatRequest(BaseModel):
     messages: list[ChatMessage] = Field(min_length=1, max_length=200)
     interactions: list[ChatInteraction] = Field(default_factory=list, max_length=20)
+    # BYOK (packet 3c): sealed key material for this turn, relayed opaquely to
+    # the keyproxy. Absent on legacy/env-key deployments.
+    key_envelope: KeyEnvelope | None = None
+    scope: KeyScope | None = None

--- a/api/schemas/keyproxy.py
+++ b/api/schemas/keyproxy.py
@@ -1,0 +1,36 @@
+"""Request/response shapes for the /api/keyproxy relay routes (BYOK 3c).
+
+These mirror the keyproxy's own wire contract (envelope v1 + scope v1) at the
+shape level only — every semantic decision (AAD checks, jti replay, budgets)
+belongs to the keyproxy. The api tier relays opaque material and never logs it.
+"""
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class KeyEnvelope(BaseModel):
+    """Envelope v1 — sealed key material, opaque to this tier."""
+
+    v: int
+    alg: str = Field(min_length=1, max_length=128)
+    kid: str = Field(min_length=1, max_length=128)
+    epk: str = Field(min_length=1, max_length=512)
+    iv: str = Field(min_length=1, max_length=128)
+    ct: str = Field(min_length=1, max_length=8192)
+    aad: dict
+
+
+class KeyScope(BaseModel):
+    """Scope v1 — what the sealed key may be used for."""
+
+    v: int
+    provider: str = Field(min_length=1, max_length=64)
+    action: str = Field(min_length=1, max_length=64)
+    params: dict = Field(default_factory=dict)
+    budget: dict
+
+
+class ValidateRequest(BaseModel):
+    envelope: KeyEnvelope
+    scope: KeyScope

--- a/api/sse.py
+++ b/api/sse.py
@@ -6,11 +6,20 @@ The chat route is the one endpoint that must NOT use QuantCoreJSONResponse
 Payload JSON mirrors api/json_response.py strictness: ``allow_nan=False`` so a
 NaN can never produce invalid JSON mid-stream — tool results are sanitized
 upstream in ChatService.
+
+Heartbeats (BYOK packet 3c): the browser-facing hop mirrors the keyproxy's
+worker/queue pattern — the event iterator runs on a thread, and whenever no
+frame arrives within KEYPROXY_HEARTBEAT_SECS a ``: ping`` comment goes out so
+proxies (IAP, Cloud Run) never see a silent connection during long provider
+thinking pauses.
 """
 from __future__ import annotations
 
 import json
 import logging
+import os
+import queue
+import threading
 from dataclasses import asdict
 from typing import Iterator
 
@@ -34,6 +43,10 @@ _EVENT_NAMES: dict[type, str] = {
 }
 
 
+def _heartbeat_secs() -> float:
+    return float(os.environ.get("KEYPROXY_HEARTBEAT_SECS", "15"))
+
+
 def sse_encode(event_type: str, data: dict) -> str:
     """Encode one SSE frame: ``event: <type>\\ndata: <one-line-json>\\n\\n``."""
     payload = json.dumps(data, ensure_ascii=False, allow_nan=False)
@@ -41,10 +54,28 @@ def sse_encode(event_type: str, data: dict) -> str:
 
 
 def event_stream(events: Iterator[ChatEvent]) -> Iterator[str]:
-    """Map ChatEvents onto SSE frames; convert generator failures to an error frame."""
-    try:
-        for event in events:
-            yield sse_encode(_EVENT_NAMES[type(event)], asdict(event))
-    except Exception as exc:  # noqa: BLE001 — stream must end with a frame, not a 500
-        logger.exception("chat event stream failed")
-        yield sse_encode("error", {"message": str(exc)})
+    """Map ChatEvents onto SSE frames with heartbeat comments during gaps;
+    convert generator failures to an error frame, never a broken response."""
+    out: queue.Queue = queue.Queue()
+
+    def worker() -> None:
+        try:
+            for event in events:
+                out.put(sse_encode(_EVENT_NAMES[type(event)], asdict(event)))
+        except Exception as exc:  # noqa: BLE001 — stream must end with a frame
+            logger.exception("chat event stream failed")
+            out.put(sse_encode("error", {"message": str(exc)}))
+        finally:
+            out.put(None)
+
+    threading.Thread(target=worker, daemon=True).start()
+    heartbeat = _heartbeat_secs()
+    while True:
+        try:
+            frame = out.get(timeout=heartbeat)
+        except queue.Empty:
+            yield ": ping\n\n"
+            continue
+        if frame is None:
+            return
+        yield frame

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -8,10 +8,11 @@
 #
 # Images (one mcp image is reused by all five wrappers — server + port are
 # selected at run time via SERVER_MODULE/PORT env, see mcp_gateway/serve.py):
-#   quantcore-api     FastAPI front door + services in-process (carries FinBERT/torch)
-#   quantcore-mcp     the shared thin MCP wrapper image
-#   quantcore-report  main.py once-and-exit (Cloud Run Job)
-#   quantcore-ui      React/Vite SPA + /api proxy (built from the frontend/ context)
+#   quantcore-api       FastAPI front door + services in-process (carries FinBERT/torch)
+#   quantcore-mcp       the shared thin MCP wrapper image
+#   quantcore-report    main.py once-and-exit (Cloud Run Job)
+#   quantcore-ui        React/Vite SPA + /api proxy (built from the frontend/ context)
+#   quantcore-keyproxy  BYOK key-redemption proxy (lean FastAPI, keyproxy/ only)
 #
 # Manual invocation (from repo root):
 #   gcloud builds submit --project quantcore-test-20260606 --config cloudbuild.yaml \
@@ -83,6 +84,19 @@ steps:
       - ${_REGION}-docker.pkg.dev/${_PROJECT}/${_REPO}/quantcore-ui:latest
       - frontend
 
+  # --- keyproxy (Dockerfile.keyproxy) — BYOK key-redemption proxy (packet 8a) ---
+  - name: gcr.io/cloud-builders/docker
+    id: build-keyproxy
+    args:
+      - build
+      - -f
+      - Dockerfile.keyproxy
+      - -t
+      - ${_REGION}-docker.pkg.dev/${_PROJECT}/${_REPO}/quantcore-keyproxy:${_TAG}
+      - -t
+      - ${_REGION}-docker.pkg.dev/${_PROJECT}/${_REPO}/quantcore-keyproxy:latest
+      - .
+
 images:
   - ${_REGION}-docker.pkg.dev/${_PROJECT}/${_REPO}/quantcore-api:${_TAG}
   - ${_REGION}-docker.pkg.dev/${_PROJECT}/${_REPO}/quantcore-api:latest
@@ -92,3 +106,5 @@ images:
   - ${_REGION}-docker.pkg.dev/${_PROJECT}/${_REPO}/quantcore-report:latest
   - ${_REGION}-docker.pkg.dev/${_PROJECT}/${_REPO}/quantcore-ui:${_TAG}
   - ${_REGION}-docker.pkg.dev/${_PROJECT}/${_REPO}/quantcore-ui:latest
+  - ${_REGION}-docker.pkg.dev/${_PROJECT}/${_REPO}/quantcore-keyproxy:${_TAG}
+  - ${_REGION}-docker.pkg.dev/${_PROJECT}/${_REPO}/quantcore-keyproxy:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,6 +78,10 @@ services:
     environment:
       KEYPROXY_AUTH_DISABLED: "1"
       PORT: "5002"
+      # Persistent local dev keypair (git-ignored, written by runUI-CONTAINERS.sh
+      # into .env.docker with \n-escaped newlines). Empty -> ephemeral per-boot
+      # keypair, which can never match the pin baked into the quantui bundle.
+      KEYPROXY_PRIVATE_KEYS: "${KEYPROXY_DEV_PRIVATE_KEYS:-}"
     ports: ["5002:5002"]
     restart: on-failure
     healthcheck:
@@ -160,7 +164,14 @@ services:
   # here: the compose api runs AUTH_DISABLED=1, so the proxy sends no bearer (the
   # token is a Cloud Run / Secret Manager concern only — see Dockerfile.ui).
   quantui:
-    build: { context: ./frontend, dockerfile: ../Dockerfile.ui }
+    build:
+      context: ./frontend
+      dockerfile: ../Dockerfile.ui
+      args:
+        # SPKI pin of the local dev keyproxy keypair (public fingerprint, not a
+        # secret) — derived into .env.docker by runUI-CONTAINERS.sh so the UI
+        # bundle pins the same key the keyproxy container loads.
+        VITE_KEYPROXY_SPKI_PINS: "${VITE_KEYPROXY_SPKI_PINS:-}"
     environment:
       QUANTCORE_REST_URL: "http://quantcore-api:5001"
       PORT: "8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,7 @@ services:
       # DSN points at the proxy CONTAINER (TEST instance) — password injected from .env.docker.
       QUANTCORE_DB_DSN: "postgresql://${QUANTCORE_DB_USER}:${QUANTCORE_DB_PASSWORD}@cloud-sql-proxy:5432/${QUANTCORE_DB_NAME}"
       AUTH_DISABLED: "1"            # local stays open; JWT lands in Step 6 for GCP only
+      KEYPROXY_URL: "http://keyproxy:5002"
       PORT: "5001"
     ports:
       - "5001:5001"                # frontend (npm run dev) and curl hit http://localhost:5001
@@ -63,6 +64,28 @@ services:
       timeout: 5s
       retries: 12
       start_period: 90s            # torch/transformers import makes first boot slow
+    networks: [quantcore]
+
+  # --- Key Proxy: the BYOK credential-isolation boundary (own slim image) ---
+  # No DB, no dependence on quantcore-api. With KEYPROXY_PRIVATE_KEYS unset it
+  # generates an ephemeral dev keypair at boot — envelopes only work against
+  # this process's lifetime, exactly what a dev stack wants. Auth open locally,
+  # mirroring AUTH_DISABLED on quantcore-api. In GCP this service is NOT
+  # internet-reachable; here it's port-mapped so the Vite dev frontend and
+  # curl can hit it directly.
+  keyproxy:
+    build: { context: ., dockerfile: Dockerfile.keyproxy }
+    environment:
+      KEYPROXY_AUTH_DISABLED: "1"
+      PORT: "5002"
+    ports: ["5002:5002"]
+    restart: on-failure
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:5002/healthz')"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 10s
     networks: [quantcore]
 
   # --- 5 MCP wrapper servers (thin HTTP gateways over quantcore-api; Rule 6) ---

--- a/docs/openapi-surface.txt
+++ b/docs/openapi-surface.txt
@@ -2,6 +2,7 @@ DELETE /api/plans/{instance_id}  ->  delete_plan_api_plans__instance_id__delete
 DELETE /api/portfolio/{ticker}  ->  remove_from_portfolio_api_portfolio__ticker__delete
 GET    /api/dashboard/stats  ->  dashboard_stats_api_dashboard_stats_get
 GET    /api/health  ->  health_api_health_get
+GET    /api/keyproxy/publickey  ->  publickey_api_keyproxy_publickey_get
 GET    /api/options/screen-watchlist  ->  screen_options_watchlist_api_options_screen_watchlist_get
 GET    /api/plans  ->  list_plans_api_plans_get
 GET    /api/plans/{instance_id}  ->  get_plan_api_plans__instance_id__get
@@ -72,6 +73,7 @@ GET    /api/symbols/{ticker}/price  ->  get_symbol_price_api_symbols__ticker__pr
 GET    /api/watchlist  ->  get_watchlist_api_watchlist_get
 PATCH  /api/plans/{instance_id}  ->  update_plan_api_plans__instance_id__patch
 POST   /api/chat  ->  chat_api_chat_post
+POST   /api/keyproxy/validate  ->  validate_api_keyproxy_validate_post
 POST   /api/plans  ->  create_plan_api_plans_post
 POST   /api/portfolio  ->  add_to_portfolio_api_portfolio_post
 POST   /api/portfolio/import  ->  import_portfolio_api_portfolio_import_post

--- a/docs/proposals/alpaca-connect-byok-plan.md
+++ b/docs/proposals/alpaca-connect-byok-plan.md
@@ -1,0 +1,1356 @@
+# Alpaca Connect — browser-vault OAuth + Trading Key Proxy plan
+
+> **Status: PROPOSAL — awaiting team review.** No Alpaca integration code has been written.
+> This document extends [`byok-key-proxy-plan.md`](byok-key-proxy-plan.md) for an Alpaca paper
+> trading account and follows [`architectural-standard-v2.md`](architectural-standard-v2.md).
+> The first delivery connects one paper account per user and displays its open positions. A
+> second read-only milestone lets the authenticated Anthropic chat sidekick retrieve those same
+> positions through a curated MCP wrapper after explicit per-message consent. Paper-order
+> execution is designed into the security boundary but is a later release.
+
+## Executive summary
+
+QuantCore will let each authenticated user connect an existing Alpaca **paper trading account**
+through Alpaca Connect OAuth. The resulting user access token will not be stored by QuantCore,
+quantui, or a database. It will be encrypted back to the browser, stored in the existing
+passphrase-protected IndexedDB vault, and freshly enveloped to a dedicated Trading Key Proxy for
+each user action.
+
+The first capability is a functional `/portfolio` page showing the user's current Alpaca open
+positions. The next milestone exposes that canonical service capability to the built-in
+Anthropic sidekick through the architecture required by Architectural Standard v2:
+`AI orchestrator -> curated MCP wrapper -> FastAPI REST -> AlpacaService`. The tool is present only
+when the user opts in for that message, and only the normalized result enters the Anthropic
+conversation. Alpaca credentials and capabilities never enter model-visible content or the
+Anthropic Key Proxy.
+
+Neither milestone places, replaces, or cancels orders. They use Alpaca's default read grant
+because no mutation exists yet. When order functionality is ready, the user will explicitly
+reauthorize the same paper account with Alpaca's `trading` scope and the browser will atomically
+replace the vaulted token. The account is therefore a **paper trading account connected with
+portfolio-read permission for these milestones**, not a permanently read-only account.
+
+Plaintext credential visibility is limited to two locations:
+
+- the user's browser while the vault is unlocked; and
+- `quantcore-keyproxy-trading`, briefly, while exchanging an OAuth code or making an in-scope
+  Alpaca call.
+
+`quantui Express` and `quantcore-api` see OAuth codes, opaque state, and ciphertext, but never the
+Alpaca client secret or user access token. Position data necessarily returns through the REST tier
+to the user, but is neither persisted nor logged.
+
+## Source documentation and an important authentication distinction
+
+This design uses the following Alpaca documentation:
+
+- [Using OAuth2 and Trading API](https://docs.alpaca.markets/us/docs/using-oauth2-and-trading-api)
+- [All Open Positions](https://docs.alpaca.markets/us/reference/getallopenpositions)
+- [Create an Order](https://docs.alpaca.markets/us/reference/postorder)
+- [Get All Orders](https://docs.alpaca.markets/us/reference/getallorders-1)
+- [Delete Order by ID](https://docs.alpaca.markets/us/reference/deleteorderbyorderid-1)
+- [Replace Order by ID](https://docs.alpaca.markets/us/reference/patchorderbyorderid-1)
+- [Alpaca authentication](https://docs.alpaca.markets/us/v1.4.2/docs/authentication)
+
+The initially supplied [Issue tokens](https://docs.alpaca.markets/us/reference/issuetokens)
+endpoint, `https://authx.alpaca.markets/v1/oauth2/token`, is the Broker API client-credentials
+flow. Alpaca explicitly documents that client credentials are not available for Trading API.
+It is not the flow for a user connecting an existing Alpaca Trading account, and it does not pair
+with `GET /v2/positions`.
+
+This plan instead uses Alpaca Connect's authorization-code flow:
+
+```text
+Authorize: https://app.alpaca.markets/oauth/authorize
+Exchange:  https://api.alpaca.markets/oauth/token
+Positions: https://paper-api.alpaca.markets/v2/positions
+```
+
+## Goals and non-goals
+
+### Goals for this delivery
+
+- Connect one Alpaca paper account per authenticated QuantCore user.
+- Use the Alpaca-hosted consent screen rather than asking users to paste Trading API keys.
+- Keep the Alpaca application client secret inside the Trading Key Proxy only.
+- Return the user access token to the browser without exposing it to quantui or quantcore-api.
+- Store the user token only in the existing encrypted browser vault.
+- Retrieve and display all open positions with accurate decimal precision.
+- Let the built-in Anthropic chat sidekick retrieve the same normalized positions and totals
+  through a curated, read-only MCP tool after explicit per-message consent.
+- Preserve the required `AI Agent -> MCP wrapper -> REST -> Service` topology and authenticated
+  identity passthrough from Architectural Standard v2.
+- Make OAuth connection, token use, and positions access attributable through metadata-only audit
+  events.
+- Keep the proxy operation taxonomy fail-closed so no order call is reachable in v1.
+- Establish interfaces and security invariants that can later support broad paper-order execution
+  and predefined multi-order workflows.
+
+### Non-goals for this delivery
+
+- Live-account access.
+- Placing, replacing, cancelling, or listing orders.
+- Requesting Alpaca's `trading`, `account:write`, or `data` OAuth scopes.
+- Multiple Alpaca accounts per QuantCore user.
+- Persisting or periodically refreshing Alpaca data on the server.
+- WebSocket trade updates.
+- External or general-purpose Alpaca MCP access.
+- MCP access to Alpaca orders or any other mutation.
+- A generic Alpaca HTTP proxy.
+
+## Decisions already made
+
+1. **Alpaca Connect authorization code, not raw Trading API keys.** Users authorize on Alpaca's
+   site. QuantCore owns one OAuth client per deployment, while each user owns a distinct grant.
+2. **Paper only.** Authorization sends `env=paper`; the proxy hardcodes the paper Trading API host.
+3. **One connection per user.** A successful reconnect replaces the existing encrypted vault
+   record. It creates no server-side connection row.
+4. **Positions only in v1.** The only provider operation is `positions.list`.
+5. **Least-privilege scope progression.** V1 relies on Alpaca's documented default read access.
+   The first order release triggers a new consent for exactly `trading` and replaces the token.
+6. **Dedicated trading deployment.** `quantcore-keyproxy-trading` is isolated from the LLM proxy
+   with its own keys, identity, secrets, pins, limits, and egress policy.
+7. **Encrypted return channel.** The OAuth access token is encrypted to a one-use key that exists
+   only in browser memory and opaque proxy state. Intermediaries never receive token plaintext.
+8. **No server-side credential persistence.** Tokens, token ciphertext, OAuth state, and account
+   connection records never enter PostgreSQL, Redis, object storage, logs, or queues.
+9. **Metadata-only audit is persisted.** The services layer records who performed which provider
+   operation and its outcome, but never credentials, position contents, or OAuth payloads.
+10. **No inactive write routes.** Order endpoints are not stubbed or hidden behind flags. They do
+    not exist until their confirmation, idempotency, audit, and durable-replay controls exist.
+11. **Sidekick-only MCP position reads.** The built-in Anthropic sidekick may receive one curated
+    `get_alpaca_positions` tool only when an unlocked user explicitly opts in for that message.
+    The wrapper calls the canonical REST endpoint and never calls a service, database, provider,
+    or key proxy directly.
+12. **Credentials are out-of-band.** The model-visible tool has no credential arguments. A
+    server-sealed, audience-bound `AgentToolGrant` and the user's JWT travel in MCP request
+    metadata. Anthropic receives neither value; it receives the normalized position result only
+    after the tool succeeds.
+13. **Agent access stays read-only.** Paper trading through MCP remains prohibited until a later
+    design adds explicit human confirmation, idempotency, service-owned risk and entitlement
+    checks, durable audit, and a distinct mutation grant.
+
+## High-level architecture
+
+```mermaid
+flowchart LR
+    B["Browser<br/>encrypted vault"] -->|"HTTPS and ciphertext"| R["FastAPI REST tier<br/>single front door"]
+    R --> C["ChatService<br/>AI orchestrator"]
+    C --> H["Anthropic Key Proxy"]
+    H --> N["Anthropic API"]
+    C --> M["Alpaca portfolio MCP<br/>curated wrapper"]
+    M -->|"Authenticated REST call"| R
+    R --> S["AlpacaService<br/>orchestration and policy"]
+    S --> A[("Provider access audit<br/>metadata only")]
+    S --> G["AlpacaKeyProxyGateway<br/>thin transport adapter"]
+    G --> P["quantcore-keyproxy-trading<br/>credential boundary"]
+    P -->|"OAuth exchange"| O["Alpaca Connect"]
+    P -->|"Bearer token, allowed operation only"| T["Alpaca Paper Trading API"]
+```
+
+The browser never calls Alpaca APIs, either key proxy, or MCP directly. The direct portfolio path
+is `Browser -> REST -> AlpacaService`. The sidekick path intentionally re-enters the canonical
+front door as `ChatService -> MCP -> REST -> AlpacaService`: the first REST request hosts the AI
+orchestrator, while the second is an independently authenticated tool request. This preserves
+Rule 6 instead of giving the in-process chat loop a privileged service bypass.
+
+### Security boundaries
+
+```mermaid
+flowchart LR
+    subgraph User_Device["User device"]
+        V["Encrypted OAuth token<br/>IndexedDB vault"]
+        M["Plaintext token<br/>unlocked memory only"]
+        V -->|"explicit unlock"| M
+    end
+    subgraph Application["Application, no token plaintext"]
+        Q["quantui Express"]
+        API["quantcore-api"]
+        CHAT["ChatService"]
+        MCP["Alpaca portfolio MCP"]
+        SVC["AlpacaService"]
+        Q --> API
+        API --> CHAT
+        CHAT -->|"Opaque grant in MCP metadata"| MCP
+        MCP -->|"JWT and opaque grant"| API
+        API --> SVC
+    end
+    subgraph Credential_Boundary["Trading credential boundary"]
+        KP["quantcore-keyproxy-trading"]
+    end
+    M -->|"single-use envelope"| Q
+    SVC -->|"opaque envelope and scope"| KP
+    KP -->|"Authorization Bearer"| ALP["Alpaca paper API"]
+    CHAT -->|"Position tool result only"| ANT["Anthropic Key Proxy and API"]
+```
+
+Compromising quantcore-api can expose position responses passing through it and can drive calls
+within a currently live, user-sealed scope. It cannot decrypt a captured token envelope, mint a
+different user's identity, widen the operation to an order, or substitute an unpinned proxy key.
+Compromising the Trading Key Proxy can expose credentials active in its memory; preventing that is
+not possible without a trusted execution environment because the proxy must authenticate to
+Alpaca. Isolation, small code size, egress restriction, and short lifetimes contain that risk.
+Compromising the MCP wrapper exposes at most one already-authorized position result: the wrapper
+cannot decrypt the `AgentToolGrant`, widen its action, change its subject, or reach Alpaca without
+passing the REST tier's validation again.
+
+## Architectural Standard v2 adherence
+
+The capability follows the required dependency direction:
+
+```text
+Direct UI: React -> FastAPI REST -> AlpacaService -> provider gateway -> Alpaca
+Agent read: ChatService -> MCP transport gateway -> curated MCP wrapper
+                -> FastAPI REST -> AlpacaService -> provider gateway -> Alpaca
+```
+
+| Component | Standard layer and responsibility |
+|---|---|
+| `/portfolio` React page | §5.7 front end: presentation and UI state only; calls REST exclusively |
+| Chat composer consent control | §5.7 front end: per-message presentation and UI state; creates a user-sealed envelope but never calls MCP or a provider |
+| `ChatService` | §5.1 AI orchestrator: dynamically curates tools, issues the tool grant through an injected grant service, caches a result for one turn, and never bypasses MCP for agent execution |
+| `api/routers/alpaca.py` | §5.4 route: Pydantic validation, principal, HTTP status/headers, exactly one service call |
+| `api/schemas/alpaca.py` | §5.4/§9: canonical request and response contracts shared by OpenAPI, WebUI, and MCP |
+| `AgentToolGrantService` | §5.1/Rule 5: centralized issuance and validation of encrypted, audience-bound, per-message capabilities |
+| `quantcore/services/alpaca.py` | §5.1 mandatory center: grant validation, profile selection, authorization, rate policy, orchestration, normalization, totals, cache policy, and audit events |
+| `McpToolGateway` | §5.3 gateway: FastMCP client transport, IAM, timeout, cancellation, and transport-error translation only |
+| Alpaca portfolio MCP wrapper | §5.5/Rule 6: hand-curated, one-call-deep semantic wrapper that forwards JWT and opaque grant to REST |
+| `quantcore/gateways/alpaca_keyproxy_gateway.py` | §5.3 gateway: proxy I/O, auth forwarding, timeouts, retries, transport error translation only |
+| provider-access audit repository | §5.1/Rule 5: metadata persistence invoked only by the service |
+| `quantcore-keyproxy-trading` | Provider-side credential boundary described below; not a second business-services layer |
+
+### Standard compliance matrix
+
+| Standard requirement | Enforced design consequence |
+|---|---|
+| P1 and Rule 1: business logic belongs in services | Tool curation, authorization, grant policy, normalization, totals, caching, and audit are service-owned; route and wrapper bodies remain one call deep |
+| P2: REST is the single remote front door | Both the WebUI and MCP wrapper invoke authenticated FastAPI endpoints; no remote client calls a service or provider directly |
+| P3 and Rule 6: MCP is a thin wrapper over REST | `get_alpaca_positions` only translates one tool call to `POST /api/alpaca/agent/positions` and returns its canonical response |
+| P4 and Rule 7: capabilities are born as services | The existing `AlpacaService` position capability remains canonical and is exposed to MCP only after REST exists |
+| Rule 2: adapters cannot access gateways or persistence | Architecture guards forbid the wrapper and route from importing services' collaborators, stores, DB modules, provider SDKs, or proxies |
+| Rule 3: gateways stay thin | MCP and key-proxy gateways own transport only and cannot select scope, grant, environment, risk, totals, or audit behavior |
+| Rule 5: cross-cutting policy is centralized | Grant policy, rate limiting, ephemeral cache policy, and metadata-only audit live in services |
+| §8 identity passthrough | Chat orchestration passes the user's JWT in hidden MCP metadata; the wrapper forwards it as the REST `Authorization` value |
+| §8 prompt-injection containment | The tool accepts no model-controlled arguments; REST still authenticates, validates the grant, rate-limits, and authorizes the exact action |
+| §8 transport isolation | The MCP service has internal ingress and a least-privilege runtime identity; only the REST front door is public |
+| §8 write gating | The curated tool is read-only; any later mutation requires confirmation, idempotency, audit, risk, and entitlement enforcement in services |
+
+### Enforceable consequences
+
+- The capability is born as `AlpacaService`, then exposed by REST, then consumed by the WebUI.
+- MCP exposure is an explicit per-capability curation decision, not automatic OpenAPI mirroring.
+- Routes do not import repositories, gateways, Alpaca libraries, `httpx`, or database modules.
+- Each route calls one service method and returns a Pydantic response model.
+- `AlpacaService` owns profile selection, validation, position normalization, aggregate
+  calculations, authorization, rate policy, cache policy, and audit behavior.
+- The API-side gateway owns external I/O only. It cannot choose OAuth scopes, environments,
+  allowed actions, or position calculations.
+- The MCP wrapper owns no validation beyond strict metadata presence and response translation. It
+  never imports a service, store, database module, provider SDK, or proxy gateway.
+- `ChatService` reaches Alpaca business logic only through the MCP wrapper and canonical REST
+  endpoint. Direct UI reads still use the normal `REST -> Service` path.
+- The frontend cannot calculate trading limits, construct provider requests, or choose OAuth
+  scopes. It displays a service-selected authorization URL and formats service-returned values.
+- Async routes, service methods, and gateways are used for I/O-bound work.
+- No CLI or cron entry point is added because browser-vault access requires an interactive user.
+- The MCP wrapper calls REST only. It cannot call a service, database, gateway, key proxy, or
+  Alpaca directly.
+- `docs/openapi-surface.txt` is updated and reviewed with every REST contract change.
+
+### Controlled proxy exception
+
+The Trading Key Proxy independently checks cryptographic scope even though canonical policy lives
+in the services layer. This is a security-boundary control, not duplicated business logic. It must
+remain effective when quantcore-api is assumed compromised.
+
+The proxy may only:
+
+- verify Google IAM and the per-user JWT;
+- verify envelope AAD, subject, provider, time, nonce, and `scope_hash`;
+- enforce the already sealed environment, operation, parameters, and budget;
+- classify an exact provider operation against a fail-closed allowlist;
+- attach a credential to a hardcoded provider request;
+- return an allowlisted provider response; and
+- discard credential material.
+
+It may not select product behavior, calculate portfolio totals, implement UI decisions, plan
+orders, perform risk analysis, or own business audit policy. Session plaintext is controlled
+security state and never leaves process memory, matching the exception already accepted in the
+base BYOK plan.
+
+## OAuth connection and encrypted token return
+
+### Why a reverse channel is needed
+
+The original BYOK envelope flows from browser to proxy. OAuth adds the opposite problem: Alpaca
+returns the access token to the proxy that holds the application client secret, but the browser is
+the sole persistent store. Returning token plaintext through quantcore-api would collapse the
+credential boundary.
+
+The solution is a one-use symmetric return key generated by the browser. The browser encrypts it
+to the pinned Trading Key Proxy, the proxy seals it into opaque OAuth state, and only the browser
+and proxy can use it to wrap or unwrap the returned token.
+
+### Connection sequence
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant B as Browser
+    participant A as quantcore-api
+    participant P as Trading Key Proxy
+    participant O as Alpaca Connect
+
+    U->>B: Choose Connect Alpaca Paper Account
+    B->>B: Require unlocked vault and generate one-use return key
+    B->>A: POST oauth start with encrypted return key
+    A->>P: Start fixed portfolio.read.v1 connection
+    P->>P: Verify envelope and create encrypted five-minute state
+    P-->>A: Authorization URL and opaque state
+    A-->>B: Authorization URL and opaque state
+    B->>O: Open user-initiated authorization popup
+    O-->>B: Redirect popup with code and matching state
+    B->>B: Clear callback URL and verify origin and exact state
+    B->>A: POST oauth exchange with code and opaque state
+    A->>P: Exchange code under verified user identity
+    P->>O: POST authorization code exchange with app client secret
+    O-->>P: User bearer token
+    P->>P: Reject unexpected write scopes and encrypt token to return key
+    P-->>A: Encrypted token receipt
+    A-->>B: Encrypted token receipt
+    B->>B: Decrypt receipt and store token in encrypted vault
+```
+
+### OAuth start contract
+
+The public route is fixed-purpose:
+
+```text
+POST /api/alpaca/oauth/start
+```
+
+Input:
+
+```json
+{
+  "return_key_envelope": { "v": 1, "alg": "...", "kid": "...", "aad": {}, "ct": "..." },
+  "scope": {
+    "v": 1,
+    "provider": "alpaca",
+    "action": "oauth.connect",
+    "params": {},
+    "budget": { "max_calls": 1, "max_mutations": 0, "ttl": 300 }
+  }
+}
+```
+
+The browser does not submit `env`, Alpaca scopes, client ID, or redirect URI. `AlpacaService`
+selects the fixed `portfolio.read.v1` profile. The proxy constructs the URL using configured,
+allowlisted values.
+
+Output:
+
+```json
+{
+  "authorization_url": "https://app.alpaca.markets/oauth/authorize?...",
+  "state": "<opaque>",
+  "expires_at": "2026-07-17T18:05:00Z"
+}
+```
+
+The URL includes `response_type=code`, the deployment's client ID and exact redirect URI, and
+`env=paper`. It omits `trading`, `account:write`, and `data` in v1.
+
+### OAuth state
+
+State is an authenticated encrypted value under `ALPACA_OAUTH_STATE_KEYS`, a rotatable AES-256
+key bundle held only by the Trading Key Proxy. Its wire form is three unpadded b64url segments:
+
+```text
+b64url(canonical header).b64url(12-byte IV).b64url(ciphertext and GCM tag)
+```
+
+The authenticated header is `{"v":1,"alg":"A256GCM","kid":"alpaca-state-2026-07-a"}` and is
+also the AES-GCM AAD. This lets the proxy select a rotation key before decryption without trusting
+an unauthenticated `kid`; unknown algorithms, versions, and key IDs fail closed. The encrypted
+plaintext contains:
+
+```json
+{
+  "v": 1,
+  "nonce": "<128-bit random>",
+  "sub_hash": "<keyed hash of verified JWT sub>",
+  "environment": "paper",
+  "grant_profile": "portfolio.read.v1",
+  "redirect_uri_hash": "<SHA-256>",
+  "return_key": "<b64url 32 bytes>",
+  "iat": 1784311200,
+  "exp": 1784311500
+}
+```
+
+The opaque state is safe to traverse Alpaca and the callback URL. The browser retains the exact
+opaque value in memory and requires byte-for-byte equality on return. The proxy separately checks
+authentication, expiry, subject binding, environment, grant profile, and redirect URI.
+
+Alpaca's published Connect flow does not document PKCE, so this plan does not invent a PKCE
+contract. CSRF and account-mix-up protection instead come from unpredictable encrypted state,
+exact browser state matching, subject and callback binding, short expiry, and Alpaca's single-use
+authorization code.
+
+### Popup callback hardening
+
+- Callback URI: `https://<quantui-origin>/oauth/alpaca/callback`.
+- The user click opens the popup synchronously so normal popup blocking rules permit it.
+- The callback accepts only `code`, `state`, and documented OAuth error fields.
+- It immediately calls `history.replaceState` to remove query parameters.
+- It uses `window.opener.postMessage` with the exact quantui origin, never `*`.
+- The opener checks `event.origin`, `event.source`, exact state, and that one connection is pending.
+- `Referrer-Policy: no-referrer` prevents callback query leakage.
+- `Cross-Origin-Opener-Policy: same-origin-allow-popups` preserves the intentional opener while
+  retaining cross-origin isolation from unrelated windows.
+- A missing opener, blocked popup, denial, close, or five-minute timeout ends the flow without
+  changing the vault.
+- No full-page redirect fallback exists in v1 because it would require persisting the one-use
+  return key outside memory.
+
+### Token receipt
+
+The proxy accepts only a bearer-token response. If Alpaca returns a `scope` field, the proxy fails
+closed if it includes `trading`, `account:write`, or `data` during `portfolio.read.v1`.
+
+It returns:
+
+```json
+{
+  "v": 1,
+  "alg": "A256GCM",
+  "iv": "<b64url 12 bytes>",
+  "ct": "<b64url ciphertext and tag>",
+  "aad": {
+    "provider": "alpaca",
+    "environment": "paper",
+    "grant_profile": "portfolio.read.v1",
+    "state_hash": "<b64url SHA-256>",
+    "iat": 1784311200
+  }
+}
+```
+
+The ciphertext contains only the token type and access token. The browser verifies the AAD,
+decrypts with the in-memory return key, and writes a provider record to the existing vault. No
+last-four token hint is displayed or stored. Safe cleartext metadata may include provider,
+environment, grant profile, connection label, and connected timestamp.
+
+If Alpaca later expires or revokes the token, v1 requires reconnect. No refresh-token behavior is
+invented because Alpaca's Trading API Connect documentation does not publish one for this flow.
+
+## Positions request and data contract
+
+### User-action scope
+
+Every refresh mints a new envelope containing the vaulted token:
+
+```json
+{
+  "v": 1,
+  "provider": "alpaca",
+  "action": "positions.list",
+  "params": { "environment": "paper" },
+  "budget": { "max_calls": 1, "max_mutations": 0, "ttl": 30 }
+}
+```
+
+The envelope AAD binds the authenticated `sub`, provider, issue time, unique `jti`, and canonical
+scope hash. The proxy redeems it once, holds the bearer token only for this one call, and tears the
+session down whether the call succeeds or fails.
+
+### Positions sequence
+
+```mermaid
+sequenceDiagram
+    participant B as Browser
+    participant R as FastAPI route
+    participant S as AlpacaService
+    participant G as Proxy gateway
+    participant P as Trading Key Proxy
+    participant A as Alpaca Paper API
+
+    B->>B: Unlock vaulted token and create positions.list envelope
+    B->>R: POST /api/alpaca/positions
+    R->>S: list_positions with Principal and request model
+    S->>G: Fetch raw positions through proxy
+    G->>P: Redeem envelope and request positions.list
+    P->>P: Verify scope and allowlist exact GET operation
+    P->>A: GET /v2/positions with bearer token
+    A-->>P: Position array and X-Request-ID
+    P-->>G: Allowlisted provider response
+    G-->>S: Raw position DTOs and request metadata
+    S->>S: Normalize decimals and calculate totals
+    S->>S: Record metadata-only audit outcome
+    S-->>R: AlpacaPositionsResponse
+    R-->>B: no-store response
+```
+
+### Public REST surface
+
+All routes require `require_principal` and use the existing per-user ES256 identity before real
+cloud credentials are permitted.
+
+| Route | Purpose |
+|---|---|
+| `GET /api/alpaca/key-info` | Relay trading-proxy public keys plus authenticated subject for envelope AAD |
+| `POST /api/alpaca/oauth/start` | Start the fixed paper `portfolio.read.v1` consent flow |
+| `POST /api/alpaca/oauth/exchange` | Exchange code and opaque state for an encrypted token receipt |
+| `POST /api/alpaca/positions` | Fetch current paper positions using a single-use token envelope |
+| `POST /api/alpaca/agent/positions` | Redeem an audience-bound sidekick grant through the canonical positions service |
+
+Sensitive material uses POST bodies, never query parameters. There is no arbitrary URL, HTTP
+method, header, environment, or provider path in any public request model.
+
+### Normalized Pydantic response
+
+Alpaca represents financial values as decimal strings. The service parses with `Decimal`, rejects
+malformed values, and returns normalized decimal strings so `QuantCoreJSONResponse` cannot coerce
+them through binary floating point.
+
+Each position contains:
+
+```text
+asset_id
+symbol
+exchange
+asset_class
+side
+qty
+qty_available
+avg_entry_price
+current_price
+market_value
+cost_basis
+unrealized_pl
+unrealized_plpc
+unrealized_intraday_pl
+unrealized_intraday_plpc
+change_today
+```
+
+All market-derived fields are nullable. This covers Alpaca assets whose price data is temporarily
+unavailable. Unknown additional provider fields are ignored and never become accidental API
+surface.
+
+Response shape:
+
+```json
+{
+  "environment": "paper",
+  "as_of": "2026-07-17T18:00:00Z",
+  "positions": [],
+  "totals": {
+    "market_value": "0",
+    "cost_basis": "0",
+    "unrealized_pl": "0",
+    "unrealized_plpc": "0",
+    "unrealized_intraday_pl": "0"
+  }
+}
+```
+
+Totals are service-owned business logic:
+
+- dollar totals are sums of non-null position values;
+- aggregate unrealized percentage is `total_unrealized_pl / abs(total_cost_basis)` when cost
+  basis is nonzero, otherwise `null`;
+- position percentages are never added together; and
+- short and fractional positions retain their signed and fractional decimal values.
+
+The response carries:
+
+```text
+Cache-Control: no-store, private
+Pragma: no-cache
+```
+
+### Error contract
+
+Provider credential failures must not masquerade as failure of the QuantCore app JWT. Stable safe
+error codes are returned through the Alpaca response schema:
+
+| Condition | REST status | Code | UI action |
+|---|---:|---|---|
+| Alpaca token invalid or revoked | 409 | `ALPACA_RECONNECT_REQUIRED` | Clear positions and offer reconnect |
+| Alpaca throttling | 429 | `ALPACA_RATE_LIMITED` | Honor safe retry delay |
+| Alpaca unavailable | 502 | `ALPACA_UNAVAILABLE` | Preserve vault token and allow retry |
+| Provider timeout | 504 | `ALPACA_TIMEOUT` | Preserve vault token and allow retry |
+| Invalid or replayed envelope | 400 | `ALPACA_REQUEST_REJECTED` | Mint a fresh user-action envelope |
+| Missing, invalid, expired, or mismatched agent grant | 403 | `ALPACA_TOOL_GRANT_REJECTED` | Retry with explicit per-message consent |
+| Internal MCP wrapper unavailable | 503 | `ALPACA_TOOL_UNAVAILABLE` | Preserve vault token and allow retry |
+| Wrong or missing QuantCore identity | 401 | existing auth response | Return to application authentication |
+
+Error bodies never contain Alpaca response bodies, OAuth values, envelopes, credentials, or
+position data. The proxy disables HTTP redirects, so a bearer token cannot follow a provider
+redirect to another host.
+
+## Anthropic sidekick access through MCP
+
+This is the second read-only milestone, after the direct `/portfolio` path is proven against a
+paper account. It deliberately exposes the existing service capability rather than introducing
+an MCP-specific position implementation.
+
+### Per-message consent and chat contract
+
+The chat composer adds `Allow this message to access Alpaca positions`. It is off by default,
+available only while a `portfolio.read.v1` Alpaca vault record is unlocked, and reset immediately
+after send. It is never stored in localStorage, IndexedDB, React Query, or another sticky client
+store. The adjacent disclosure states that enabling it lets the sidekick retrieve positions once
+and sends the returned position data to the user's configured Anthropic account.
+
+When enabled, the browser creates a fresh envelope and adds one provider grant to the existing
+Anthropic BYOK chat request. Existing top-level `key_envelope` and `scope` fields remain the
+Anthropic credential contract from the base proposal; `tool_grants` is a separate, bounded list
+for provider tools:
+
+```json
+{
+  "chat_request_id": "5d6b94c8-52fd-4f3c-8f97-46bfe8fb0493",
+  "messages": [],
+  "key_envelope": {},
+  "scope": {},
+  "tool_grants": [
+    {
+      "provider": "alpaca",
+      "envelope": {},
+      "scope": {
+        "v": 1,
+        "provider": "alpaca",
+        "action": "positions.list",
+        "params": {
+          "environment": "paper",
+          "consumer": "anthropic_chat",
+          "chat_request_id": "5d6b94c8-52fd-4f3c-8f97-46bfe8fb0493"
+        },
+        "budget": {
+          "max_calls": 1,
+          "max_mutations": 0,
+          "ttl": 300
+        }
+      }
+    }
+  ]
+}
+```
+
+The browser generates `chat_request_id` with `crypto.randomUUID()`. The schema accepts zero or one
+tool-grant entry in this milestone and only `provider=alpaca`; its list shape permits additive
+providers later without changing the chat envelope. It rejects duplicate or unknown providers,
+extra fields, mutation budgets, or a scope request ID that differs from the body. The
+Trading Key Proxy applies a provider-specific maximum envelope age of 300 seconds only to
+`positions.list` with `consumer=anthropic_chat`, one call, zero mutations, and the paper host.
+The direct `/portfolio` action retains its 30-second lifetime. This narrow exception accommodates
+the first Anthropic turn without widening any operation or permitting a second provider call.
+
+If the toggle is off, `tool_grants` contains no Alpaca entry and `ChatService` omits the Alpaca
+tool entirely. The model cannot ask for, discover, or synthesize a missing capability.
+
+### Server-sealed agent tool grant
+
+`AgentToolGrantService`, wired through the composition root, validates the submitted grant's
+shape and binding and seals the still-encrypted Alpaca envelope and scope into an
+`AgentToolGrant`. The API does not decrypt the OAuth token. The opaque wire value is AES-256-GCM
+under the rotatable `AGENT_TOOL_GRANT_KEYS` bundle and uses the same versioned
+`header.iv.ciphertext` convention as OAuth state.
+
+The encrypted claims are:
+
+```json
+{
+  "v": 1,
+  "aud": "alpaca-portfolio-mcp",
+  "sub_hash": "<keyed hash of authenticated subject>",
+  "tool": "get_alpaca_positions",
+  "provider": "alpaca",
+  "action": "positions.list",
+  "chat_request_id": "5d6b94c8-52fd-4f3c-8f97-46bfe8fb0493",
+  "envelope": {},
+  "scope": {},
+  "nonce": "<128-bit random>",
+  "iat": 1784311200,
+  "exp": 1784311500
+}
+```
+
+The expiry cannot exceed the embedded scope or Trading Key Proxy envelope deadline. The grant is
+not persisted. Its embedded envelope `jti` provides one-use redemption at the credential
+boundary; after the first successful redemption, replay fails even if a grant is captured. The
+extra encryption prevents the MCP wrapper from inspecting or altering provider capability
+details and binds the ciphertext to one audience and one tool.
+
+`ChatService` advertises exactly this model-visible schema when the grant is present:
+
+```text
+get_alpaca_positions() -> AlpacaPositionsResponse
+```
+
+It has no model-controlled arguments. The service calls an injected `McpToolGateway`, which passes
+the following namespaced FastMCP request metadata out-of-band from the Anthropic tool schema:
+
+```json
+{
+  "quantcore": {
+    "user_authorization": "Bearer <per-user JWT>",
+    "agent_tool_grant": "<opaque>",
+    "chat_request_id": "5d6b94c8-52fd-4f3c-8f97-46bfe8fb0493"
+  }
+}
+```
+
+The API-to-MCP HTTP request uses a Google IAM ID token to invoke the internal Cloud Run service;
+the user's JWT stays inside MCP metadata on that hop. The wrapper extracts it and sends it as
+`Authorization` to FastAPI. If the REST service also requires Cloud Run IAM, the wrapper sends its
+Google ID token separately as `X-Serverless-Authorization`. This follows the standard's identity
+passthrough rule without confusing application identity with service identity.
+
+### Curated wrapper and canonical REST endpoint
+
+The dedicated Alpaca portfolio FastMCP server exports only `get_alpaca_positions`. Its tool body:
+
+1. requires the three namespaced metadata values;
+2. constructs `POST /api/alpaca/agent/positions` with body
+   `{ "tool_grant": "<opaque>" }`;
+3. forwards the user JWT;
+4. returns the canonical `AlpacaPositionsResponse`; and
+5. converts bounded HTTP failures to safe tool errors.
+
+The wrapper performs no decryption, claim validation, authorization, rate limiting, audit,
+normalization, calculation, cache decision, database access, or provider access. The endpoint's
+Pydantic request has only `tool_grant`; there are no symbol, URL, path, environment, scope, header,
+or provider-operation fields for the model to influence.
+
+The one-call-deep REST route obtains `Principal` and calls
+`AlpacaService.list_positions_for_agent(principal, request)`. The service opens the grant through
+the injected `AgentToolGrantService`, validates every claim against the principal and route,
+applies service-owned rate policy, then executes the same private canonical positions workflow
+used by `list_positions`. Both entry methods share normalization, aggregate totals, error mapping,
+and audit behavior; neither route nor MCP duplicates them.
+
+### Agent request sequence
+
+```mermaid
+sequenceDiagram
+    participant B as Browser
+    participant R as Chat REST route
+    participant C as ChatService
+    participant H as Anthropic Key Proxy
+    participant A as Anthropic
+    participant M as Alpaca portfolio MCP
+    participant P as Alpaca REST route
+    participant S as AlpacaService
+    participant K as Trading Key Proxy
+    participant T as Alpaca Paper API
+
+    B->>B: Opt in and create Alpaca read envelope
+    B->>R: Send chat request with Anthropic envelope and Alpaca tool grant
+    R->>C: Start authenticated chat turn
+    C->>C: Validate and seal the agent tool grant
+    C->>H: Start Anthropic session with curated tool schema
+    H->>A: Stream model request
+    A-->>H: Request get_alpaca_positions
+    H-->>C: Tool use block
+    C->>M: Call tool with JWT and opaque grant in MCP metadata
+    M->>P: POST authenticated agent positions request
+    P->>S: Call list_positions_for_agent
+    S->>S: Validate subject audience tool action request and budget
+    S->>K: Redeem embedded envelope for positions.list
+    K->>T: GET paper positions with user bearer token
+    T-->>K: Position array
+    K-->>S: Allowlisted response
+    S->>S: Normalize totals and write metadata-only audit
+    S-->>P: Canonical positions response
+    P-->>M: No-store response
+    M-->>C: Tool result
+    C->>C: Cache result for this turn only
+    C->>H: Continue Anthropic session with tool result
+    H->>A: Continue model request
+    A-->>H: Final response
+    H-->>C: Final response
+    C-->>R: Stream response and clear turn state
+    R-->>B: Sidekick response
+```
+
+The Anthropic Key Proxy receives only the Anthropic envelope and session, model messages, tool
+schema, and eventual tool result. It never receives the Alpaca envelope, OAuth token,
+`AgentToolGrant`, JWT metadata, or Trading Key Proxy session. The full normalized positions and
+totals necessarily become part of the user's Anthropic conversation after tool execution; the
+per-message disclosure makes that data transfer explicit.
+
+After one successful call, `ChatService` returns the ephemeral cached result if the model requests
+the same tool again in that turn. It does not call MCP, REST, the Trading Key Proxy, or Alpaca a
+second time. The cache is bounded to the request, never persisted, never logged, and cleared in a
+`finally` path on success, error, timeout, disconnect, or cancellation.
+
+Missing metadata, invalid consent, grant mismatch, expiry, replay, locked vault, REST/MCP timeout,
+or provider failure returns a safe tool error and no position data. `ChatService` may let the model
+explain that the user must retry with the toggle enabled, but it does not reveal which security
+check failed. No fallback path calls `AlpacaService` directly.
+
+## Metadata-only audit
+
+Architectural Standard v2 puts audit policy in the services layer. Add a small append-only
+`provider_access_audit` table and repository. This is not credential persistence.
+
+Each event records:
+
+- timestamp;
+- authenticated principal subject or stable internal identifier;
+- provider (`alpaca`);
+- environment (`paper`);
+- operation (`oauth.start`, `oauth.exchange`, or `positions.list`);
+- consumer (`portfolio_ui` or `anthropic_chat`);
+- grant profile;
+- success or safe error category;
+- QuantCore correlation ID;
+- chat request ID and MCP tool name for agent calls;
+- Alpaca `X-Request-ID`, when present; and
+- latency.
+
+It must never record:
+
+- client ID secrets or user tokens;
+- authorization codes or OAuth state;
+- token receipts or BYOK envelopes;
+- request or response bodies;
+- symbols, quantities, prices, position values, or totals; or
+- exception dumps containing provider material.
+
+`AlpacaService` writes an `attempted` event before provider access and a `succeeded` or `failed`
+event afterward through the injected audit repository. Routes, gateways, the proxy, and the
+frontend cannot write audit rows directly. If the initial audit write fails, provider access fails
+closed. If the outcome write fails after an attempt was durably recorded, operational monitoring
+is raised under the same correlation ID; the read-only v1 response may still complete. Future
+mutations will require both their durable pre-execution audit and idempotency record before the
+provider call.
+
+## Frontend experience
+
+### Navigation and naming
+
+Add a `Portfolio` navigation item and `/portfolio` route titled **Alpaca Paper Portfolio**. The
+existing DB-backed holdings remain on the Securities page and its user-facing filter is renamed
+from “Portfolio” to **Tracked holdings** to distinguish the manual QuantCore universe from the
+connected brokerage account.
+
+### Chat consent control
+
+Add a non-sticky checkbox or toggle next to the chat send control labeled
+`Allow this message to access Alpaca positions`. Its accessible description says:
+
+> The sidekick may read your current Alpaca paper positions once for this message. Position data
+> returned by the tool will be sent to your configured Anthropic account.
+
+The control is disabled with an `Unlock Alpaca to enable` explanation when the provider vault is
+locked, absent, or lacks `portfolio.read.v1`. Sending captures the current boolean, resets it
+before awaiting the network response, and constructs the Alpaca envelope only when it was true.
+A failed or cancelled send does not silently re-enable consent; the user must opt in again.
+Neither the assistant nor a prompt can change the control.
+
+### Page states
+
+| State | Experience |
+|---|---|
+| No Alpaca vault record | Explain Alpaca Connect and show `Connect Alpaca Paper Account` |
+| Vault locked | Show `Unlock to view positions`; make no Alpaca request |
+| Connecting | Show popup progress and a cancel action |
+| Popup blocked | Explain how to allow the user-initiated Alpaca popup and retry |
+| Consent denied or expired | Leave the vault unchanged and show a safe retry message |
+| Connected and loading | Show skeleton summary cards and grid |
+| Connected with positions | Show totals and sortable position rows |
+| Connected with zero positions | Confirm the connection worked and state `No open positions` |
+| Token invalid or revoked | Clear cached positions and show `Reconnect Alpaca` |
+| Provider temporarily unavailable | Keep the vault record and offer retry |
+
+### Positions panel
+
+Summary cards:
+
+- market value;
+- cost basis;
+- unrealized gain/loss and percentage; and
+- intraday unrealized gain/loss.
+
+Sortable grid columns:
+
+- symbol;
+- asset class;
+- side;
+- quantity and available quantity;
+- average entry;
+- current price;
+- market value;
+- daily change;
+- intraday P/L; and
+- total unrealized P/L and percentage.
+
+Clicking a symbol opens the existing `/securities/:symbol` detail page. Formatting is
+presentation-only; calculations and provider normalization stay in `AlpacaService`.
+
+Positions refresh every 60 seconds while the vault is unlocked and the page is visible. A manual
+refresh is available. Auto-refresh pauses when hidden, offline, locked, or rate-limited. Locking
+or disconnecting cancels in-flight queries and removes Alpaca position data from React Query.
+No position data enters localStorage, IndexedDB, service workers, analytics, or error telemetry.
+
+### Disconnect and revocation
+
+Disconnect deletes the encrypted Alpaca record from the browser after confirmation and clears
+all in-memory data. Because the v1 design has no published Alpaca token-revocation API to call, the
+UI also tells the user how to remove the application's authorization in Alpaca. Exact copy and
+link target are verified during Alpaca Connect application registration before rollout.
+
+## Trading Proxy deployment and controls
+
+`quantcore-keyproxy-trading` uses the same reviewed crypto primitives and generic session model as
+the base key proxy, but is a different Cloud Run service and trust domain.
+
+| Control | Trading deployment |
+|---|---|
+| Ingress | `--no-allow-unauthenticated`; only quantcore-api runtime SA has `run.invoker` |
+| Identity | ES256 JWT, audience specific to the trading proxy, verified independently |
+| Envelope key | Separate P-256 keypair and frontend SPKI pin list |
+| OAuth secrets | Separate test/prod client secret and rotatable OAuth-state key bundle |
+| Session TTL | At most 30 seconds for a direct UI read; at most 300 seconds for the explicitly tagged agent read; one provider call and explicit teardown in either case |
+| Scaling | `--max-instances=1` for v1 session coherence |
+| Redirects | Disabled on token and provider HTTP clients |
+| Provider hosts | Hardcoded, never request-influenced |
+| Egress | FQDN-aware deny-by-default policy for the required Alpaca hosts only |
+| Logging | Allowlist metadata only, with body/header logging disabled |
+| Rate limit | Per-sub redemption limit sized above the 60-second UI refresh cadence |
+
+Use a Google Cloud Secure Web Proxy or an approved equivalent for FQDN-aware egress policy. Code
+allowlisting alone is required but is not considered the network control. The service may reach:
+
+```text
+api.alpaca.markets:443
+paper-api.alpaca.markets:443
+```
+
+`app.alpaca.markets` is opened by the user's browser, not by the proxy. Secrets are injected by
+Cloud Run at startup. No arbitrary outbound host, URL, proxy, or redirect target is configurable
+from request data.
+
+## Alpaca portfolio MCP deployment
+
+Deploy `quantcore-mcp-alpaca-portfolio` as a separate, internal-ingress Cloud Run service using
+FastMCP streamable HTTP transport. It has no Alpaca credentials, database access, Cloud SQL
+binding, Trading Key Proxy permission, or general outbound internet access. Its runtime identity
+may invoke only the QuantCore REST tier, and only the quantcore-api runtime identity may invoke
+the MCP service.
+
+The service exports one hand-curated tool rather than mirroring the whole Alpaca OpenAPI group.
+Its shared REST client is the only HTTP seam and must preserve user identity as required by
+Architectural Standard v2. Local development runs the wrapper as a separate process or container
+against the local FastAPI base URL; production uses the internal Cloud Run URL. The tool contract
+and behavior are identical in both environments.
+
+The reentrant `quantcore-api -> MCP -> quantcore-api` call requires an async, concurrently served
+REST deployment. The MCP hop uses a bounded connect/read/total timeout shorter than the remaining
+chat-turn deadline and propagates cancellation. A deployment smoke test must exercise the loop to
+prevent connection-pool starvation or a single-worker deadlock. No fallback can replace it with
+`ChatService -> AlpacaService`, because that would violate Rule 6.
+
+## OAuth permission progression
+
+The encrypted vault record carries a grant profile so the UI and service never infer authority
+from token presence alone.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Disconnected
+    Disconnected --> PortfolioRead: Connect paper account
+    PortfolioRead --> PortfolioRead: Read open positions
+    PortfolioRead --> TradingEnabled: Reauthorize when order release ships
+    TradingEnabled --> TradingEnabled: Read positions and execute confirmed paper actions
+    PortfolioRead --> Disconnected: Disconnect or revoke
+    TradingEnabled --> Disconnected: Disconnect or revoke
+```
+
+For the future upgrade:
+
+- the user selects `Enable Paper Trading` in a dedicated consent flow;
+- `AlpacaService` selects `paper-trading.v1` and requests exactly `trading`;
+- Alpaca displays the expanded permission to the user;
+- the proxy verifies the returned grant includes the expected scope and no unrequested scope;
+- the browser validates and stores the new encrypted token before deleting the old record; and
+- failure leaves the previous portfolio-read token intact.
+
+The upgrade does not automatically enable any provider endpoint. Proxy operation taxonomy and
+REST/service capabilities remain separately fail-closed.
+
+## Future roadmap designed into the boundary
+
+These phases are intentionally not implemented by the positions release. They are documented so
+v1 does not create an unsafe dead end.
+
+### Broad single-order paper trading
+
+The next trading proposal may cover:
+
+- equities, options, and crypto;
+- market, limit, stop, stop-limit, and trailing-stop orders;
+- bracket, OCO, OTO, and Alpaca-supported multi-leg orders;
+- extended-hours eligibility;
+- open-order listing and terminal-state reconciliation;
+- cancellation and replacement; and
+- quantity-based sizing initially, with any later sizing modes added explicitly to the schema.
+
+Every mutation must use plan, confirm, execute:
+
+1. The browser sends user intent to a thin REST route.
+2. `AlpacaService` validates the intent and creates a canonical, bounded order plan.
+3. The browser renders that plan verbatim, including paper environment, asset, side, quantity,
+   type, prices, order class, time in force, extended-hours flag, and mutation limit.
+4. The user explicitly confirms.
+5. The browser seals the exact plan into `scope_hash` with a fresh `jti`.
+6. The service owns idempotency, risk, entitlement, and audit behavior.
+7. The proxy independently permits one exact Alpaca mutation matching the sealed plan.
+
+The envelope `jti` deterministically supplies Alpaca's `client_order_id`. If the submission
+outcome is unknown, the service reconciles by client order ID using a new read scope. It never
+blindly resubmits with a new mutation envelope.
+
+Before the first mutation ships:
+
+- replace in-memory nonce replay protection with a dedicated durable atomic store;
+- add service-owned risk and entitlement policy;
+- require a durable pre-execution audit record and terminal reconciliation event;
+- add explicit human confirmation and a short mutation TTL;
+- enforce server-side quantity, price, call, and mutation ceilings;
+- add an operation-by-operation provider taxonomy with fail-closed tests;
+- keep all execution hosts fixed to Alpaca paper endpoints; and
+- complete a new security review before any live-account design begins.
+
+### Additional AI and MCP access
+
+The delivered MCP surface remains limited to sidekick-initiated position reads with per-message
+consent. External MCP clients, unattended agents, scheduled portfolio polling, other Alpaca read
+operations, and every mutation require a separate capability review. New capabilities must still
+be born in `AlpacaService`, exposed through canonical REST, and then deliberately curated for MCP.
+
+Any future paper-order tool must use a separate confirmed-mutation grant. The human confirmation
+must render the final service-generated order plan, and services must enforce the confirmation,
+idempotency key, entitlements, risk limits, durable pre-execution audit, and reconciliation. The
+MCP wrapper remains a one-call-deep REST adapter and cannot implement or weaken those controls.
+
+### Predefined multi-order workflows
+
+A later scope-v2 release may execute named, versioned workflow templates:
+
+- the service expands a selected workflow into an ordered, fully bounded step list;
+- the user confirms the complete list before the first mutation;
+- the envelope seals template ID, version, steps, limits, order, and allowed failure handling;
+- the proxy enforces next-step ordering, success gating, per-step idempotency, and budgets;
+- compensation steps must be declared and confirmed in advance; and
+- partial completion is a saga requiring reconciliation and a blocking alert, not an ACID
+  rollback.
+
+There will never be a generic “execute these arbitrary Alpaca requests” endpoint or workflow.
+
+## Environment variables and secrets
+
+| Component | Name | Purpose |
+|---|---|---|
+| quantcore-api | `TRADING_KEYPROXY_URL` | Internal Cloud Run URL for the trading proxy |
+| quantcore-api | `TRADING_KEYPROXY_TIMEOUT` | Bounded proxy request timeout |
+| quantcore-api | `ALPACA_PORTFOLIO_MCP_URL` | Internal streamable HTTP endpoint for the curated wrapper |
+| quantcore-api | `ALPACA_PORTFOLIO_MCP_TIMEOUT` | Bounded MCP tool-call timeout below the chat-turn deadline |
+| quantcore-api | `AGENT_TOOL_GRANT_KEYS` | Rotatable AES-256-GCM keys for opaque per-message tool grants |
+| quantcore-api | `AGENT_TOOL_GRANT_MAX_TTL` | Server ceiling of 300 seconds for the read-only sidekick grant |
+| Alpaca portfolio MCP | `QUANTCORE_API_URL` | Canonical REST front-door base URL |
+| Alpaca portfolio MCP | `QUANTCORE_API_AUDIENCE` | Cloud Run IAM audience for the REST hop |
+| trading proxy | `KEYPROXY_PRIVATE_KEYS` | Trading-only envelope private-key bundle |
+| trading proxy | `ALPACA_OAUTH_CLIENT_ID` | Deployment-specific public OAuth client identifier |
+| trading proxy | `ALPACA_OAUTH_CLIENT_SECRET` | Secret Manager-mounted OAuth application secret |
+| trading proxy | `ALPACA_OAUTH_REDIRECT_URI` | Exact allowlisted quantui callback URI |
+| trading proxy | `ALPACA_OAUTH_STATE_KEYS` | Rotatable AES-256 state-encryption keys |
+| trading proxy | `QUANTCORE_JWT_PUBLIC_KEY` | ES256 verification key only |
+| trading proxy | `KEYPROXY_JWT_AUDIENCE` | Trading-proxy-specific audience |
+| trading proxy | `ALPACA_AGENT_ENVELOPE_MAX_SKEW` | Hard ceiling of 300 seconds for the exact agent positions profile |
+| frontend build | `VITE_TRADING_KEYPROXY_SPKI_PINS` | Test/prod trading-proxy public-key fingerprints |
+
+Test and production use different OAuth applications, callback URIs, client secrets, state keys,
+envelope keys, pins, runtime identities, and GCP projects. No real secret has a local default.
+Local and CI tests use deterministic fake providers and test-only key material.
+
+## Implementation packets
+
+Implementation follows the base proposal's one-packet, one-reviewable-commit cadence.
+
+| Packet | Deliverable | Status |
+|---|---|---|
+| A0 | This proposal, team security review, and Alpaca Connect registration request | ☐ |
+| A1 | OAuth-state and token-receipt crypto with shared Python/TypeScript vectors | ☐ |
+| A2 | Trading proxy deployment skeleton, OAuth exchange, and `positions.list` provider | ☐ |
+| A3 | Metadata-only audit repository and `AlpacaService` with fake collaborators | ☐ |
+| A4 | Thin Pydantic REST routes, proxy gateway, error mapping, and OpenAPI snapshot | ☐ |
+| A5 | Vault Alpaca record, popup callback flow, and connection UI | ☐ |
+| A6 | `/portfolio` page, summaries, position grid, and cache lifecycle | ☐ |
+| A7 | IAM, secrets, pins, FQDN-restricted egress, CI, and paper smoke test | ☐ |
+| A8 | Agent-tool grant service, chat request contract, and per-message consent UI | ☐ |
+| A9 | Canonical agent REST endpoint, curated FastMCP wrapper, MCP gateway, and ChatService tool wiring | ☐ |
+| A10 | MCP IAM, private deployment, architecture guards, and sidekick end-to-end test | ☐ |
+
+### Prerequisite gate
+
+Real OAuth tokens must not be used until the shared BYOK work provides:
+
+- the browser vault and explicit unlock lifecycle;
+- strict CSP, Trusted Types, `Referrer-Policy`, and popup-compatible COOP;
+- per-user ES256 JWTs with service-specific audiences;
+- public-key pinning and rotation; and
+- IAM-locked Cloud Run invocation.
+
+Packets A8 through A10 additionally require the base proposal's authenticated Anthropic
+`TurnContext`, Key Proxy chat client, and provider-scoped session lifecycle. A7's direct
+`/portfolio` paper-account acceptance must pass before A8 begins, so the MCP milestone wraps a
+known canonical service rather than debugging OAuth, normalization, and agent orchestration at
+the same time.
+
+Alpaca application registration can proceed in parallel. Development remains on a mock OAuth and
+mock positions provider until the gate is complete.
+
+### Packet A1 — return-channel crypto
+
+- Add shared vectors for OAuth state, return-key envelopes, token receipts, tampering, expiry,
+  Unicode, and key rotation.
+- Keep browser crypto on native `crypto.subtle` and proxy crypto on the existing reviewed Python
+  primitives.
+- Prove intermediaries cannot decrypt the return key or token receipt.
+
+### Packet A2 — Trading Key Proxy
+
+- Reuse the common key-proxy auth, envelope, replay, scope, and session primitives without sharing
+  deployment keys or sessions with the LLM proxy.
+- Add fixed OAuth start/exchange operations and one provider taxonomy entry: `positions.list`.
+- Use pooled async HTTP clients with redirects disabled, TLS verification, strict timeouts, and
+  constant safe failures.
+- Ensure raw provider bodies never enter exception logs.
+
+### Packet A3 — service and audit
+
+- Add `AlpacaService` as the canonical capability.
+- Inject the proxy gateway and audit repository through `quantcore/services/registry.py`.
+- Keep grant selection, position validation, Decimal normalization, totals, error categories, and
+  audit behavior in the service.
+- Add the metadata-only audit schema through the repo's normal additive PostgreSQL migration and
+  `init_schema()` parity path.
+
+### Packet A4 — REST front door
+
+- Add Pydantic request/response schemas and one-call-deep routes.
+- Apply `require_principal` to every route.
+- Return no-store headers and stable safe errors.
+- Update `docs/openapi-surface.txt` and architecture guards.
+
+### Packets A5 and A6 — frontend
+
+- Add the vault grant profile, return-key lifecycle, exact-origin popup handler, reconnect, and
+  disconnect flows.
+- Add `/portfolio` and rename the existing tracked-holdings filter.
+- Fetch only while unlocked and visible; clear financial data on lock or disconnect.
+- Do not add trading controls, disabled order buttons, or future-order placeholders.
+
+### Packet A7 — rollout
+
+- Register separate test/prod Alpaca Connect apps with exact callbacks.
+- Provision trading-only identities, secrets, keys, pins, Cloud Run service, and egress policy.
+- Deploy test first, verify a dedicated paper account, then promote the exact reviewed image by
+  digest through the existing gated production workflow.
+- Record callback, consent, disconnect/revocation, and log-audit results in this document.
+
+### Packet A8 — per-message agent capability
+
+- Add canonical Pydantic `ToolGrant`, `AgentPositionsRequest`, and existing response-model reuse;
+  extend `ChatRequest` with `chat_request_id` and the bounded `tool_grants` list.
+- Add `AgentToolGrantService` with versioned AES-GCM issuance and validation, rotation vectors,
+  exact claim binding, expiry, and never-log tests; wire it only through the composition root.
+- Add the off-by-default chat control, disclosure, vault-unlocked gate, fresh Alpaca envelope,
+  immediate reset-on-send behavior, and cancellation cleanup.
+- Verify the Anthropic request and tool schema contain no Alpaca envelope, grant, JWT, or
+  credential-shaped tool parameter.
+
+### Packet A9 — canonical MCP positions path
+
+- Add the one-call-deep `POST /api/alpaca/agent/positions` route and reuse the canonical
+  `AlpacaPositionsResponse` Pydantic contract.
+- Add `AlpacaService.list_positions_for_agent`, sharing the direct-read normalization, totals,
+  errors, and audit workflow while adding principal/grant/rate checks.
+- Add the one-tool FastMCP wrapper over REST and a thin async `McpToolGateway` for `ChatService`;
+  preserve user JWT metadata and separate Cloud Run service identity.
+- Dynamically include `get_alpaca_positions` only with a valid per-message grant; cache one
+  successful result for the turn and clear it on every terminal path.
+- Update `docs/openapi-surface.txt` and the MCP list-tools snapshot in the same packet.
+
+### Packet A10 — private deployment and end-to-end proof
+
+- Deploy the wrapper with internal ingress, least-privilege invoker relationships, bounded
+  timeouts, cancellation propagation, no Cloud SQL attachment, and no provider egress.
+- Add architecture-import guards, OpenAPI/MCP contract checks, never-log capture, replay and
+  confused-deputy tests, and a reentrant-call concurrency smoke test.
+- Exercise a complete tool-using chat against deterministic Anthropic and Alpaca fakes, then a
+  dedicated paper account, and record credential/data-flow inspection results in this proposal.
+
+## Verification
+
+### Architecture tests
+
+- `api/routers/alpaca.py` imports only schemas, auth/dependency seams, and service DTOs/errors.
+- Each route body contains exactly one service call and no provider or persistence logic.
+- `AlpacaKeyProxyGateway` contains no scope selection, totals, risk, entitlement, or audit logic.
+- `AlpacaService` tests use fake gateway and audit repository collaborators.
+- The React feature imports only frontend API/hook/vault abstractions and never provider SDKs.
+- The Alpaca MCP package imports only its FastMCP/REST adapter seams and canonical contract types;
+  it cannot import services, stores, DB modules, provider SDKs, or key-proxy gateways.
+- `get_alpaca_positions` makes exactly one REST call and exports no other Alpaca tool.
+- `ChatService` reaches the agent positions capability only through `McpToolGateway`; import and
+  call-graph guards reject a direct `ChatService -> AlpacaService` path.
+- The MCP request re-enters REST without deadlock under the production worker and connection-pool
+  configuration.
+- OpenAPI snapshot changes are explicit and reviewed.
+
+### Crypto and OAuth tests
+
+- Python and TypeScript agree on every shared vector.
+- Wrong subject, environment, callback, grant profile, key, state, and expiry fail closed.
+- Token receipt AAD or ciphertext tampering fails authentication.
+- Popup messages with wrong origin, source, state, or no pending connection are ignored.
+- Consent denial, popup close, popup block, timeout, and callback reload leave the vault unchanged.
+- V1 authorization URL contains `env=paper` and no `trading`, `account:write`, or `data` scope.
+- An unexpected write scope in the token response is rejected.
+- State and authorization-code values never appear in logs or browser history after callback.
+
+### Provider and security tests
+
+- The only allowed provider operation is exact `GET /v2/positions` on
+  `paper-api.alpaca.markets`.
+- POST, PATCH, DELETE, alternate paths, alternate hosts, live environment, and redirects fail.
+- Replayed and stale envelopes fail; cross-user token envelopes fail.
+- Agent envelopes are accepted for at most 300 seconds only when provider, action, consumer,
+  environment, request binding, max calls, and zero-mutation budget match the fixed profile.
+- The proxy tears down token sessions on success, provider error, timeout, and client cancellation.
+- A captured envelope is not sufficient without the matching per-user JWT.
+- Failure log capture contains no client secret, token, envelope, code, state, symbol, quantity,
+  price, value, total, request body, or provider response body.
+
+### Service and contract tests
+
+- Empty and populated positions normalize correctly.
+- Whole, fractional, long, short, equity, option, crypto, and nullable market fields are accepted
+  within the documented response shape.
+- Invalid decimal fields fail safely without leaking provider bodies.
+- Aggregate dollar values and percentage calculations are exact.
+- Alpaca 401/403, 429, 5xx, timeout, and malformed payloads map to stable safe errors.
+- Audit rows contain required metadata and no disallowed financial or credential data.
+- Response headers prevent browser/intermediary caching.
+
+### Agent grant, MCP, and chat tests
+
+- Grant ciphertext tampering, unknown key/version/algorithm, expiry, replay, wrong subject hash,
+  audience, tool, provider, action, environment, request ID, or budget fail closed.
+- The tool is absent when consent is off, the vault is locked, the profile is missing, or the
+  submitted grant is invalid; it is present only for the opted-in message.
+- The Anthropic tool schema has zero arguments and Anthropic proxy traffic contains no Alpaca
+  envelope, token, tool grant, Trading Key Proxy session, or user JWT metadata.
+- FastMCP metadata remains out of model-visible arguments. The wrapper forwards the user JWT in
+  REST `Authorization` and uses a separate Google identity for each Cloud Run hop.
+- Repeated model requests for the tool in one turn return the ephemeral cached result and produce
+  exactly one MCP, REST, Trading Key Proxy, and Alpaca call.
+- Success, rejection, timeout, client disconnect, and cancellation clear turn cache and grant
+  references and tear down any live provider session.
+- A caller outside the internal service identity cannot invoke the wrapper; a caller without a
+  valid user JWT and matching agent grant cannot use the REST endpoint.
+- Tool errors are bounded and reveal no claim mismatch, credential, provider body, position body,
+  or internal endpoint.
+
+### Frontend tests
+
+- All page states render and transition correctly.
+- A successful token receipt is vaulted only after cryptographic validation.
+- Reconnect replaces the vault record atomically.
+- Lock and disconnect cancel queries and clear position data.
+- Auto-refresh runs only while unlocked, online, visible, and below the rate limit.
+- Decimal formatting, negative values, null values, sorting, responsive layout, and symbol
+  navigation work correctly.
+- No position data is written to localStorage or IndexedDB.
+- The chat opt-in is off initially, disabled while Alpaca is unavailable or locked, resets before
+  awaiting send, and never persists or silently re-enables after retry or cancellation.
+- The exact Anthropic data-transfer disclosure is visible and accessible beside the consent
+  control.
+
+### End-to-end acceptance
+
+1. Connect a dedicated Alpaca paper account through the test OAuth application.
+2. Ensure the paper account has at least one open position created outside this feature.
+3. Confirm the `/portfolio` rows and totals match Alpaca.
+4. Confirm zero order endpoints exist and no provider mutation was attempted.
+5. Lock the vault and confirm position data disappears and refresh stops.
+6. Reconnect and disconnect successfully.
+7. Inspect browser storage, quantui logs, API logs, proxy logs, audit rows, and network traces for
+   forbidden credential or financial payloads; the count must be zero.
+8. Ask the sidekick to show current positions without opting in and confirm no Alpaca tool is
+   advertised or called.
+9. Opt in for one message, ask the same question, and confirm the tool result and response match
+   the `/portfolio` canonical positions and totals.
+10. Confirm the next message has no Alpaca tool unless the user opts in again, and confirm a
+    repeated tool request within the opted-in turn causes no second Alpaca request.
+11. Inspect Anthropic proxy traffic and confirm it contains only the tool schema and normalized
+    result, never the Alpaca token, envelope, grant, JWT metadata, or Trading Key Proxy session.
+12. Run the full backend suite, architecture guards, OpenAPI check, MCP smoke/contract tests,
+    frontend typecheck, unit tests, coverage ratchet, and Playwright flow with no skipped or
+    weakened security tests.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| XSS can act as an unlocked user | Strict CSP, Trusted Types, strong passphrase, short unlocked lifetime, no third-party scripts, exact confirmation in future mutation flows |
+| Compromised API observes positions | Positions necessarily traverse REST; use per-user auth, no-store, no body logs, short memory retention, and metadata-only telemetry |
+| Position data is disclosed to Anthropic unexpectedly | Per-message non-sticky opt-in, adjacent explicit disclosure, tool omission without a grant, and no automatic retry consent |
+| Prompt injection requests broker access | The model cannot create a tool or capability; the tool has no arguments and exists only when the browser supplies a user-sealed grant |
+| Confused-deputy MCP call | Preserve the per-user JWT in hidden metadata and revalidate subject, audience, tool, request, scope, and rate policy at REST |
+| Compromised MCP wrapper consumes a grant | Encrypted audience-bound grant, matching JWT, single-use envelope, exact read-only scope, short expiry, internal ingress, and no provider egress |
+| Reentrant REST/MCP call deadlocks | Async clients and handlers, bounded timeouts, separate connection pools, cancellation propagation, and deployment concurrency smoke tests |
+| Compromised API substitutes proxy key | Separate build-time SPKI pins for the trading proxy |
+| OAuth state theft or login CSRF | Encrypted unpredictable state, exact browser equality, subject/callback/profile binding, five-minute expiry, single pending flow |
+| OAuth token exposed on return path | One-use in-memory return key and AES-GCM token receipt |
+| Provider redirect exfiltrates token | Redirects disabled and provider hosts hardcoded |
+| Proxy compromise exposes active tokens | Separate smallest-TCB deployment, restricted ingress/egress, short sessions, no persistence, future TEE roadmap |
+| Browser data is cleared | User reconnects through Alpaca; no unrecoverable user-created secret is lost |
+| Alpaca token expiry behavior changes | Treat 401 as reconnect; do not invent refresh behavior; monitor official docs before implementation |
+| V1 token lacks future trade permission | Deliberate least privilege; explicit `trading` reauthorization is part of the order release |
+| In-memory replay state is lost on restart | Accepted for read-only positions under short skew; durable atomic replay is mandatory before mutations |
+| OAuth app approval blocks real testing | Build and test against deterministic mocks; registration is a rollout gate, not a reason to weaken controls |
+
+## Team-review questions
+
+The implementation defaults above are decision-complete, but reviewers should challenge these
+specific boundaries before approval:
+
+- Is the one-use return-key protocol small and auditable enough, or should the browser vault gain a
+  persistent encrypted receipt keypair instead?
+- Does the chosen GCP egress control provide a true FQDN deny-by-default policy for both required
+  Alpaca hosts?
+- Does Alpaca's registered-app dashboard provide a stable user-revocation link we can safely place
+  in the disconnect UI?
+- Are metadata-only audit fields sufficient for privacy and operational investigation?
+- Are the base BYOK CSP, per-user JWT, pinning, and vault prerequisites complete enough to permit a
+  real paper token?
+- Is the per-message disclosure sufficiently clear that normalized position data enters the
+  user's Anthropic conversation after a successful tool call?
+- Are the internal Cloud Run identities and user-JWT metadata hop independently testable and
+  least-privilege in both test and production projects?
+- Is the narrow 300-second agent-read envelope window acceptable for model latency given its
+  one-call, zero-mutation, paper-only, subject-bound scope?
+- Does the future mutation boundary preserve Architectural Standard v2 ownership of risk,
+  idempotency, and audit in `AlpacaService` while retaining independent proxy enforcement?
+
+Any change that introduces server-side token persistence, direct frontend/provider access, a
+generic proxy operation, a route with business logic, an unconfirmed mutation, or a write-capable
+MCP tool requires a new security and architecture review rather than an edit made mid-packet.

--- a/docs/proposals/byok-key-proxy-plan.md
+++ b/docs/proposals/byok-key-proxy-plan.md
@@ -739,7 +739,7 @@ the context):
 | 6 | Chat integration: envelope attach in `chatStream.ts`/`ChatContext`, ChatRail gating (absent/locked/unlocked), retire env-key path, compose E2E (persistent dev keypair + pin bake in `runUI-CONTAINERS.sh`; empty-bearer h11 fix in the gateway) | ✅ 2026-07-18 | (Phase 6 commit) |
 | 7a | ES256 verifiers: `api/auth.py` dual-mode (ES256 users + legacy HS256), keyproxy ES256-only, algorithm-confusion tests. Note: `cryptography` moved into `requirements-base.txt` (PyJWT needs it for ES256; invariant 1 refined — key material/decrypt path still keyproxy-only) | ✅ 2026-07-18 | (Phase 7 commit) |
 | 7b | Express IAP-verify + per-user ES256 mint (`frontend/server/auth.mjs`, jose, `node --test` suite); ladder keyed on `QUANTUI_SIGNING_KEY` presence, hard 401 on bad/absent assertion. Cloud E2E (two IAP users → distinct subs in api logs) + secret creation (`quantui-signing-key`/`-pub`) are deploy-time steps | ✅ 2026-07-18 | (Phase 7 commit) |
-| 8a | CI wiring: `cloudbuild.yaml` build-keyproxy step, `deploy.yml` (+ gitleaks secret-scanning job), `prod-rollout.yml` | ☐ | |
+| 8a | CI wiring: `cloudbuild.yaml` build-keyproxy step, `deploy.yml` (+ gitleaks secret-scanning job), `prod-rollout.yml`. Local proof: full 255-commit history scans clean under `.gitleaks.toml` (5 false positives triaged → narrow allowlist regexes); planted anthropic/AWS/PEM fakes all caught. CI-on-PR + throwaway-branch plant proof remain John's step (no pushes from this session) | ✅ 2026-07-18 | (Phase 8a commit) |
 | 8b | Manual first-deploy runbook (IAM-locked keyproxy), executed interactively with John; results logged here | ☐ | |
 
 ## Phase details

--- a/docs/proposals/byok-key-proxy-plan.md
+++ b/docs/proposals/byok-key-proxy-plan.md
@@ -727,8 +727,8 @@ the context):
 | 1a | Python envelope crypto + keypair script + shared test vectors (`keyproxy/crypto.py`, `scripts/generate_keyproxy_keypair.py`, `tests/vectors/keyproxy_envelope_v1.json`) | ✅ 2026-07-17 | PR #102 (`de85cfb`) |
 | 1b | TypeScript envelope crypto proven against the same vectors (`frontend/src/vault/envelope.ts`, SPKI pin check) | ✅ 2026-07-17 | #103 |
 | 2a | Keyproxy core modules: `auth.py`, `replay.py`, `sessions.py`, `scopes.py` + unit tests (incl. `test_replay_race`, budget exhaustion) | ✅ 2026-07-17 | (this packet's PR) |
-| 2b | Keyproxy app: factory, publickey/validate/sessions endpoints, Anthropic provider (taxonomy), correlation ids, never-log test | ☐ | |
-| 2c | `Dockerfile.keyproxy` + compose wiring | ☐ | |
+| 2b | Keyproxy app: factory, publickey/validate/sessions endpoints, Anthropic provider (taxonomy), correlation ids, never-log test | ✅ 2026-07-17 | (Phase 2 commit) |
+| 2c | `Dockerfile.keyproxy` + compose wiring | ✅ 2026-07-17 | (Phase 2 commit) |
 | 3a | Streaming turn endpoint (stub-provider tests, `: ping` heartbeats, keyproxy-side no-compression) | ☐ | |
 | 3b | `KeyProxyChatClient` + session exchange + `test_keyproxy_stream_no_buffering` + `test_thinking_block_signature_roundtrip` | ☐ | |
 | 3c | Chat-tier plumbing: `TurnContext`, `key_envelope`/`scope` on `/api/chat`, keyproxy router/schemas, registry precedence, `api/sse.py` heartbeats, OpenAPI snapshot, `test_keyproxy_stream_not_compressed` | ☐ | |

--- a/docs/proposals/byok-key-proxy-plan.md
+++ b/docs/proposals/byok-key-proxy-plan.md
@@ -735,7 +735,7 @@ the context):
 | 4 | Frontend vault: IndexedDB + WebCrypto (`vaultStore.ts`, `vaultCrypto.ts`, `KeyVaultContext.tsx`), `fake-indexeddb` tests | ✅ 2026-07-18 | (Phase 4 commit) |
 | 5a | Settings UI: `/settings` route + nav, `ApiKeysSection`, Add/Rotate/Unlock dialogs, Remove confirm, validate-on-save UX, passphrase-strength minimum | ✅ 2026-07-18 | (Phase 5 commit) |
 | 5b | Page hardening: CSP header + Trusted Types in `server.mjs` (must land before any real key is pasted); sink audit clean, fonts self-hosted to keep `default-src 'self'` | ✅ 2026-07-18 | (Phase 5 commit) |
-| 6 | Chat integration: envelope attach in `chatStream.ts`/`ChatContext`, ChatRail gating (absent/locked/unlocked), retire env-key path, compose E2E | ☐ | |
+| 6 | Chat integration: envelope attach in `chatStream.ts`/`ChatContext`, ChatRail gating (absent/locked/unlocked), retire env-key path, compose E2E (persistent dev keypair + pin bake in `runUI-CONTAINERS.sh`; empty-bearer h11 fix in the gateway) | ✅ 2026-07-18 | (Phase 6 commit) |
 | 7a | ES256 verifiers: `api/auth.py` dual-mode (ES256 users + legacy HS256), keyproxy ES256-only, algorithm-confusion tests | ☐ | |
 | 7b | Express IAP-verify + per-user ES256 mint (`quantui-signing-key`); retire the shared `quantui-api-token` in cloud | ☐ | |
 | 8a | CI wiring: `cloudbuild.yaml` build-keyproxy step, `deploy.yml` (+ gitleaks secret-scanning job), `prod-rollout.yml` | ☐ | |

--- a/docs/proposals/byok-key-proxy-plan.md
+++ b/docs/proposals/byok-key-proxy-plan.md
@@ -167,19 +167,19 @@ sequenceDiagram
     R->>R: encrypt key to PINNED proxy pubkey → envelope {kid, epk, iv, ct, aad incl. scope_hash}
     R->>E: POST /api/chat {messages, key_envelope, scope}
     E->>A: + Authorization: Bearer per-user JWT (server-side mint, Phase 7)
-    A->>A: verify JWT → Principal; ChatService tool loop starts
+    A->>A: verify JWT → Principal, then start the ChatService tool loop
     A->>P: POST /v1/sessions {provider, envelope, scope} + JWT (+ Google IAM ID token)
-    P->>P: verify JWT · AAD checks (sub/provider/iat/jti/scope_hash) · decrypt key once
+    P->>P: verify JWT, check AAD (sub/provider/iat/jti/scope_hash), decrypt key once
     P-->>A: {session_id, expires_at}
     loop each model turn (≤ max_iterations)
         A->>P: POST /v1/providers/anthropic/messages/stream {session_id, params}
-        P->>P: session live? sub match? scope allows this call? budget left?
-        P->>O: SDK streaming call (user's key)
+        P->>P: session live, sub matches, scope allows call, budget remains
+        P->>O: SDK streaming call using the user key
         O-->>P: SSE stream
-        P-->>A: SSE delta…, final
+        P-->>A: SSE deltas and final event
         A->>A: run tools locally, extend conversation
     end
-    A->>P: DELETE /v1/sessions/{session_id} (best effort; TTL is the backstop)
+    A->>P: DELETE session (best effort, TTL is the backstop)
     P->>P: discard plaintext key
     A-->>E: SSE (text deltas, tool status, done)
     E-->>R: SSE
@@ -729,9 +729,9 @@ the context):
 | 2a | Keyproxy core modules: `auth.py`, `replay.py`, `sessions.py`, `scopes.py` + unit tests (incl. `test_replay_race`, budget exhaustion) | ✅ 2026-07-17 | (this packet's PR) |
 | 2b | Keyproxy app: factory, publickey/validate/sessions endpoints, Anthropic provider (taxonomy), correlation ids, never-log test | ✅ 2026-07-17 | (Phase 2 commit) |
 | 2c | `Dockerfile.keyproxy` + compose wiring | ✅ 2026-07-17 | (Phase 2 commit) |
-| 3a | Streaming turn endpoint (stub-provider tests, `: ping` heartbeats, keyproxy-side no-compression) | ☐ | |
-| 3b | `KeyProxyChatClient` + session exchange + `test_keyproxy_stream_no_buffering` + `test_thinking_block_signature_roundtrip` | ☐ | |
-| 3c | Chat-tier plumbing: `TurnContext`, `key_envelope`/`scope` on `/api/chat`, keyproxy router/schemas, registry precedence, `api/sse.py` heartbeats, OpenAPI snapshot, `test_keyproxy_stream_not_compressed` | ☐ | |
+| 3a | Streaming turn endpoint (stub-provider tests, `: ping` heartbeats, keyproxy-side no-compression) | ✅ 2026-07-17 | (Phase 3 commit) |
+| 3b | `KeyProxyChatClient` + session exchange + `test_keyproxy_stream_no_buffering` + `test_thinking_block_signature_roundtrip` | ✅ 2026-07-17 | (Phase 3 commit) |
+| 3c | Chat-tier plumbing: `TurnContext`, `key_envelope`/`scope` on `/api/chat`, keyproxy router/schemas, registry precedence, `api/sse.py` heartbeats, OpenAPI snapshot, `test_keyproxy_stream_not_compressed` | ✅ 2026-07-18 | (Phase 3 commit) |
 | 4 | Frontend vault: IndexedDB + WebCrypto (`vaultStore.ts`, `vaultCrypto.ts`, `KeyVaultContext.tsx`), `fake-indexeddb` tests | ☐ | |
 | 5a | Settings UI: `/settings` route + nav, `ApiKeysSection`, Add/Rotate/Unlock dialogs, Remove confirm, validate-on-save UX, passphrase-strength minimum | ☐ | |
 | 5b | Page hardening: CSP header + Trusted Types in `server.mjs` (must land before any real key is pasted) | ☐ | |

--- a/docs/proposals/byok-key-proxy-plan.md
+++ b/docs/proposals/byok-key-proxy-plan.md
@@ -646,6 +646,7 @@ the "Auth" column is the *application-layer* check on top:
 | keyproxy | `KEYPROXY_SESSION_TTL` | sliding session TTL, default 300 s; hard lifetime cap 900 s regardless of activity |
 | keyproxy | `KEYPROXY_MAX_SESSION_TOKENS` | server-side ceiling on any scope's `budget.max_tokens` (default 250 000); crossing it (or minting a scope above it) returns the "system-imposed threshold — ask the dev team to raise it" rejection |
 | quantui (Express) | `QUANTUI_SIGNING_KEY` | ES256 **private** signing key ← new per-project secret `quantui-signing-key` (Phase 7) — only Express can mint user identities |
+| quantui (Express) | `QUANTUI_IAP_AUDIENCE` | expected `aud` of the IAP assertion (`/projects/<num>/locations/<region>/services/quantui`, per project) — required whenever `QUANTUI_SIGNING_KEY` is set; Express fails fast at startup if the key is present without it (packet 7b) |
 | quantcore-api + keyproxy | `QUANTCORE_JWT_PUBLIC_KEY` | ES256 **public** verification key ← `quantui-signing-pub` secret (Phase 7; public material, secret-mounted for uniform wiring) |
 | keyproxy + api | `KEYPROXY_HEARTBEAT_SECS` | SSE `: ping` comment interval during provider quiet gaps, default 15 s (both hops) |
 | frontend (build-time) | `VITE_KEYPROXY_SPKI_PINS` | comma-separated b64url SHA-256 SPKI fingerprints baked into the bundle; `envelope.ts` refuses unpinned proxy keys |
@@ -736,8 +737,8 @@ the context):
 | 5a | Settings UI: `/settings` route + nav, `ApiKeysSection`, Add/Rotate/Unlock dialogs, Remove confirm, validate-on-save UX, passphrase-strength minimum | ✅ 2026-07-18 | (Phase 5 commit) |
 | 5b | Page hardening: CSP header + Trusted Types in `server.mjs` (must land before any real key is pasted); sink audit clean, fonts self-hosted to keep `default-src 'self'` | ✅ 2026-07-18 | (Phase 5 commit) |
 | 6 | Chat integration: envelope attach in `chatStream.ts`/`ChatContext`, ChatRail gating (absent/locked/unlocked), retire env-key path, compose E2E (persistent dev keypair + pin bake in `runUI-CONTAINERS.sh`; empty-bearer h11 fix in the gateway) | ✅ 2026-07-18 | (Phase 6 commit) |
-| 7a | ES256 verifiers: `api/auth.py` dual-mode (ES256 users + legacy HS256), keyproxy ES256-only, algorithm-confusion tests | ☐ | |
-| 7b | Express IAP-verify + per-user ES256 mint (`quantui-signing-key`); retire the shared `quantui-api-token` in cloud | ☐ | |
+| 7a | ES256 verifiers: `api/auth.py` dual-mode (ES256 users + legacy HS256), keyproxy ES256-only, algorithm-confusion tests. Note: `cryptography` moved into `requirements-base.txt` (PyJWT needs it for ES256; invariant 1 refined — key material/decrypt path still keyproxy-only) | ✅ 2026-07-18 | (Phase 7 commit) |
+| 7b | Express IAP-verify + per-user ES256 mint (`frontend/server/auth.mjs`, jose, `node --test` suite); ladder keyed on `QUANTUI_SIGNING_KEY` presence, hard 401 on bad/absent assertion. Cloud E2E (two IAP users → distinct subs in api logs) + secret creation (`quantui-signing-key`/`-pub`) are deploy-time steps | ✅ 2026-07-18 | (Phase 7 commit) |
 | 8a | CI wiring: `cloudbuild.yaml` build-keyproxy step, `deploy.yml` (+ gitleaks secret-scanning job), `prod-rollout.yml` | ☐ | |
 | 8b | Manual first-deploy runbook (IAM-locked keyproxy), executed interactively with John; results logged here | ☐ | |
 
@@ -1086,7 +1087,7 @@ The review's ten security invariants, each mapped to the named control or test t
 
 | # | Invariant | Held by |
 |---|---|---|
-| 1 | Only the Key Proxy decrypts credentials | By construction: quantcore-api never gains the `cryptography` dependency (Phase 1 requirements split); the envelope is an opaque field everywhere except `keyproxy/crypto.py` |
+| 1 | Only the Key Proxy decrypts credentials | By construction: the envelope private-key material (`KEYPROXY_PRIVATE_KEYS`) is mounted only into the keyproxy service, and the envelope is an opaque field everywhere except `keyproxy/crypto.py`. (Refined in packet 7a: the api image now carries the `cryptography` *library* — PyJWT needs it for ES256 verification — but never the key material or the decryption code path.) |
 | 2 | Verifiers cannot mint identities | ES256 + `aud` (decision #13); Phase 7 verifier tests incl. the algorithm-confusion probe |
 | 3 | One envelope = one redemption | `test_keyproxy_service.py`: second redemption of a burned `jti` → 400 (Phase 2) |
 | 4 | Every session is bounded | Session-lifecycle tests: sliding TTL expiry + hard 900 s cap (Phase 2) |

--- a/docs/proposals/byok-key-proxy-plan.md
+++ b/docs/proposals/byok-key-proxy-plan.md
@@ -732,7 +732,7 @@ the context):
 | 3a | Streaming turn endpoint (stub-provider tests, `: ping` heartbeats, keyproxy-side no-compression) | ✅ 2026-07-17 | (Phase 3 commit) |
 | 3b | `KeyProxyChatClient` + session exchange + `test_keyproxy_stream_no_buffering` + `test_thinking_block_signature_roundtrip` | ✅ 2026-07-17 | (Phase 3 commit) |
 | 3c | Chat-tier plumbing: `TurnContext`, `key_envelope`/`scope` on `/api/chat`, keyproxy router/schemas, registry precedence, `api/sse.py` heartbeats, OpenAPI snapshot, `test_keyproxy_stream_not_compressed` | ✅ 2026-07-18 | (Phase 3 commit) |
-| 4 | Frontend vault: IndexedDB + WebCrypto (`vaultStore.ts`, `vaultCrypto.ts`, `KeyVaultContext.tsx`), `fake-indexeddb` tests | ☐ | |
+| 4 | Frontend vault: IndexedDB + WebCrypto (`vaultStore.ts`, `vaultCrypto.ts`, `KeyVaultContext.tsx`), `fake-indexeddb` tests | ✅ 2026-07-18 | (Phase 4 commit) |
 | 5a | Settings UI: `/settings` route + nav, `ApiKeysSection`, Add/Rotate/Unlock dialogs, Remove confirm, validate-on-save UX, passphrase-strength minimum | ☐ | |
 | 5b | Page hardening: CSP header + Trusted Types in `server.mjs` (must land before any real key is pasted) | ☐ | |
 | 6 | Chat integration: envelope attach in `chatStream.ts`/`ChatContext`, ChatRail gating (absent/locked/unlocked), retire env-key path, compose E2E | ☐ | |

--- a/docs/proposals/byok-key-proxy-plan.md
+++ b/docs/proposals/byok-key-proxy-plan.md
@@ -733,8 +733,8 @@ the context):
 | 3b | `KeyProxyChatClient` + session exchange + `test_keyproxy_stream_no_buffering` + `test_thinking_block_signature_roundtrip` | ✅ 2026-07-17 | (Phase 3 commit) |
 | 3c | Chat-tier plumbing: `TurnContext`, `key_envelope`/`scope` on `/api/chat`, keyproxy router/schemas, registry precedence, `api/sse.py` heartbeats, OpenAPI snapshot, `test_keyproxy_stream_not_compressed` | ✅ 2026-07-18 | (Phase 3 commit) |
 | 4 | Frontend vault: IndexedDB + WebCrypto (`vaultStore.ts`, `vaultCrypto.ts`, `KeyVaultContext.tsx`), `fake-indexeddb` tests | ✅ 2026-07-18 | (Phase 4 commit) |
-| 5a | Settings UI: `/settings` route + nav, `ApiKeysSection`, Add/Rotate/Unlock dialogs, Remove confirm, validate-on-save UX, passphrase-strength minimum | ☐ | |
-| 5b | Page hardening: CSP header + Trusted Types in `server.mjs` (must land before any real key is pasted) | ☐ | |
+| 5a | Settings UI: `/settings` route + nav, `ApiKeysSection`, Add/Rotate/Unlock dialogs, Remove confirm, validate-on-save UX, passphrase-strength minimum | ✅ 2026-07-18 | (Phase 5 commit) |
+| 5b | Page hardening: CSP header + Trusted Types in `server.mjs` (must land before any real key is pasted); sink audit clean, fonts self-hosted to keep `default-src 'self'` | ✅ 2026-07-18 | (Phase 5 commit) |
 | 6 | Chat integration: envelope attach in `chatStream.ts`/`ChatContext`, ChatRail gating (absent/locked/unlocked), retire env-key path, compose E2E | ☐ | |
 | 7a | ES256 verifiers: `api/auth.py` dual-mode (ES256 users + legacy HS256), keyproxy ES256-only, algorithm-confusion tests | ☐ | |
 | 7b | Express IAP-verify + per-user ES256 mint (`quantui-signing-key`); retire the shared `quantui-api-token` in cloud | ☐ | |

--- a/docs/proposals/byok-key-proxy-plan.md
+++ b/docs/proposals/byok-key-proxy-plan.md
@@ -725,8 +725,8 @@ the context):
 |--------|------|--------|--------|
 | 0 | This proposal doc + GitHub issue #100 with the phase checklist (rides with packet 1a's commit) | ✅ 2026-07-16 | PR #101 (`b74c651`) |
 | 1a | Python envelope crypto + keypair script + shared test vectors (`keyproxy/crypto.py`, `scripts/generate_keyproxy_keypair.py`, `tests/vectors/keyproxy_envelope_v1.json`) | ✅ 2026-07-17 | PR #102 (`de85cfb`) |
-| 1b | TypeScript envelope crypto proven against the same vectors (`frontend/src/vault/envelope.ts`, SPKI pin check) | ✅ 2026-07-17 | (this packet's PR) |
-| 2a | Keyproxy core modules: `auth.py`, `replay.py`, `sessions.py`, `scopes.py` + unit tests (incl. `test_replay_race`, budget exhaustion) | ☐ | |
+| 1b | TypeScript envelope crypto proven against the same vectors (`frontend/src/vault/envelope.ts`, SPKI pin check) | ✅ 2026-07-17 | #103 |
+| 2a | Keyproxy core modules: `auth.py`, `replay.py`, `sessions.py`, `scopes.py` + unit tests (incl. `test_replay_race`, budget exhaustion) | ✅ 2026-07-17 | (this packet's PR) |
 | 2b | Keyproxy app: factory, publickey/validate/sessions endpoints, Anthropic provider (taxonomy), correlation ids, never-log test | ☐ | |
 | 2c | `Dockerfile.keyproxy` + compose wiring | ☐ | |
 | 3a | Streaming turn endpoint (stub-provider tests, `: ping` heartbeats, keyproxy-side no-compression) | ☐ | |

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,9 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Harvest Ladder Dashboard</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600;700;900&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <!-- Fonts are self-hosted (@fontsource, imported in main.tsx) so the strict
+         CSP (default-src 'self') holds with no external origins. -->
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
+        "@fontsource/inter": "^5.2.8",
+        "@fontsource/orbitron": "^5.2.8",
         "@mui/icons-material": "^6.4.0",
         "@mui/material": "^6.4.0",
         "@mui/x-data-grid": "^7.26.0",
@@ -1150,6 +1152,24 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@fontsource/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/orbitron": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/orbitron/-/orbitron-5.2.8.tgz",
+      "integrity": "sha512-ruzrDl5vnqNykk5DZWY0Ezj4aeFZSbCnwJTc/98ojNJHSsHhlhT2r7rwQrA5sptmF8JtB8TQTAvlfRvcV28RPw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,6 +30,7 @@
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.3.0",
         "@vitest/coverage-v8": "^4.1.10",
+        "fake-indexeddb": "^6.2.5",
         "jsdom": "^29.1.1",
         "typescript": "^5.7.0",
         "vite": "^6.4.1",
@@ -3611,6 +3612,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fdir": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,6 +34,7 @@
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",
     "@vitest/coverage-v8": "^4.1.10",
+    "fake-indexeddb": "^6.2.5",
     "jsdom": "^29.1.1",
     "typescript": "^5.7.0",
     "vite": "^6.4.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,8 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
+    "@fontsource/inter": "^5.2.8",
+    "@fontsource/orbitron": "^5.2.8",
     "@mui/icons-material": "^6.4.0",
     "@mui/material": "^6.4.0",
     "@mui/x-data-grid": "^7.26.0",

--- a/frontend/server/auth.mjs
+++ b/frontend/server/auth.mjs
@@ -1,0 +1,119 @@
+// QuantUI per-user token mint (BYOK packet 7b, decision #13).
+//
+// In cloud, IAP has already authenticated the person before a request reaches
+// this server; IAP attaches a Google-signed ES256 JWT in the
+// `x-goog-iap-jwt-assertion` header. This module verifies that assertion
+// against Google's public JWKS (issuer + per-service audience), then mints a
+// short-lived ES256 JWT of our own — `sub` = the IAP email, `exp` ≈ 15 min,
+// `aud` = both backend services — signed with a private key ONLY this Express
+// server holds (`quantui-signing-key` secret). quantcore-api and the keyproxy
+// verify with the public half, so verifiers cannot mint identities.
+//
+// Fallback ladder (keyed on configuration, so a deploy without the new
+// secrets keeps today's behavior):
+//   1. QUANTUI_SIGNING_KEY set        -> per-user mint; a missing/invalid IAP
+//                                        assertion is a hard 401 (never falls
+//                                        through to the shared token).
+//   2. else QUANTCORE_API_TOKEN set   -> legacy static service token.
+//   3. else                           -> no Authorization header (compose,
+//                                        where the api runs AUTH_DISABLED).
+//
+// Never-log policy: assertions, minted tokens, and jose error messages never
+// reach a log line or a response body.
+
+import { SignJWT, jwtVerify, importPKCS8, createRemoteJWKSet } from 'jose';
+
+export const IAP_ISSUER = 'https://cloud.google.com/iap';
+export const IAP_JWKS_URL = 'https://www.gstatic.com/iap/verify/public_key-jwk';
+export const USER_TOKEN_AUDIENCE = ['quantcore-api', 'quantcore-keyproxy'];
+
+const TOKEN_TTL_SECONDS = 15 * 60;
+// Re-mint when a cached token has less than this long to live, so a token is
+// never handed out about to expire mid-request.
+const REMINT_MARGIN_SECONDS = 60;
+
+/** Raised for any assertion problem — the caller maps it to a uniform 401. */
+export class IapAuthError extends Error {}
+
+/**
+ * Build the auth provider for the /api proxy.
+ *
+ * @param {object} opts
+ * @param {string|null} opts.signingKeyPem  PKCS8 ES256 private key (per-user mode when set).
+ * @param {string|null} opts.iapAudience    expected `aud` of the IAP assertion (required in per-user mode).
+ * @param {string|null} opts.staticToken    legacy shared service token (ladder rung 2).
+ * @param {*} [opts.iapKeys]                key / JWKS-resolver for verifying assertions
+ *                                          (tests inject a local key; defaults to Google's JWKS).
+ * @param {() => number} [opts.now]         seconds-since-epoch clock (injectable for tests).
+ * @returns {{ mode: string, authorizationFor: (assertion: string|undefined) => Promise<string|null> }}
+ */
+export function createAuthProvider({ signingKeyPem, iapAudience, staticToken, iapKeys, now }) {
+  const clock = now || (() => Date.now() / 1000);
+
+  if (!signingKeyPem) {
+    const header = staticToken ? `Bearer ${staticToken}` : null;
+    return {
+      mode: staticToken ? 'static-token' : 'open',
+      authorizationFor: async () => header,
+    };
+  }
+
+  if (!iapAudience) {
+    // Fail fast at startup: a signing key without the expected IAP audience
+    // would mean minting identities from unverifiable assertions.
+    throw new Error('QUANTUI_SIGNING_KEY is set but QUANTUI_IAP_AUDIENCE is not');
+  }
+
+  const keys = iapKeys || createRemoteJWKSet(new URL(IAP_JWKS_URL));
+  const privateKeyPromise = importPKCS8(signingKeyPem, 'ES256');
+  const cache = new Map(); // email -> { header, exp }
+
+  async function mintFor(email) {
+    const cached = cache.get(email);
+    const nowSecs = clock();
+    if (cached && cached.exp - nowSecs > REMINT_MARGIN_SECONDS) {
+      return cached.header;
+    }
+    const exp = Math.floor(nowSecs) + TOKEN_TTL_SECONDS;
+    const token = await new SignJWT({ email })
+      .setProtectedHeader({ alg: 'ES256' })
+      .setSubject(email)
+      .setAudience(USER_TOKEN_AUDIENCE)
+      .setIssuedAt(Math.floor(nowSecs))
+      .setExpirationTime(exp)
+      .sign(await privateKeyPromise);
+    const header = `Bearer ${token}`;
+    cache.set(email, { header, exp });
+    return header;
+  }
+
+  return {
+    mode: 'per-user',
+    authorizationFor: async (assertion) => {
+      if (!assertion) {
+        throw new IapAuthError('missing IAP assertion');
+      }
+      let payload;
+      try {
+        ({ payload } = await jwtVerify(assertion, keys, {
+          issuer: IAP_ISSUER,
+          audience: iapAudience,
+          algorithms: ['ES256'],
+        }));
+      } catch {
+        // Deliberately unchained: jose error text describes the token.
+        throw new IapAuthError('invalid IAP assertion');
+      }
+      // The JWT `email` claim is the plain address; the legacy header form
+      // ("accounts.google.com:user@…") is stripped defensively.
+      const email = String(payload.email || payload.sub || '').replace(
+        /^accounts\.google\.com:/,
+        ''
+      );
+      if (!email) {
+        throw new IapAuthError('assertion carries no identity');
+      }
+      return mintFor(email);
+    },
+  };
+}

--- a/frontend/server/auth.test.mjs
+++ b/frontend/server/auth.test.mjs
@@ -1,0 +1,235 @@
+// BYOK packet 7b tests: IAP-assertion verification + per-user ES256 minting
+// (auth.mjs). Run with `npm test` (node --test) in frontend/server/.
+//
+// Fake IAP assertions are minted locally with a second EC keypair standing in
+// for Google's; the provider takes the verification key by injection, so no
+// network (and no real Google JWKS) is involved.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { generateKeyPairSync } from 'node:crypto';
+import { SignJWT, jwtVerify, decodeJwt } from 'jose';
+
+import {
+  createAuthProvider,
+  IapAuthError,
+  IAP_ISSUER,
+  USER_TOKEN_AUDIENCE,
+} from './auth.mjs';
+
+const IAP_AUDIENCE = '/projects/000000000000/locations/us-central1/services/quantui';
+
+function keyPair() {
+  return generateKeyPairSync('ec', { namedCurve: 'P-256' });
+}
+
+// Stand-in for Google's IAP signing key.
+const google = keyPair();
+// The Express signing key (QUANTUI_SIGNING_KEY).
+const signing = keyPair();
+const SIGNING_PEM = signing.privateKey
+  .export({ type: 'pkcs8', format: 'pem' })
+  .toString();
+
+async function fakeAssertion({
+  email = 'john@funkyinnovations.com',
+  issuer = IAP_ISSUER,
+  audience = IAP_AUDIENCE,
+  expiresIn = 600,
+  key = google.privateKey,
+} = {}) {
+  const now = Math.floor(Date.now() / 1000);
+  return new SignJWT({ email })
+    .setProtectedHeader({ alg: 'ES256' })
+    .setSubject(`accounts.google.com:${email}`)
+    .setIssuer(issuer)
+    .setAudience(audience)
+    .setIssuedAt(now)
+    .setExpirationTime(now + expiresIn)
+    .sign(key);
+}
+
+function perUserProvider(overrides = {}) {
+  return createAuthProvider({
+    signingKeyPem: SIGNING_PEM,
+    iapAudience: IAP_AUDIENCE,
+    staticToken: 'legacy-static-token',
+    iapKeys: google.publicKey,
+    ...overrides,
+  });
+}
+
+async function rejectsWithIapError(promise) {
+  await assert.rejects(promise, (err) => {
+    assert.ok(err instanceof IapAuthError, `expected IapAuthError, got ${err}`);
+    return true;
+  });
+}
+
+// --- per-user mode: verify + mint ------------------------------------------ //
+
+test('valid assertion mints a per-user ES256 token', async () => {
+  const provider = perUserProvider();
+  assert.equal(provider.mode, 'per-user');
+
+  const header = await provider.authorizationFor(await fakeAssertion());
+  assert.match(header, /^Bearer /);
+
+  const token = header.slice('Bearer '.length);
+  const { payload, protectedHeader } = await jwtVerify(token, signing.publicKey, {
+    audience: 'quantcore-api',
+  });
+  assert.equal(protectedHeader.alg, 'ES256');
+  assert.equal(payload.sub, 'john@funkyinnovations.com');
+  assert.deepEqual(payload.aud, USER_TOKEN_AUDIENCE);
+  assert.equal(payload.exp - payload.iat, 15 * 60);
+
+  // Also valid for the keyproxy audience.
+  await jwtVerify(token, signing.publicKey, { audience: 'quantcore-keyproxy' });
+});
+
+test('expired assertion is rejected', async () => {
+  const provider = perUserProvider();
+  const stale = await fakeAssertion({ expiresIn: -3600 });
+  await rejectsWithIapError(provider.authorizationFor(stale));
+});
+
+test('wrong-audience assertion is rejected', async () => {
+  const provider = perUserProvider();
+  const other = await fakeAssertion({
+    audience: '/projects/999/locations/us-central1/services/other-app',
+  });
+  await rejectsWithIapError(provider.authorizationFor(other));
+});
+
+test('wrong-issuer assertion is rejected', async () => {
+  const provider = perUserProvider();
+  const forged = await fakeAssertion({ issuer: 'https://evil.example.com' });
+  await rejectsWithIapError(provider.authorizationFor(forged));
+});
+
+test('assertion signed by the wrong key is rejected', async () => {
+  const provider = perUserProvider();
+  const imposter = keyPair();
+  const forged = await fakeAssertion({ key: imposter.privateKey });
+  await rejectsWithIapError(provider.authorizationFor(forged));
+});
+
+test('absent assertion is a hard reject — never falls through to the static token', async () => {
+  const provider = perUserProvider(); // staticToken IS configured
+  await rejectsWithIapError(provider.authorizationFor(undefined));
+  await rejectsWithIapError(provider.authorizationFor(''));
+});
+
+test('rejection message never contains the assertion or verifier detail', async () => {
+  const provider = perUserProvider();
+  const stale = await fakeAssertion({ expiresIn: -3600 });
+  try {
+    await provider.authorizationFor(stale);
+    assert.fail('expected rejection');
+  } catch (err) {
+    assert.ok(!err.message.includes(stale));
+    for (const fragment of ['exp', 'signature', 'JWT', 'claim']) {
+      assert.ok(
+        !err.message.includes(fragment),
+        `error message leaks verifier detail: ${err.message}`
+      );
+    }
+  }
+});
+
+test('legacy sub-only identity (accounts.google.com: prefix) is stripped', async () => {
+  const provider = perUserProvider();
+  const now = Math.floor(Date.now() / 1000);
+  // No email claim; identity only in the prefixed sub.
+  const assertion = await new SignJWT({})
+    .setProtectedHeader({ alg: 'ES256' })
+    .setSubject('accounts.google.com:thomas@zoidbergfolio.com')
+    .setIssuer(IAP_ISSUER)
+    .setAudience(IAP_AUDIENCE)
+    .setIssuedAt(now)
+    .setExpirationTime(now + 600)
+    .sign(google.privateKey);
+  const header = await provider.authorizationFor(assertion);
+  const payload = decodeJwt(header.slice('Bearer '.length));
+  assert.equal(payload.sub, 'thomas@zoidbergfolio.com');
+});
+
+test('assertion with no identity claim is rejected', async () => {
+  const provider = perUserProvider();
+  const now = Math.floor(Date.now() / 1000);
+  const anonymous = await new SignJWT({})
+    .setProtectedHeader({ alg: 'ES256' })
+    .setIssuer(IAP_ISSUER)
+    .setAudience(IAP_AUDIENCE)
+    .setIssuedAt(now)
+    .setExpirationTime(now + 600)
+    .sign(google.privateKey);
+  await rejectsWithIapError(provider.authorizationFor(anonymous));
+});
+
+// --- caching --------------------------------------------------------------- //
+
+test('same user gets the cached token; near expiry triggers a re-mint', async () => {
+  let fakeNow = Math.floor(Date.now() / 1000);
+  const provider = perUserProvider({ now: () => fakeNow });
+
+  const first = await provider.authorizationFor(await fakeAssertion());
+  const again = await provider.authorizationFor(await fakeAssertion());
+  assert.equal(again, first, 'fresh token should be served from cache');
+
+  fakeNow += 14 * 60 + 30; // 30s of validity left — inside the re-mint margin
+  const reminted = await provider.authorizationFor(await fakeAssertion());
+  assert.notEqual(reminted, first, 'near-expiry token should be re-minted');
+});
+
+test('different users get different tokens', async () => {
+  const provider = perUserProvider();
+  const a = await provider.authorizationFor(
+    await fakeAssertion({ email: 'john@funkyinnovations.com' })
+  );
+  const b = await provider.authorizationFor(
+    await fakeAssertion({ email: 'thomas@zoidbergfolio.com' })
+  );
+  assert.notEqual(a, b);
+  assert.equal(decodeJwt(a.slice(7)).sub, 'john@funkyinnovations.com');
+  assert.equal(decodeJwt(b.slice(7)).sub, 'thomas@zoidbergfolio.com');
+});
+
+// --- fallback ladder ------------------------------------------------------- //
+
+test('no signing key + static token -> legacy static header, assertion ignored', async () => {
+  const provider = createAuthProvider({
+    signingKeyPem: null,
+    iapAudience: null,
+    staticToken: 'legacy-static-token',
+  });
+  assert.equal(provider.mode, 'static-token');
+  assert.equal(await provider.authorizationFor(undefined), 'Bearer legacy-static-token');
+  assert.equal(
+    await provider.authorizationFor(await fakeAssertion()),
+    'Bearer legacy-static-token'
+  );
+});
+
+test('no signing key + no static token -> no header (AUTH_DISABLED parity)', async () => {
+  const provider = createAuthProvider({
+    signingKeyPem: null,
+    iapAudience: null,
+    staticToken: null,
+  });
+  assert.equal(provider.mode, 'open');
+  assert.equal(await provider.authorizationFor(undefined), null);
+});
+
+test('signing key without IAP audience fails fast at startup', () => {
+  assert.throws(
+    () =>
+      createAuthProvider({
+        signingKeyPem: SIGNING_PEM,
+        iapAudience: null,
+        staticToken: null,
+      }),
+    /QUANTUI_SIGNING_KEY is set but QUANTUI_IAP_AUDIENCE is not/
+  );
+});

--- a/frontend/server/package-lock.json
+++ b/frontend/server/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "express": "^4.21.2",
-        "http-proxy-middleware": "^2.0.7"
+        "http-proxy-middleware": "^2.0.7",
+        "jose": "^6.2.3"
       }
     },
     "node_modules/@types/http-proxy": {
@@ -588,6 +589,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/math-intrinsics": {

--- a/frontend/server/package.json
+++ b/frontend/server/package.json
@@ -5,10 +5,12 @@
   "version": "1.0.0",
   "description": "Static-SPA server + /api reverse proxy for QuantUI on Cloud Run (behind IAP).",
   "scripts": {
-    "start": "node server.mjs"
+    "start": "node server.mjs",
+    "test": "node --test"
   },
   "dependencies": {
     "express": "^4.21.2",
-    "http-proxy-middleware": "^2.0.7"
+    "http-proxy-middleware": "^2.0.7",
+    "jose": "^6.2.3"
   }
 }

--- a/frontend/server/server.mjs
+++ b/frontend/server/server.mjs
@@ -33,6 +33,26 @@ const API_TOKEN = (process.env.QUANTCORE_API_TOKEN || '').trim();
 
 const app = express();
 
+// Strict CSP (BYOK packet 5b): the SPA is fully self-contained (fonts are
+// self-hosted via @fontsource), so everything locks to 'self'. The only
+// exception is style-src 'unsafe-inline', required by MUI/emotion's runtime
+// <style> injection. require-trusted-types-for 'script' turns on Trusted
+// Types enforcement so any future DOM XSS sink throws instead of executing.
+const CSP =
+  "default-src 'self'; " +
+  "connect-src 'self'; " +
+  "frame-ancestors 'none'; " +
+  "object-src 'none'; " +
+  "form-action 'self'; " +
+  "base-uri 'none'; " +
+  "style-src 'self' 'unsafe-inline'; " +
+  "require-trusted-types-for 'script'";
+
+app.use((_req, res, next) => {
+  res.setHeader('Content-Security-Policy', CSP);
+  next();
+});
+
 // Lightweight liveness probe (does not touch the api) for Cloud Run / compose.
 app.get('/healthz', (_req, res) => res.status(200).send('ok'));
 

--- a/frontend/server/server.mjs
+++ b/frontend/server/server.mjs
@@ -1,25 +1,32 @@
 // QuantUI production server — the Cloud Run equivalent of vite.config.ts's dev proxy.
 //
 // Serves the built static SPA (dist/) AND reverse-proxies /api/* to the JWT-protected
-// REST tier (quantcore-api), injecting the bearer token SERVER-SIDE from the
-// QUANTCORE_API_TOKEN env (a Secret Manager secret on Cloud Run). The token therefore
+// REST tier (quantcore-api), attaching the bearer token SERVER-SIDE. The token therefore
 // never reaches the browser bundle, and the browser stays same-origin (no CORS).
 //
-// Behind Google IAP on Cloud Run: IAP gates who can load the UI; this server holds the
-// service identity that authenticates the UI->API hop. When QUANTCORE_API_TOKEN is unset
-// (local docker-compose, where the api runs AUTH_DISABLED), no Authorization header is
-// added, preserving the open local contract.
+// Behind Google IAP on Cloud Run: IAP gates who can load the UI; this server turns the
+// IAP-verified identity into the token for the UI->API hop. Since BYOK packet 7b
+// (decision #13) that token is PER-USER: the IAP assertion is verified and a short-lived
+// ES256 JWT is minted with sub = the user's email (see auth.mjs for the full ladder —
+// signing key -> per-user mint; else QUANTCORE_API_TOKEN -> legacy static; else none,
+// preserving the open local contract where the api runs AUTH_DISABLED).
 //
 // Env:
-//   PORT                Cloud Run injects this (default 8080 locally).
-//   QUANTCORE_REST_URL  base URL of quantcore-api (default http://127.0.0.1:5001).
-//   QUANTCORE_API_TOKEN bearer token presented to the api; omitted from requests if unset.
-//   DIST_DIR            override the static root (default ../dist relative to this file).
+//   PORT                  Cloud Run injects this (default 8080 locally).
+//   QUANTCORE_REST_URL    base URL of quantcore-api (default http://127.0.0.1:5001).
+//   QUANTUI_SIGNING_KEY   ES256 private key (PKCS8 PEM) for per-user minting — the
+//                         quantui-signing-key secret; only this service holds it.
+//   QUANTUI_IAP_AUDIENCE  expected `aud` of the IAP assertion (per-project value,
+//                         "/projects/<num>/locations/<region>/services/quantui").
+//                         Required whenever QUANTUI_SIGNING_KEY is set.
+//   QUANTCORE_API_TOKEN   legacy static bearer; used only when no signing key is set.
+//   DIST_DIR              override the static root (default ../dist relative to this file).
 
 import express from 'express';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createProxyMiddleware } from 'http-proxy-middleware';
+import { createAuthProvider, IapAuthError } from './auth.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const DIST_DIR = process.env.DIST_DIR || path.resolve(__dirname, '..', 'dist');
@@ -30,6 +37,17 @@ const API_TARGET = process.env.QUANTCORE_REST_URL || 'http://127.0.0.1:5001';
 // token is piped into `gcloud secrets versions add --data-file=-`): an Authorization
 // header with a newline throws ERR_INVALID_CHAR and would crash the proxy.
 const API_TOKEN = (process.env.QUANTCORE_API_TOKEN || '').trim();
+// \n unescaping lets the PEM be supplied single-line in compose/env files.
+const SIGNING_KEY = (process.env.QUANTUI_SIGNING_KEY || '').trim().replace(/\\n/g, '\n');
+const IAP_AUDIENCE = (process.env.QUANTUI_IAP_AUDIENCE || '').trim();
+
+// Throws at startup (bilge-pump: loud, immediate) if the signing key is set
+// without the IAP audience — that combination could mint unverified identities.
+const authProvider = createAuthProvider({
+  signingKeyPem: SIGNING_KEY || null,
+  iapAudience: IAP_AUDIENCE || null,
+  staticToken: API_TOKEN || null,
+});
 
 const app = express();
 
@@ -56,15 +74,35 @@ app.use((_req, res, next) => {
 // Lightweight liveness probe (does not touch the api) for Cloud Run / compose.
 app.get('/healthz', (_req, res) => res.status(200).send('ok'));
 
-// /api/* -> REST tier, with the bearer injected here (never in the browser).
+// /api/* -> REST tier, with the bearer attached here (never in the browser).
+// onProxyReq is synchronous, so the (possibly async) verify+mint runs in this
+// middleware first and parks the header on the request for the proxy to read.
+app.use('/api', async (req, res, next) => {
+  try {
+    req.quantuiAuthorization = await authProvider.authorizationFor(
+      req.headers['x-goog-iap-jwt-assertion']
+    );
+    next();
+  } catch (err) {
+    if (err instanceof IapAuthError) {
+      // Uniform reject; never echoes the assertion or verifier error text.
+      res.status(401).json({ detail: 'IAP assertion missing or invalid' });
+    } else {
+      // e.g. Google JWKS unreachable — fail closed, equally tersely.
+      console.error('quantui auth middleware failure:', err?.constructor?.name);
+      res.status(503).json({ detail: 'authentication temporarily unavailable' });
+    }
+  }
+});
+
 app.use(
   '/api',
   createProxyMiddleware({
     target: API_TARGET,
     changeOrigin: true,
-    onProxyReq: (proxyReq) => {
-      if (API_TOKEN) {
-        proxyReq.setHeader('authorization', `Bearer ${API_TOKEN}`);
+    onProxyReq: (proxyReq, req) => {
+      if (req.quantuiAuthorization) {
+        proxyReq.setHeader('authorization', req.quantuiAuthorization);
       }
     },
   })
@@ -75,6 +113,10 @@ app.use(express.static(DIST_DIR));
 app.get('*', (_req, res) => res.sendFile(path.join(DIST_DIR, 'index.html')));
 
 app.listen(PORT, () => {
-  const auth = API_TOKEN ? 'token injected' : 'no token (AUTH_DISABLED parity)';
+  const auth = {
+    'per-user': 'per-user mint (IAP)',
+    'static-token': 'static token injected',
+    open: 'no token (AUTH_DISABLED parity)',
+  }[authProvider.mode];
   console.log(`QuantUI serving ${DIST_DIR} on :${PORT} -> ${API_TARGET} (${auth})`);
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import DashboardIcon from '@mui/icons-material/Dashboard';
 import ListAltIcon from '@mui/icons-material/ListAlt';
 import ShowChartIcon from '@mui/icons-material/ShowChart';
 import BarChartIcon from '@mui/icons-material/BarChart';
+import SettingsIcon from '@mui/icons-material/Settings';
 import LightModeIcon from '@mui/icons-material/LightMode';
 import DarkModeIcon from '@mui/icons-material/DarkMode';
 import ChatIcon from '@mui/icons-material/Chat';
@@ -18,6 +19,7 @@ import PlanDetailPage from './components/plans/PlanDetailPage';
 import SymbolsPage from './components/symbols/SymbolsPage';
 import SecuritiesPage from './components/securities/SecuritiesPage';
 import SecurityDetailPage from './components/securities/SecurityDetailPage';
+import SettingsPage from './components/settings/SettingsPage';
 import { useAppTheme } from './ThemeContext';
 
 function Layout() {
@@ -32,6 +34,7 @@ function Layout() {
     { label: 'Securities', path: '/securities', icon: <BarChartIcon /> },
     { label: 'Plans', path: '/plans', icon: <ListAltIcon /> },
     { label: 'Symbols', path: '/symbols', icon: <ShowChartIcon /> },
+    { label: 'Settings', path: '/settings', icon: <SettingsIcon /> },
   ];
 
   return (
@@ -160,6 +163,7 @@ export default function App() {
         <Route path="/plans" element={<PlansPage />} />
         <Route path="/plans/:id" element={<PlanDetailPage />} />
         <Route path="/symbols" element={<SymbolsPage />} />
+        <Route path="/settings" element={<SettingsPage />} />
         <Route path="*" element={<Typography variant="h5" sx={{ mt: 4 }}>Page not found</Typography>} />
       </Route>
     </Routes>

--- a/frontend/src/api/chatStream.test.ts
+++ b/frontend/src/api/chatStream.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { parseSSEChunk, streamChat } from './chatStream';
+import { parseSSEChunk, streamChat, type ChatKeyMaterial } from './chatStream';
 import type { ChatStreamEvent } from '../chat/types';
 
 const frame = (event: string, data: object) =>
@@ -153,6 +153,35 @@ describe('streamChat', () => {
 
     await streamChat([{ role: 'user', content: 'hi' }], () => {}, undefined, []);
     expect(JSON.parse(fetchMock.mock.calls[1][1].body)).not.toHaveProperty('interactions');
+  });
+
+  it('serializes key material as key_envelope/scope, omitted when absent (BYOK 6)', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockImplementation(async () =>
+        sseResponse([frame('done', { stop_reason: 'end_turn' })]),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const keyMaterial = {
+      keyEnvelope: { v: 1, kid: 'kp-test' },
+      scope: {
+        v: 1,
+        provider: 'anthropic',
+        action: 'chat.turn',
+        params: {},
+        budget: { max_calls: 20, max_mutations: 0, max_tokens: 250000, ttl: 300 },
+      },
+    } as unknown as ChatKeyMaterial;
+    await streamChat([{ role: 'user', content: 'hi' }], () => {}, undefined, undefined, keyMaterial);
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.key_envelope).toEqual({ v: 1, kid: 'kp-test' });
+    expect(body.scope).toEqual(keyMaterial.scope);
+
+    await streamChat([{ role: 'user', content: 'hi' }], () => {});
+    const bare = JSON.parse(fetchMock.mock.calls[1][1].body);
+    expect(bare).not.toHaveProperty('key_envelope');
+    expect(bare).not.toHaveProperty('scope');
   });
 
   it('rejects with status on non-2xx', async () => {

--- a/frontend/src/api/chatStream.ts
+++ b/frontend/src/api/chatStream.ts
@@ -7,6 +7,14 @@
  */
 import { ApiError } from './client';
 import type { ApiChatMessage, ChatInteraction, ChatStreamEvent } from '../chat/types';
+import type { KeyScope } from './keyproxy';
+import type { Envelope } from '../vault/envelope';
+
+/** Single-use sealed key material riding along with one chat turn (BYOK 6). */
+export interface ChatKeyMaterial {
+  keyEnvelope: Envelope;
+  scope: KeyScope;
+}
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL || '';
 const API_TOKEN = import.meta.env.VITE_API_TOKEN || '';
@@ -82,6 +90,7 @@ export async function streamChat(
   onEvent: (event: ChatStreamEvent) => void,
   signal?: AbortSignal,
   interactions?: ChatInteraction[],
+  keyMaterial?: ChatKeyMaterial,
 ): Promise<void> {
   const response = await fetch(`${API_BASE}/api/chat`, {
     method: 'POST',
@@ -92,6 +101,9 @@ export async function streamChat(
     body: JSON.stringify({
       messages,
       ...(interactions && interactions.length > 0 ? { interactions } : {}),
+      ...(keyMaterial
+        ? { key_envelope: keyMaterial.keyEnvelope, scope: keyMaterial.scope }
+        : {}),
     }),
     signal,
   });

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -26,7 +26,11 @@ export async function apiRequest<T>(
 
   if (!response.ok) {
     const error = await response.json().catch(() => ({}));
-    throw new ApiError(error.message || error.error || response.statusText, response.status);
+    // `detail` is FastAPI's error field; `message`/`error` are legacy shapes.
+    throw new ApiError(
+      error.message || error.error || error.detail || response.statusText,
+      response.status,
+    );
   }
 
   return response.json();

--- a/frontend/src/api/keyproxy.test.ts
+++ b/frontend/src/api/keyproxy.test.ts
@@ -1,0 +1,126 @@
+/**
+ * /api/keyproxy client tests (BYOK 5a): the 10-minute pubkey cache, the
+ * validate POST wire shape, and FastAPI `{detail}` errors surfacing as the
+ * ApiError message (the copy the dialogs show verbatim).
+ *
+ * Runs the real api client against a stubbed global fetch so the whole
+ * request path — URL, method, body, error extraction — is under test.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ApiError } from './client';
+import {
+  KEYPROXY_INFO_CACHE_MS,
+  clearKeyProxyInfoCache,
+  getKeyProxyInfo,
+  validateKey,
+  type KeyProxyInfo,
+} from './keyproxy';
+import type { Envelope } from '../vault/envelope';
+
+const INFO: KeyProxyInfo = {
+  keys: [{ kid: 'kp-2026-07', alg: 'ECDH-ES-P256+HKDF-SHA256+A256GCM', spki: 'AAAA' }],
+  sub: 'john',
+};
+
+const ENVELOPE: Envelope = {
+  v: 1,
+  alg: 'ECDH-ES-P256+HKDF-SHA256+A256GCM',
+  kid: 'kp-2026-07',
+  epk: 'BBBB',
+  iv: 'CCCC',
+  ct: 'DDDD',
+  aad: { sub: 'john', provider: 'anthropic', iat: 1, jti: 'x', scope_hash: 'h' },
+};
+
+const SCOPE = {
+  v: 1,
+  provider: 'anthropic',
+  action: 'key.validate',
+  params: {},
+  budget: { max_calls: 1, max_mutations: 0, ttl: 60 },
+};
+
+/** A fresh Response per call — bodies are single-use. */
+function respondWith(body: unknown, status = 200): () => Promise<Response> {
+  return () =>
+    Promise.resolve(
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+}
+
+describe('keyproxy api client', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    clearKeyProxyInfoCache();
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('fetches pubkey info once and serves the cache within 10 minutes', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    fetchMock.mockImplementation(respondWith(INFO));
+
+    const first = await getKeyProxyInfo();
+    expect(first).toEqual(INFO);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe('/api/keyproxy/publickey');
+
+    vi.advanceTimersByTime(KEYPROXY_INFO_CACHE_MS - 1);
+    expect(await getKeyProxyInfo()).toEqual(INFO);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('refetches after the cache expires', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    fetchMock.mockImplementation(respondWith(INFO));
+
+    await getKeyProxyInfo();
+    vi.advanceTimersByTime(KEYPROXY_INFO_CACHE_MS);
+    await getKeyProxyInfo();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('clearKeyProxyInfoCache forces a refetch', async () => {
+    fetchMock.mockImplementation(respondWith(INFO));
+    await getKeyProxyInfo();
+    clearKeyProxyInfoCache();
+    await getKeyProxyInfo();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('validateKey POSTs the envelope + scope and returns the result', async () => {
+    fetchMock.mockImplementation(respondWith({ valid: true, provider: 'anthropic', key_hint: '…abcd' }));
+
+    const result = await validateKey(ENVELOPE, SCOPE);
+    expect(result).toEqual({ valid: true, provider: 'anthropic', key_hint: '…abcd' });
+
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/keyproxy/validate');
+    expect(options.method).toBe('POST');
+    expect(JSON.parse(options.body)).toEqual({ envelope: ENVELOPE, scope: SCOPE });
+  });
+
+  it("surfaces FastAPI's {detail} error copy as the ApiError message", async () => {
+    fetchMock.mockImplementation(
+      respondWith({ detail: 'The key proxy is unavailable; try again shortly.' }, 503),
+    );
+
+    await expect(validateKey(ENVELOPE, SCOPE)).rejects.toThrow(
+      'The key proxy is unavailable; try again shortly.',
+    );
+    fetchMock.mockImplementation(respondWith({ detail: 'nope' }, 400));
+    const err = await validateKey(ENVELOPE, SCOPE).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).status).toBe(400);
+  });
+});

--- a/frontend/src/api/keyproxy.ts
+++ b/frontend/src/api/keyproxy.ts
@@ -1,0 +1,70 @@
+/**
+ * /api/keyproxy client (BYOK 5a) — pubkey discovery + the Settings-flow key
+ * validation relay.
+ *
+ * The publickey response carries the proxy's envelope-encryption keys
+ * (newest first) plus the caller's `sub` — the AAD binding value the browser
+ * cannot otherwise learn (Express injects the JWT server-side). It is cached
+ * for 10 minutes; envelope encryption re-verifies the SPKI pin on every use,
+ * so a stale cache can never widen trust.
+ *
+ * Never-log policy: envelopes are opaque ciphertext and nothing here logs.
+ */
+import { apiRequest } from './client';
+import type { Envelope } from '../vault/envelope';
+
+/** One proxy envelope-encryption key, as served by GET /api/keyproxy/publickey. */
+export interface KeyProxyPublicKey {
+  kid: string;
+  alg: string;
+  /** b64url SPKI DER. */
+  spki: string;
+}
+
+export interface KeyProxyInfo {
+  /** Newest first — encrypt to keys[0]. */
+  keys: KeyProxyPublicKey[];
+  /** The caller's JWT subject; envelopes must set aad.sub to exactly this. */
+  sub: string;
+}
+
+/** Scope v1 wire shape (semantics live in the keyproxy — see the plan). */
+export interface KeyScope {
+  v: number;
+  provider: string;
+  action: string;
+  params: Record<string, unknown>;
+  budget: Record<string, number>;
+}
+
+export interface KeyValidationResult {
+  valid: boolean;
+  provider: string;
+  key_hint: string;
+}
+
+export const KEYPROXY_INFO_CACHE_MS = 10 * 60 * 1000;
+
+let cachedInfo: { info: KeyProxyInfo; fetchedAt: number } | null = null;
+
+/** Pubkey + sub, cached 10 minutes (per the plan's packet 5a contract). */
+export async function getKeyProxyInfo(): Promise<KeyProxyInfo> {
+  if (cachedInfo !== null && Date.now() - cachedInfo.fetchedAt < KEYPROXY_INFO_CACHE_MS) {
+    return cachedInfo.info;
+  }
+  const info = await apiRequest<KeyProxyInfo>('/api/keyproxy/publickey');
+  cachedInfo = { info, fetchedAt: Date.now() };
+  return info;
+}
+
+export function clearKeyProxyInfoCache(): void {
+  cachedInfo = null;
+}
+
+/** Relay a sealed key + scope to POST /api/keyproxy/validate. */
+export function validateKey(envelope: Envelope, scope: KeyScope): Promise<KeyValidationResult> {
+  return apiRequest<KeyValidationResult>('/api/keyproxy/validate', {
+    method: 'POST',
+    body: JSON.stringify({ envelope, scope }),
+  });
+}

--- a/frontend/src/chat/ChatContext.tsx
+++ b/frontend/src/chat/ChatContext.tsx
@@ -13,7 +13,9 @@ import {
   useState,
   type ReactNode,
 } from 'react';
-import { streamChat } from '../api/chatStream';
+import { streamChat, type ChatKeyMaterial } from '../api/chatStream';
+import { sealKeyForTurn } from '../hooks/useKeyProxy';
+import { useKeyVaultOptional } from '../vault/KeyVaultContext';
 import type {
   ApiChatMessage,
   ChatInteraction,
@@ -135,6 +137,8 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   const [isStreaming, setIsStreaming] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  // Optional so the provider still works without a vault (tests, isolation).
+  const vault = useKeyVaultOptional();
 
   useEffect(() => {
     try {
@@ -270,6 +274,17 @@ export function ChatProvider({ children }: { children: ReactNode }) {
       };
 
       try {
+        // BYOK: seal the vault key into a fresh single-use envelope for this
+        // turn (fresh jti — one user action, one envelope). Plaintext exists
+        // only as an argument on its way into WebCrypto; if the vault is
+        // absent or locked we send no envelope and the backend answers with
+        // its Settings-prompt error frame.
+        let keyMaterial: ChatKeyMaterial | undefined;
+        const apiKey = vault?.getPlaintextKey('anthropic') ?? null;
+        if (apiKey !== null) {
+          const sealed = await sealKeyForTurn('anthropic', apiKey);
+          keyMaterial = { keyEnvelope: sealed.envelope, scope: sealed.scope };
+        }
         await streamChat(
           history,
           (event) => {
@@ -283,6 +298,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
           },
           controller.signal,
           interactions,
+          keyMaterial,
         );
       } catch (exc) {
         if ((exc as Error).name !== 'AbortError') {
@@ -294,7 +310,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         abortRef.current = null;
       }
     },
-    [messages, isStreaming, pendingInteractions],
+    [messages, isStreaming, pendingInteractions, vault],
   );
 
   return (

--- a/frontend/src/components/chat/ChatRail.test.tsx
+++ b/frontend/src/components/chat/ChatRail.test.tsx
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import { IDBFactory } from 'fake-indexeddb';
 import type { ChatStreamEvent } from '../../chat/types';
 
 // Controllable stream mock — tests drive events by hand.
@@ -13,6 +15,7 @@ const streamChatMock = vi.fn(
     onEvent: (e: ChatStreamEvent) => void,
     _signal?: unknown,
     _interactions?: unknown,
+    _keyMaterial?: unknown,
   ) =>
     new Promise<void>((resolve) => {
       currentOnEvent = onEvent;
@@ -23,16 +26,35 @@ vi.mock('../../api/chatStream', () => ({
   streamChat: (...args: Parameters<typeof streamChatMock>) => streamChatMock(...args),
 }));
 
+// Sealing is covered with real crypto in useKeyProxy.test.ts; here we only
+// assert the wiring — ChatContext seals per send and attaches the result.
+const FAKE_ENVELOPE = { v: 1, kid: 'kp-test', aad: { jti: 'fake-jti' } };
+const FAKE_SCOPE = { v: 1, provider: 'anthropic', action: 'chat.turn' };
+const sealKeyForTurnMock = vi.fn(async (_provider: string, _apiKey: string) => ({
+  envelope: FAKE_ENVELOPE,
+  scope: FAKE_SCOPE,
+}));
+vi.mock('../../hooks/useKeyProxy', () => ({
+  sealKeyForTurn: (...args: Parameters<typeof sealKeyForTurnMock>) =>
+    sealKeyForTurnMock(...args),
+  useValidateKey: () => ({ mutateAsync: vi.fn(), reset: vi.fn() }),
+}));
+
 import { ChatProvider } from '../../chat/ChatContext';
+import { KeyVaultProvider } from '../../vault/KeyVaultContext';
+import { wrapKey } from '../../vault/vaultCrypto';
+import { putRecord } from '../../vault/vaultStore';
 import ChatRail from './ChatRail';
 
 function renderRail() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false, enabled: false } } });
   return render(
     <QueryClientProvider client={qc}>
-      <ChatProvider>
-        <ChatRail />
-      </ChatProvider>
+      <MemoryRouter>
+        <ChatProvider>
+          <ChatRail />
+        </ChatProvider>
+      </MemoryRouter>
     </QueryClientProvider>,
   );
 }
@@ -256,6 +278,108 @@ describe('ChatRail', () => {
 
       await sendPrompt('plain question');
       expect(streamChatMock.mock.calls[0][3]).toEqual([]);
+      finishStream();
+    });
+  });
+
+  describe('BYOK key gating (packet 6)', () => {
+    const PASSPHRASE = 'correct horse battery staple';
+    const API_KEY = 'sk-ant-test-key-abcd';
+
+    function renderRailWithVault() {
+      const qc = new QueryClient({
+        defaultOptions: { queries: { retry: false, enabled: false } },
+      });
+      return render(
+        <QueryClientProvider client={qc}>
+          <MemoryRouter>
+            <KeyVaultProvider>
+              <ChatProvider>
+                <ChatRail />
+              </ChatProvider>
+            </KeyVaultProvider>
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+    }
+
+    async function seedVault() {
+      await putRecord({
+        provider: 'anthropic',
+        ...(await wrapKey(API_KEY, PASSPHRASE)),
+        label: 'Personal key',
+        last4: 'abcd',
+        createdAt: Date.now(),
+      });
+    }
+
+    async function unlockViaDialog() {
+      await userEvent.click(screen.getByTestId('chat-unlock'));
+      const dialog = await screen.findByRole('dialog');
+      await userEvent.type(within(dialog).getByLabelText(/Vault passphrase/), PASSPHRASE);
+      await userEvent.click(within(dialog).getByRole('button', { name: 'Unlock' }));
+    }
+
+    beforeEach(() => {
+      Object.defineProperty(globalThis, 'indexedDB', {
+        value: new IDBFactory(),
+        configurable: true,
+      });
+      sealKeyForTurnMock.mockClear();
+    });
+
+    it('absent: disables the input and shows the Settings CTA', async () => {
+      renderRailWithVault();
+      expect(await screen.findByTestId('chat-key-cta')).toHaveTextContent(
+        'Add your Anthropic API key in Settings to use the sidekick.',
+      );
+      expect(screen.getByTestId('chat-input').querySelector('textarea, input')).toBeDisabled();
+      expect(screen.getByRole('link', { name: 'Settings' })).toHaveAttribute(
+        'href',
+        '/settings',
+      );
+      expect(screen.queryByTestId('chat-key-indicator')).toBeNull();
+    });
+
+    it('locked: unlocking through the rail banner enables the input and shows the indicator', async () => {
+      await seedVault();
+      renderRailWithVault();
+      expect(await screen.findByTestId('chat-key-locked')).toBeInTheDocument();
+      const input = () => screen.getByTestId('chat-input').querySelector('textarea, input')!;
+      expect(input()).toBeDisabled();
+
+      await unlockViaDialog();
+
+      expect(await screen.findByTestId('chat-key-indicator')).toBeInTheDocument();
+      expect(screen.queryByTestId('chat-key-locked')).toBeNull();
+      await waitFor(() => expect(input()).toBeEnabled());
+    });
+
+    it('unlocked: each send seals a fresh envelope and attaches it to the stream call', async () => {
+      await seedVault();
+      renderRailWithVault();
+      await screen.findByTestId('chat-key-locked');
+      await unlockViaDialog();
+      await waitFor(() =>
+        expect(screen.getByTestId('chat-input').querySelector('textarea, input')).toBeEnabled(),
+      );
+
+      await sendPrompt('How is INTC?');
+      await waitFor(() => expect(streamChatMock).toHaveBeenCalledTimes(1));
+      expect(sealKeyForTurnMock).toHaveBeenCalledWith('anthropic', API_KEY);
+      expect(streamChatMock.mock.calls[0][4]).toEqual({
+        keyEnvelope: FAKE_ENVELOPE,
+        scope: FAKE_SCOPE,
+      });
+      finishStream();
+    });
+
+    it('without a vault provider the rail stays ungated and sends no envelope', async () => {
+      renderRail();
+      await sendPrompt('hello');
+      await waitFor(() => expect(streamChatMock).toHaveBeenCalledTimes(1));
+      expect(sealKeyForTurnMock).not.toHaveBeenCalled();
+      expect(streamChatMock.mock.calls[0][4]).toBeUndefined();
       finishStream();
     });
   });

--- a/frontend/src/components/chat/ChatRail.tsx
+++ b/frontend/src/components/chat/ChatRail.tsx
@@ -4,9 +4,11 @@
  * routes; visibility is controlled by ChatContext.railOpen.
  */
 import { useEffect, useRef, useState } from 'react';
+import { Link as RouterLink } from 'react-router-dom';
 import {
   Alert,
   Box,
+  Button,
   Chip,
   CircularProgress,
   IconButton,
@@ -21,7 +23,11 @@ import DeleteSweepIcon from '@mui/icons-material/DeleteSweep';
 import BoltIcon from '@mui/icons-material/Bolt';
 import FullscreenIcon from '@mui/icons-material/Fullscreen';
 import FullscreenExitIcon from '@mui/icons-material/FullscreenExit';
+import LockIcon from '@mui/icons-material/Lock';
+import LockOpenIcon from '@mui/icons-material/LockOpen';
 import { useChat } from '../../chat/ChatContext';
+import { useKeyVaultOptional } from '../../vault/KeyVaultContext';
+import UnlockDialog from '../settings/UnlockDialog';
 import type { ChatMessage, Segment } from '../../chat/types';
 import DirectiveRenderer from './DirectiveRenderer';
 
@@ -109,8 +115,14 @@ export default function ChatRail() {
     removeInteraction,
   } = useChat();
   const [draft, setDraft] = useState('');
+  const [unlockOpen, setUnlockOpen] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
+  // BYOK gating: null vault (tests/isolation) or a vault still reading
+  // IndexedDB stays ungated — the rail behaves exactly as before.
+  const vault = useKeyVaultOptional();
+  const keyStatus = vault?.ready ? vault.status('anthropic') : null;
+  const inputBlocked = keyStatus === 'absent' || keyStatus === 'locked';
   // In fullscreen, give directive components (charts, signal panels) most of
   // the width while keeping comfortable side gutters.
   const centered = expanded ? { maxWidth: '80%', mx: 'auto', width: '100%' } : {};
@@ -124,7 +136,7 @@ export default function ChatRail() {
 
   const submit = () => {
     const text = draft.trim();
-    if (!text || isStreaming) return;
+    if (!text || isStreaming || inputBlocked) return;
     setDraft('');
     void sendMessage(text);
     // Scroll every scrollable ancestor (message list AND the page itself) to
@@ -152,6 +164,16 @@ export default function ChatRail() {
         <Typography variant="subtitle2" sx={{ flex: 1 }}>
           Sidekick
         </Typography>
+        {keyStatus === 'unlocked' && (
+          <Tooltip title="API key unlocked — each message is sealed into a fresh single-use envelope">
+            <LockOpenIcon
+              fontSize="small"
+              color="success"
+              data-testid="chat-key-indicator"
+              sx={{ opacity: 0.7 }}
+            />
+          </Tooltip>
+        )}
         <Tooltip title={expanded ? 'Collapse to side rail' : 'Expand to full screen'}>
           <IconButton size="small" onClick={() => setExpanded(!expanded)} data-testid="chat-expand">
             {expanded ? <FullscreenExitIcon fontSize="small" /> : <FullscreenIcon fontSize="small" />}
@@ -209,6 +231,36 @@ export default function ChatRail() {
         </Stack>
       )}
 
+      {keyStatus === 'absent' && (
+        <Alert
+          severity="info"
+          data-testid="chat-key-cta"
+          sx={{ mx: 1.5, mb: 1, ...centered }}
+          action={
+            <Button component={RouterLink} to="/settings" size="small" color="inherit">
+              Settings
+            </Button>
+          }
+        >
+          Add your Anthropic API key in Settings to use the sidekick.
+        </Alert>
+      )}
+      {keyStatus === 'locked' && (
+        <Alert
+          severity="info"
+          icon={<LockIcon fontSize="inherit" />}
+          data-testid="chat-key-locked"
+          sx={{ mx: 1.5, mb: 1, ...centered }}
+          action={
+            <Button size="small" color="inherit" data-testid="chat-unlock" onClick={() => setUnlockOpen(true)}>
+              Unlock
+            </Button>
+          }
+        >
+          Your API key vault is locked. Unlock it to chat.
+        </Alert>
+      )}
+
       <Stack direction="row" spacing={1} sx={{ p: 1.5, pt: 0.5, ...centered }}>
         <TextField
           data-testid="chat-input"
@@ -218,7 +270,7 @@ export default function ChatRail() {
           maxRows={4}
           placeholder={isStreaming ? 'Thinking…' : 'Ask the sidekick…'}
           value={draft}
-          disabled={isStreaming}
+          disabled={isStreaming || inputBlocked}
           onChange={(e) => setDraft(e.target.value)}
           onKeyDown={(e) => {
             if (e.key === 'Enter' && !e.shiftKey) {
@@ -230,12 +282,13 @@ export default function ChatRail() {
         <IconButton
           color="primary"
           onClick={submit}
-          disabled={isStreaming || !draft.trim()}
+          disabled={isStreaming || inputBlocked || !draft.trim()}
           data-testid="chat-send"
         >
           <SendIcon />
         </IconButton>
       </Stack>
+      {vault && <UnlockDialog open={unlockOpen} onClose={() => setUnlockOpen(false)} />}
     </Box>
   );
 }

--- a/frontend/src/components/settings/AddKeyDialog.test.tsx
+++ b/frontend/src/components/settings/AddKeyDialog.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * AddKeyDialog flow tests (BYOK 5a): weak passphrases are refused before any
+ * network call, validation failure keeps the dialog open with nothing stored,
+ * and success stores only ciphertext (never-log) and closes.
+ *
+ * The key-proxy hook is mocked (its real crypto is covered in
+ * hooks/useKeyProxy.test.ts); the vault underneath is real, on a fresh
+ * fake-indexeddb per test.
+ */
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { IDBFactory } from 'fake-indexeddb';
+import type { ReactNode } from 'react';
+
+import AddKeyDialog from './AddKeyDialog';
+import { KeyVaultProvider } from '../../vault/KeyVaultContext';
+import { wrapKey } from '../../vault/vaultCrypto';
+import { getAllRecords, putRecord } from '../../vault/vaultStore';
+import { useValidateKey } from '../../hooks/useKeyProxy';
+
+vi.mock('../../hooks/useKeyProxy', () => ({
+  useValidateKey: vi.fn(),
+}));
+
+const API_KEY = 'sk-ant-test-key-abcd';
+const PASSPHRASE = 'correct horse battery staple';
+
+const mutateAsync = vi.fn();
+const useValidateKeyMock = vi.mocked(useValidateKey);
+
+function renderDialog(onClose = vi.fn()) {
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <KeyVaultProvider>{children}</KeyVaultProvider>
+  );
+  render(<AddKeyDialog open onClose={onClose} />, { wrapper });
+  return onClose;
+}
+
+async function fillForm(fields: { apiKey?: string; passphrase?: string; confirm?: string }) {
+  const user = userEvent.setup();
+  if (fields.apiKey) await user.type(screen.getByLabelText(/^API key/), fields.apiKey);
+  if (fields.passphrase) {
+    await user.type(screen.getByLabelText(/Vault passphrase/), fields.passphrase);
+  }
+  if (fields.confirm) {
+    await user.type(screen.getByLabelText(/Confirm passphrase/), fields.confirm);
+  }
+  return user;
+}
+
+describe('AddKeyDialog', () => {
+  beforeEach(() => {
+    Object.defineProperty(globalThis, 'indexedDB', {
+      value: new IDBFactory(),
+      configurable: true,
+    });
+    mutateAsync.mockReset().mockResolvedValue({
+      valid: true,
+      provider: 'anthropic',
+      key_hint: '…abcd',
+    });
+    useValidateKeyMock.mockReturnValue({
+      mutateAsync,
+      reset: vi.fn(),
+    } as unknown as ReturnType<typeof useValidateKey>);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('refuses a weak passphrase before any API call and stores nothing', async () => {
+    renderDialog();
+    const user = await fillForm({
+      apiKey: API_KEY,
+      passphrase: 'abcdefghijkl',
+      confirm: 'abcdefghijkl',
+    });
+    await user.click(screen.getByRole('button', { name: 'Validate & Save' }));
+
+    // Shown twice: as live helper text under the field and as the submit error.
+    expect(
+      await screen.findAllByText('Add another word or more variety (mixed case, digits, symbols).'),
+    ).toHaveLength(2);
+    expect(mutateAsync).not.toHaveBeenCalled();
+    expect(await getAllRecords()).toEqual([]);
+  });
+
+  it('refuses mismatched passphrases without calling the API', async () => {
+    renderDialog();
+    const user = await fillForm({
+      apiKey: API_KEY,
+      passphrase: PASSPHRASE,
+      confirm: 'correct horse battery stable',
+    });
+    await user.click(screen.getByRole('button', { name: 'Validate & Save' }));
+
+    expect(await screen.findByText('Passphrases do not match.')).toBeTruthy();
+    expect(mutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('validates, stores ciphertext only, and closes on success', async () => {
+    const onClose = renderDialog();
+    const user = await fillForm({
+      apiKey: API_KEY,
+      passphrase: PASSPHRASE,
+      confirm: PASSPHRASE,
+    });
+    await user.click(screen.getByRole('button', { name: 'Validate & Save' }));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+    expect(mutateAsync).toHaveBeenCalledWith({ provider: 'anthropic', apiKey: API_KEY });
+
+    const records = await getAllRecords();
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      provider: 'anthropic',
+      label: 'Personal key',
+      last4: 'abcd',
+    });
+    // Never-log: what persists is ciphertext, not the key or passphrase.
+    expect(JSON.stringify(records[0])).not.toContain(API_KEY);
+    expect(JSON.stringify(records[0])).not.toContain(PASSPHRASE);
+  });
+
+  it('keeps the dialog open with the error and stores nothing when validation fails', async () => {
+    mutateAsync.mockRejectedValue(
+      new Error('The provider rejected this key. Check that you pasted it completely.'),
+    );
+    const onClose = renderDialog();
+    const user = await fillForm({
+      apiKey: API_KEY,
+      passphrase: PASSPHRASE,
+      confirm: PASSPHRASE,
+    });
+    await user.click(screen.getByRole('button', { name: 'Validate & Save' }));
+
+    expect(
+      await screen.findByText(
+        'The provider rejected this key. Check that you pasted it completely.',
+      ),
+    ).toBeTruthy();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(await getAllRecords()).toEqual([]);
+  });
+
+  it('with an existing vault asks only for the vault passphrase and enforces it', async () => {
+    await putRecord({
+      provider: 'anthropic',
+      ...(await wrapKey('sk-ant-old-key-wxyz', PASSPHRASE)),
+      label: 'Personal key',
+      last4: 'wxyz',
+      createdAt: Date.now(),
+    });
+    renderDialog();
+
+    // The stored key loads async; the dialog then switches out of vault-creation mode.
+    await waitFor(() =>
+      expect(screen.getByLabelText(/Existing vault passphrase/)).toBeTruthy(),
+    );
+    expect(screen.queryByLabelText(/Confirm passphrase/)).toBeNull();
+
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/^API key/), API_KEY);
+    await user.type(screen.getByLabelText(/Existing vault passphrase/), 'not the passphrase');
+    await user.click(screen.getByRole('button', { name: 'Validate & Save' }));
+
+    expect(
+      await screen.findByText('Incorrect passphrase (or the stored key is corrupted).'),
+    ).toBeTruthy();
+    // The old record is untouched.
+    const records = await getAllRecords();
+    expect(records).toHaveLength(1);
+    expect(records[0].last4).toBe('wxyz');
+  });
+});

--- a/frontend/src/components/settings/AddKeyDialog.tsx
+++ b/frontend/src/components/settings/AddKeyDialog.tsx
@@ -1,0 +1,208 @@
+/**
+ * Add-key dialog (BYOK 5a), modeled on securities/AddSecurityDialog.
+ *
+ * Flow: paste key + passphrase → seal-and-validate through the key proxy →
+ * store encrypted in the vault only on success (failure keeps the dialog
+ * open with the error). When this is the vault's first key the passphrase is
+ * being *set*, so the strength minimum and a confirm field apply; afterwards
+ * the one-passphrase rule means the existing vault passphrase is required.
+ */
+import { useEffect, useState } from 'react';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+
+import { useKeyVault } from '../../vault/KeyVaultContext';
+import { useValidateKey } from '../../hooks/useKeyProxy';
+import { estimatePassphraseStrength } from './passphraseStrength';
+
+export const SUPPORTED_PROVIDERS = [{ id: 'anthropic', name: 'Anthropic' }];
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+const EMPTY_FORM = {
+  provider: 'anthropic',
+  label: '',
+  apiKey: '',
+  passphrase: '',
+  confirm: '',
+};
+
+export default function AddKeyDialog({ open, onClose }: Props) {
+  const [form, setForm] = useState(EMPTY_FORM);
+  const [error, setError] = useState('');
+  const [pending, setPending] = useState(false);
+  const { keys, addKey } = useKeyVault();
+  const validate = useValidateKey();
+
+  // First key = the passphrase is being set; afterwards it must match the vault's.
+  const creatingVault = keys.length === 0;
+  const strength = estimatePassphraseStrength(form.passphrase);
+
+  useEffect(() => {
+    if (open) {
+      setForm(EMPTY_FORM);
+      setError('');
+      setPending(false);
+      validate.reset();
+    }
+  }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const set = (field: keyof typeof EMPTY_FORM) => (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => setForm((f) => ({ ...f, [field]: e.target.value }));
+
+  const handleSubmit = async () => {
+    const apiKey = form.apiKey.trim();
+    if (!apiKey) {
+      setError('Paste an API key.');
+      return;
+    }
+    if (!form.passphrase) {
+      setError('A passphrase is required.');
+      return;
+    }
+    if (creatingVault) {
+      if (!strength.ok) {
+        setError(strength.feedback);
+        return;
+      }
+      if (form.passphrase !== form.confirm) {
+        setError('Passphrases do not match.');
+        return;
+      }
+    }
+    setError('');
+    setPending(true);
+    try {
+      await validate.mutateAsync({ provider: form.provider, apiKey });
+      await addKey({
+        provider: form.provider,
+        apiKey,
+        passphrase: form.passphrase,
+        label: form.label.trim() || 'Personal key',
+      });
+      onClose();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Add API Key</DialogTitle>
+
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 0.5 }}>
+          <Typography variant="body2" color="text.secondary">
+            Your key is validated once through the key proxy, then stored encrypted
+            in this browser only — clearing site data or switching devices means
+            pasting it again.
+          </Typography>
+
+          <Stack direction="row" spacing={2}>
+            <FormControl size="small" sx={{ width: 160 }}>
+              <InputLabel id="add-key-provider-label">Provider</InputLabel>
+              <Select
+                labelId="add-key-provider-label"
+                value={form.provider}
+                label="Provider"
+                onChange={(e) => setForm((f) => ({ ...f, provider: e.target.value }))}
+              >
+                {SUPPORTED_PROVIDERS.map((p) => (
+                  <MenuItem key={p.id} value={p.id}>{p.name}</MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <TextField
+              label="Label"
+              size="small"
+              value={form.label}
+              onChange={set('label')}
+              placeholder="Personal key"
+              sx={{ flex: 1 }}
+            />
+          </Stack>
+
+          <TextField
+            label="API key *"
+            size="small"
+            type="password"
+            value={form.apiKey}
+            onChange={set('apiKey')}
+            autoComplete="off"
+            fullWidth
+            autoFocus
+          />
+
+          <TextField
+            label={creatingVault ? 'Vault passphrase *' : 'Existing vault passphrase *'}
+            size="small"
+            type="password"
+            value={form.passphrase}
+            onChange={set('passphrase')}
+            autoComplete="new-password"
+            fullWidth
+            helperText={
+              creatingVault
+                ? form.passphrase
+                  ? strength.feedback
+                  : 'Protects every key in this vault. You will need it to unlock.'
+                : 'One passphrase covers every key in this vault.'
+            }
+            FormHelperTextProps={{
+              sx: creatingVault && form.passphrase && !strength.ok
+                ? { color: 'warning.main' }
+                : undefined,
+            }}
+          />
+
+          {creatingVault && (
+            <TextField
+              label="Confirm passphrase *"
+              size="small"
+              type="password"
+              value={form.confirm}
+              onChange={set('confirm')}
+              autoComplete="new-password"
+              fullWidth
+            />
+          )}
+
+          {error && (
+            <Typography variant="caption" sx={{ color: '#ef4444' }}>
+              {error}
+            </Typography>
+          )}
+        </Stack>
+      </DialogContent>
+
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={onClose} disabled={pending}>Cancel</Button>
+        <Button
+          variant="contained"
+          onClick={handleSubmit}
+          disabled={pending || !form.apiKey.trim() || !form.passphrase}
+        >
+          {pending ? 'Validating…' : 'Validate & Save'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/settings/ApiKeysSection.test.tsx
+++ b/frontend/src/components/settings/ApiKeysSection.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * ApiKeysSection tests (BYOK 5a): the provider row's three states (absent /
+ * locked / unlocked) and the confirm-guarded remove flow.
+ */
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { IDBFactory } from 'fake-indexeddb';
+import type { ReactNode } from 'react';
+
+import ApiKeysSection from './ApiKeysSection';
+import { KeyVaultProvider } from '../../vault/KeyVaultContext';
+import { wrapKey } from '../../vault/vaultCrypto';
+import { getAllRecords, putRecord } from '../../vault/vaultStore';
+
+vi.mock('../../hooks/useKeyProxy', () => ({
+  useValidateKey: () => ({ mutateAsync: vi.fn(), reset: vi.fn() }),
+}));
+
+const PASSPHRASE = 'correct horse battery staple';
+
+async function seedVault() {
+  await putRecord({
+    provider: 'anthropic',
+    ...(await wrapKey('sk-ant-test-key-abcd', PASSPHRASE)),
+    label: 'Personal key',
+    last4: 'abcd',
+    createdAt: Date.now(),
+  });
+}
+
+function renderSection() {
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <KeyVaultProvider>{children}</KeyVaultProvider>
+  );
+  render(<ApiKeysSection />, { wrapper });
+}
+
+describe('ApiKeysSection', () => {
+  beforeEach(() => {
+    Object.defineProperty(globalThis, 'indexedDB', {
+      value: new IDBFactory(),
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('shows the empty state with an Add Key button', async () => {
+    renderSection();
+    expect(await screen.findByText('No key stored')).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Add Key/ })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Rotate' })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Unlock/ })).toBeNull();
+  });
+
+  it('shows a stored key as locked with its label, last4, and actions', async () => {
+    await seedVault();
+    renderSection();
+
+    expect(await screen.findByText('••••abcd')).toBeTruthy();
+    expect(screen.getByText('Personal key')).toBeTruthy();
+    expect(screen.getByText('Locked')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Rotate' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Remove' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Unlock/ })).toBeTruthy();
+  });
+
+  it('unlocking via the vault Unlock button flips the chip and offers Lock', async () => {
+    await seedVault();
+    renderSection();
+    const user = userEvent.setup();
+
+    await user.click(await screen.findByRole('button', { name: /Unlock/ }));
+    const dialog = screen.getByRole('dialog');
+    await user.type(within(dialog).getByLabelText(/Vault passphrase/), PASSPHRASE);
+    await user.click(within(dialog).getByRole('button', { name: 'Unlock' }));
+
+    expect(await screen.findByText('Unlocked')).toBeTruthy();
+    // The closing dialog keeps the page aria-hidden until its exit transition ends.
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+    await user.click(screen.getByRole('button', { name: /^Lock$/ }));
+    expect(await screen.findByText('Locked')).toBeTruthy();
+  });
+
+  it('remove asks for confirmation naming the provider, then deletes', async () => {
+    await seedVault();
+    renderSection();
+    const user = userEvent.setup();
+
+    await user.click(await screen.findByRole('button', { name: 'Remove' }));
+    expect(
+      await screen.findByText(/Remove the stored Anthropic key from this browser\?/),
+    ).toBeTruthy();
+
+    await user.click(
+      within(screen.getByRole('dialog')).getByRole('button', { name: 'Remove' }),
+    );
+    await waitFor(async () => expect(await getAllRecords()).toEqual([]));
+    expect(await screen.findByText('No key stored')).toBeTruthy();
+  });
+
+  it('cancelling the remove confirmation keeps the key', async () => {
+    await seedVault();
+    renderSection();
+    const user = userEvent.setup();
+
+    await user.click(await screen.findByRole('button', { name: 'Remove' }));
+    await screen.findByText(/Remove the stored Anthropic key/);
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(await getAllRecords()).toHaveLength(1);
+    expect(screen.getByText('••••abcd')).toBeTruthy();
+  });
+});

--- a/frontend/src/components/settings/ApiKeysSection.tsx
+++ b/frontend/src/components/settings/ApiKeysSection.tsx
@@ -1,0 +1,175 @@
+/**
+ * API-keys section of the Settings page (BYOK 5a): one row per supported
+ * provider showing label, masked last4, and lock status, with Add / Rotate /
+ * Remove actions plus vault-level Unlock and Lock.
+ */
+import { useState } from 'react';
+import {
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Paper,
+  Stack,
+  Typography,
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import LockIcon from '@mui/icons-material/Lock';
+import LockOpenIcon from '@mui/icons-material/LockOpen';
+
+import { useKeyVault } from '../../vault/KeyVaultContext';
+import ConfirmDialog from '../common/ConfirmDialog';
+import AddKeyDialog, { SUPPORTED_PROVIDERS } from './AddKeyDialog';
+import RotateKeyDialog from './RotateKeyDialog';
+import UnlockDialog from './UnlockDialog';
+
+export default function ApiKeysSection() {
+  const { keys, ready, status, removeKey, lock } = useKeyVault();
+  const [addOpen, setAddOpen] = useState(false);
+  const [unlockOpen, setUnlockOpen] = useState(false);
+  const [rotateProvider, setRotateProvider] = useState<string | null>(null);
+  const [removeProvider, setRemoveProvider] = useState<string | null>(null);
+  const [removing, setRemoving] = useState(false);
+
+  if (!ready) {
+    return (
+      <Paper sx={{ p: 3, display: 'flex', justifyContent: 'center' }}>
+        <CircularProgress size={24} />
+      </Paper>
+    );
+  }
+
+  const anyLocked = keys.some((k) => status(k.provider) === 'locked');
+  const anyUnlocked = keys.some((k) => status(k.provider) === 'unlocked');
+
+  const handleRemove = async () => {
+    if (removeProvider === null) return;
+    setRemoving(true);
+    try {
+      await removeKey(removeProvider);
+    } finally {
+      setRemoving(false);
+      setRemoveProvider(null);
+    }
+  };
+
+  const removeName =
+    SUPPORTED_PROVIDERS.find((p) => p.id === removeProvider)?.name ?? removeProvider;
+
+  return (
+    <Paper sx={{ p: 3 }}>
+      <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1 }}>
+        <Typography variant="h6">LLM API Keys</Typography>
+        <Stack direction="row" spacing={1}>
+          {anyLocked && (
+            <Button
+              size="small"
+              startIcon={<LockOpenIcon />}
+              onClick={() => setUnlockOpen(true)}
+            >
+              Unlock
+            </Button>
+          )}
+          {anyUnlocked && (
+            <Button size="small" startIcon={<LockIcon />} onClick={() => lock()}>
+              Lock
+            </Button>
+          )}
+        </Stack>
+      </Stack>
+
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        Keys are encrypted with your vault passphrase and stored in this browser
+        only. The server sees them solely inside sealed, single-use envelopes.
+      </Typography>
+
+      <Stack spacing={1.5}>
+        {SUPPORTED_PROVIDERS.map((p) => {
+          const stored = keys.find((k) => k.provider === p.id);
+          const providerStatus = status(p.id);
+          return (
+            <Box
+              key={p.id}
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                border: 1,
+                borderColor: 'divider',
+                borderRadius: 1,
+                px: 2,
+                py: 1.5,
+              }}
+            >
+              <Stack direction="row" spacing={2} alignItems="center">
+                <Typography sx={{ fontWeight: 600, minWidth: 90 }}>{p.name}</Typography>
+                {stored ? (
+                  <>
+                    <Typography variant="body2" color="text.secondary">
+                      {stored.label}
+                    </Typography>
+                    <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
+                      ••••{stored.last4}
+                    </Typography>
+                    <Chip
+                      size="small"
+                      label={providerStatus === 'unlocked' ? 'Unlocked' : 'Locked'}
+                      color={providerStatus === 'unlocked' ? 'success' : 'default'}
+                    />
+                  </>
+                ) : (
+                  <Typography variant="body2" color="text.secondary">
+                    No key stored
+                  </Typography>
+                )}
+              </Stack>
+
+              <Stack direction="row" spacing={1}>
+                {stored ? (
+                  <>
+                    <Button size="small" onClick={() => setRotateProvider(p.id)}>
+                      Rotate
+                    </Button>
+                    <Button
+                      size="small"
+                      color="error"
+                      onClick={() => setRemoveProvider(p.id)}
+                    >
+                      Remove
+                    </Button>
+                  </>
+                ) : (
+                  <Button
+                    size="small"
+                    variant="contained"
+                    startIcon={<AddIcon />}
+                    onClick={() => setAddOpen(true)}
+                  >
+                    Add Key
+                  </Button>
+                )}
+              </Stack>
+            </Box>
+          );
+        })}
+      </Stack>
+
+      <AddKeyDialog open={addOpen} onClose={() => setAddOpen(false)} />
+      <UnlockDialog open={unlockOpen} onClose={() => setUnlockOpen(false)} />
+      <RotateKeyDialog
+        open={rotateProvider !== null}
+        onClose={() => setRotateProvider(null)}
+        provider={rotateProvider ?? ''}
+      />
+      <ConfirmDialog
+        open={removeProvider !== null}
+        title="Remove API Key"
+        message={`Remove the stored ${removeName} key from this browser? You can add it again later.`}
+        confirmLabel="Remove"
+        loading={removing}
+        onConfirm={() => void handleRemove()}
+        onCancel={() => setRemoveProvider(null)}
+      />
+    </Paper>
+  );
+}

--- a/frontend/src/components/settings/RotateKeyDialog.test.tsx
+++ b/frontend/src/components/settings/RotateKeyDialog.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * RotateKeyDialog flow tests (BYOK 5a): the new key is validated before the
+ * stored record is touched, and a wrong passphrase or failed validation
+ * leaves the old key material intact.
+ */
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { IDBFactory } from 'fake-indexeddb';
+import type { ReactNode } from 'react';
+
+import RotateKeyDialog from './RotateKeyDialog';
+import { KeyVaultProvider } from '../../vault/KeyVaultContext';
+import { unwrapKey, wrapKey } from '../../vault/vaultCrypto';
+import { getAllRecords, putRecord } from '../../vault/vaultStore';
+import { useValidateKey } from '../../hooks/useKeyProxy';
+
+vi.mock('../../hooks/useKeyProxy', () => ({
+  useValidateKey: vi.fn(),
+}));
+
+const OLD_KEY = 'sk-ant-old-key-wxyz';
+const NEW_KEY = 'sk-ant-new-key-abcd';
+const PASSPHRASE = 'correct horse battery staple';
+
+const mutateAsync = vi.fn();
+const useValidateKeyMock = vi.mocked(useValidateKey);
+
+async function seedVault() {
+  await putRecord({
+    provider: 'anthropic',
+    ...(await wrapKey(OLD_KEY, PASSPHRASE)),
+    label: 'Personal key',
+    last4: 'wxyz',
+    createdAt: Date.now(),
+  });
+}
+
+function renderDialog(onClose = vi.fn()) {
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <KeyVaultProvider>{children}</KeyVaultProvider>
+  );
+  render(<RotateKeyDialog open onClose={onClose} provider="anthropic" />, { wrapper });
+  return onClose;
+}
+
+async function submit(apiKey: string, passphrase: string) {
+  const user = userEvent.setup();
+  await user.type(screen.getByLabelText(/New API key/), apiKey);
+  await user.type(screen.getByLabelText(/Vault passphrase/), passphrase);
+  await user.click(screen.getByRole('button', { name: 'Rotate Key' }));
+}
+
+describe('RotateKeyDialog', () => {
+  beforeEach(async () => {
+    Object.defineProperty(globalThis, 'indexedDB', {
+      value: new IDBFactory(),
+      configurable: true,
+    });
+    await seedVault();
+    mutateAsync.mockReset().mockResolvedValue({
+      valid: true,
+      provider: 'anthropic',
+      key_hint: '…abcd',
+    });
+    useValidateKeyMock.mockReturnValue({
+      mutateAsync,
+      reset: vi.fn(),
+    } as unknown as ReturnType<typeof useValidateKey>);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('validates the new key, swaps the material, and closes', async () => {
+    const onClose = renderDialog();
+    await submit(NEW_KEY, PASSPHRASE);
+
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+    expect(mutateAsync).toHaveBeenCalledWith({ provider: 'anthropic', apiKey: NEW_KEY });
+
+    const [record] = await getAllRecords();
+    expect(record.last4).toBe('abcd');
+    expect(await unwrapKey(record, PASSPHRASE)).toBe(NEW_KEY);
+    expect(JSON.stringify(record)).not.toContain(NEW_KEY);
+  });
+
+  it('a wrong passphrase keeps the old key and the dialog open', async () => {
+    const onClose = renderDialog();
+    await submit(NEW_KEY, 'not the passphrase');
+
+    expect(
+      await screen.findByText('Incorrect passphrase (or the stored key is corrupted).'),
+    ).toBeTruthy();
+    expect(onClose).not.toHaveBeenCalled();
+
+    const [record] = await getAllRecords();
+    expect(await unwrapKey(record, PASSPHRASE)).toBe(OLD_KEY);
+  });
+
+  it('a failed validation never touches the stored record', async () => {
+    mutateAsync.mockRejectedValue(
+      new Error('The provider rejected this key. Check that you pasted it completely.'),
+    );
+    const onClose = renderDialog();
+    await submit(NEW_KEY, PASSPHRASE);
+
+    expect(
+      await screen.findByText(
+        'The provider rejected this key. Check that you pasted it completely.',
+      ),
+    ).toBeTruthy();
+    expect(onClose).not.toHaveBeenCalled();
+
+    const [record] = await getAllRecords();
+    expect(record.last4).toBe('wxyz');
+    expect(await unwrapKey(record, PASSPHRASE)).toBe(OLD_KEY);
+  });
+});

--- a/frontend/src/components/settings/RotateKeyDialog.tsx
+++ b/frontend/src/components/settings/RotateKeyDialog.tsx
@@ -1,0 +1,117 @@
+/**
+ * Rotate-key dialog (BYOK 5a): replace one provider's key material under the
+ * existing vault passphrase. The new key is validated through the key proxy
+ * before the old record is overwritten — a failed validation (or a wrong
+ * passphrase) leaves the stored key untouched and the dialog open.
+ */
+import { useEffect, useState } from 'react';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+
+import { useKeyVault } from '../../vault/KeyVaultContext';
+import { useValidateKey } from '../../hooks/useKeyProxy';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  provider: string;
+}
+
+export default function RotateKeyDialog({ open, onClose, provider }: Props) {
+  const [apiKey, setApiKey] = useState('');
+  const [passphrase, setPassphrase] = useState('');
+  const [error, setError] = useState('');
+  const [pending, setPending] = useState(false);
+  const { rotateKey } = useKeyVault();
+  const validate = useValidateKey();
+
+  useEffect(() => {
+    if (open) {
+      setApiKey('');
+      setPassphrase('');
+      setError('');
+      setPending(false);
+      validate.reset();
+    }
+  }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleSubmit = async () => {
+    const key = apiKey.trim();
+    if (!key) {
+      setError('Paste the new API key.');
+      return;
+    }
+    if (!passphrase) {
+      setError('Your vault passphrase is required.');
+      return;
+    }
+    setError('');
+    setPending(true);
+    try {
+      await validate.mutateAsync({ provider, apiKey: key });
+      await rotateKey({ provider, apiKey: key, passphrase });
+      onClose();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Rotate API Key</DialogTitle>
+
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 0.5 }}>
+          <Typography variant="body2" color="text.secondary">
+            The new key is validated before the old one is replaced.
+          </Typography>
+          <TextField
+            label="New API key *"
+            size="small"
+            type="password"
+            value={apiKey}
+            onChange={(e) => setApiKey(e.target.value)}
+            autoComplete="off"
+            fullWidth
+            autoFocus
+          />
+          <TextField
+            label="Vault passphrase *"
+            size="small"
+            type="password"
+            value={passphrase}
+            onChange={(e) => setPassphrase(e.target.value)}
+            autoComplete="current-password"
+            fullWidth
+          />
+          {error && (
+            <Typography variant="caption" sx={{ color: '#ef4444' }}>
+              {error}
+            </Typography>
+          )}
+        </Stack>
+      </DialogContent>
+
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={onClose} disabled={pending}>Cancel</Button>
+        <Button
+          variant="contained"
+          onClick={handleSubmit}
+          disabled={pending || !apiKey.trim() || !passphrase}
+        >
+          {pending ? 'Validating…' : 'Rotate Key'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/settings/SettingsPage.tsx
+++ b/frontend/src/components/settings/SettingsPage.tsx
@@ -1,0 +1,15 @@
+/** Settings page (BYOK 5a): currently just the API-keys vault section. */
+import { Stack, Typography } from '@mui/material';
+
+import ApiKeysSection from './ApiKeysSection';
+
+export default function SettingsPage() {
+  return (
+    <Stack spacing={3}>
+      <Typography variant="h5" sx={{ fontWeight: 600 }}>
+        Settings
+      </Typography>
+      <ApiKeysSection />
+    </Stack>
+  );
+}

--- a/frontend/src/components/settings/UnlockDialog.test.tsx
+++ b/frontend/src/components/settings/UnlockDialog.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * UnlockDialog tests (BYOK 5a): the right passphrase unlocks and closes; a
+ * wrong one shows the constant vault error and stays open. Real vault + real
+ * crypto on a fresh fake-indexeddb.
+ */
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { IDBFactory } from 'fake-indexeddb';
+import type { ReactNode } from 'react';
+
+import UnlockDialog from './UnlockDialog';
+import { KeyVaultProvider, useKeyVault } from '../../vault/KeyVaultContext';
+import { wrapKey } from '../../vault/vaultCrypto';
+import { putRecord } from '../../vault/vaultStore';
+
+const PASSPHRASE = 'correct horse battery staple';
+
+/** Exposes the vault status alongside the dialog under test. */
+function StatusProbe() {
+  const { status } = useKeyVault();
+  return <span data-testid="status">{status('anthropic')}</span>;
+}
+
+function renderDialog(onClose = vi.fn()) {
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <KeyVaultProvider>{children}</KeyVaultProvider>
+  );
+  render(
+    <>
+      <UnlockDialog open onClose={onClose} />
+      <StatusProbe />
+    </>,
+    { wrapper },
+  );
+  return onClose;
+}
+
+describe('UnlockDialog', () => {
+  beforeEach(async () => {
+    Object.defineProperty(globalThis, 'indexedDB', {
+      value: new IDBFactory(),
+      configurable: true,
+    });
+    await putRecord({
+      provider: 'anthropic',
+      ...(await wrapKey('sk-ant-test-key-abcd', PASSPHRASE)),
+      label: 'Personal key',
+      last4: 'abcd',
+      createdAt: Date.now(),
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('unlocks the vault and closes on the right passphrase', async () => {
+    const onClose = renderDialog();
+    await waitFor(() => expect(screen.getByTestId('status').textContent).toBe('locked'));
+
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/Vault passphrase/), PASSPHRASE);
+    await user.click(screen.getByRole('button', { name: 'Unlock' }));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+    expect(screen.getByTestId('status').textContent).toBe('unlocked');
+  });
+
+  it('shows the constant error and stays open on a wrong passphrase', async () => {
+    const onClose = renderDialog();
+    await waitFor(() => expect(screen.getByTestId('status').textContent).toBe('locked'));
+
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/Vault passphrase/), 'not the passphrase');
+    await user.click(screen.getByRole('button', { name: 'Unlock' }));
+
+    expect(
+      await screen.findByText('Incorrect passphrase (or the stored key is corrupted).'),
+    ).toBeTruthy();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByTestId('status').textContent).toBe('locked');
+  });
+});

--- a/frontend/src/components/settings/UnlockDialog.tsx
+++ b/frontend/src/components/settings/UnlockDialog.tsx
@@ -1,0 +1,95 @@
+/**
+ * Unlock dialog (BYOK 5a): one passphrase opens every stored provider key.
+ * Reused by the chat gating in Phase 6, so it lives free of Settings-page
+ * assumptions.
+ */
+import { useEffect, useState } from 'react';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+
+import { useKeyVault } from '../../vault/KeyVaultContext';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function UnlockDialog({ open, onClose }: Props) {
+  const [passphrase, setPassphrase] = useState('');
+  const [error, setError] = useState('');
+  const [pending, setPending] = useState(false);
+  const { unlock } = useKeyVault();
+
+  useEffect(() => {
+    if (open) {
+      setPassphrase('');
+      setError('');
+      setPending(false);
+    }
+  }, [open]);
+
+  const handleSubmit = async () => {
+    if (!passphrase) {
+      setError('Enter your vault passphrase.');
+      return;
+    }
+    setError('');
+    setPending(true);
+    try {
+      await unlock(passphrase);
+      onClose();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Unlock Vault</DialogTitle>
+
+      <DialogContent>
+        <Stack spacing={2} sx={{ mt: 0.5 }}>
+          <TextField
+            label="Vault passphrase *"
+            size="small"
+            type="password"
+            value={passphrase}
+            onChange={(e) => setPassphrase(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') void handleSubmit();
+            }}
+            autoComplete="current-password"
+            fullWidth
+            autoFocus
+          />
+          {error && (
+            <Typography variant="caption" sx={{ color: '#ef4444' }}>
+              {error}
+            </Typography>
+          )}
+        </Stack>
+      </DialogContent>
+
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={onClose} disabled={pending}>Cancel</Button>
+        <Button
+          variant="contained"
+          onClick={handleSubmit}
+          disabled={pending || !passphrase}
+        >
+          {pending ? 'Unlocking…' : 'Unlock'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/settings/passphraseStrength.test.ts
+++ b/frontend/src/components/settings/passphraseStrength.test.ts
@@ -1,0 +1,42 @@
+/** Passphrase-strength minimum tests (BYOK 5a). */
+import { describe, expect, it } from 'vitest';
+
+import {
+  MIN_PASSPHRASE_BITS,
+  MIN_PASSPHRASE_LENGTH,
+  estimatePassphraseStrength,
+} from './passphraseStrength';
+
+describe('estimatePassphraseStrength', () => {
+  it('rejects an empty passphrase with the length feedback', () => {
+    const result = estimatePassphraseStrength('');
+    expect(result.ok).toBe(false);
+    expect(result.bits).toBe(0);
+    expect(result.feedback).toContain(`at least ${MIN_PASSPHRASE_LENGTH} characters`);
+  });
+
+  it('rejects anything under the length floor regardless of variety', () => {
+    const result = estimatePassphraseStrength('aA1!aA1!aA1');
+    expect(result.ok).toBe(false);
+    expect(result.feedback).toContain(`at least ${MIN_PASSPHRASE_LENGTH} characters`);
+  });
+
+  it('rejects 12 lowercase letters (56 bits) on the entropy floor', () => {
+    const result = estimatePassphraseStrength('abcdefghijkl');
+    expect(result.ok).toBe(false);
+    expect(result.bits).toBeLessThan(MIN_PASSPHRASE_BITS);
+    expect(result.feedback).toContain('Add another word or more variety');
+  });
+
+  it('accepts a multi-word passphrase well past both floors', () => {
+    const result = estimatePassphraseStrength('correct horse battery staple');
+    expect(result.ok).toBe(true);
+    expect(result.bits).toBeGreaterThanOrEqual(MIN_PASSPHRASE_BITS);
+    expect(result.feedback).toContain('Strong passphrase');
+  });
+
+  it('accepts a 12-char mixed-class passphrase (variety clears the entropy floor)', () => {
+    const result = estimatePassphraseStrength('aB3$eF6&iJ9!');
+    expect(result.ok).toBe(true);
+  });
+});

--- a/frontend/src/components/settings/passphraseStrength.ts
+++ b/frontend/src/components/settings/passphraseStrength.ts
@@ -1,0 +1,43 @@
+/**
+ * Passphrase-strength minimum for vault creation (BYOK 5a).
+ *
+ * The IndexedDB blob is offline-brute-forceable at PBKDF2-600k if exfiltrated,
+ * so weak passphrases are refused outright: a hard length floor plus a naive
+ * character-class entropy estimate (length × log2(pool)). Deliberately simple
+ * and explainable — the inline feedback is the product, not the estimator.
+ */
+export const MIN_PASSPHRASE_LENGTH = 12;
+export const MIN_PASSPHRASE_BITS = 60;
+
+export interface PassphraseStrength {
+  ok: boolean;
+  /** Estimated entropy in bits (0 for an empty passphrase). */
+  bits: number;
+  /** Inline feedback shown under the field. */
+  feedback: string;
+}
+
+export function estimatePassphraseStrength(passphrase: string): PassphraseStrength {
+  let pool = 0;
+  if (/[a-z]/.test(passphrase)) pool += 26;
+  if (/[A-Z]/.test(passphrase)) pool += 26;
+  if (/[0-9]/.test(passphrase)) pool += 10;
+  if (/[^a-zA-Z0-9]/.test(passphrase)) pool += 33;
+  const bits = pool > 0 ? Math.round(passphrase.length * Math.log2(pool)) : 0;
+
+  if (passphrase.length < MIN_PASSPHRASE_LENGTH) {
+    return {
+      ok: false,
+      bits,
+      feedback: `Use at least ${MIN_PASSPHRASE_LENGTH} characters — a few random words work well.`,
+    };
+  }
+  if (bits < MIN_PASSPHRASE_BITS) {
+    return {
+      ok: false,
+      bits,
+      feedback: 'Add another word or more variety (mixed case, digits, symbols).',
+    };
+  }
+  return { ok: true, bits, feedback: `Strong passphrase (~${bits} bits).` };
+}

--- a/frontend/src/hooks/useKeyProxy.test.ts
+++ b/frontend/src/hooks/useKeyProxy.test.ts
@@ -1,0 +1,110 @@
+/**
+ * sealAndValidateKey tests (BYOK 5a): real P-256 envelope crypto against a
+ * mocked api module. Proves the envelope is bound to the caller's sub and the
+ * scope hash, that the plaintext key never appears in what goes on the wire
+ * (never-log), and that an unpinned proxy key is refused.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  b64urlEncode,
+  computeScopeHash,
+  spkiFingerprint,
+  type Envelope,
+} from '../vault/envelope';
+import { keyValidationScope, sealAndValidateKey } from './useKeyProxy';
+import { getKeyProxyInfo, validateKey } from '../api/keyproxy';
+
+vi.mock('../api/keyproxy', async () => {
+  const actual = await vi.importActual<typeof import('../api/keyproxy')>('../api/keyproxy');
+  return { ...actual, getKeyProxyInfo: vi.fn(), validateKey: vi.fn() };
+});
+
+const API_KEY = 'sk-ant-test-secret-key-abcd';
+
+const getInfoMock = vi.mocked(getKeyProxyInfo);
+const validateMock = vi.mocked(validateKey);
+
+let spkiB64: string;
+
+async function generateProxyKey(): Promise<{ spkiB64: string; fingerprint: string }> {
+  const pair = await crypto.subtle.generateKey(
+    { name: 'ECDH', namedCurve: 'P-256' },
+    true,
+    ['deriveBits'],
+  );
+  const spkiDer = new Uint8Array(await crypto.subtle.exportKey('spki', pair.publicKey));
+  return { spkiB64: b64urlEncode(spkiDer), fingerprint: await spkiFingerprint(spkiDer) };
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  const proxy = await generateProxyKey();
+  spkiB64 = proxy.spkiB64;
+  vi.stubEnv('VITE_KEYPROXY_SPKI_PINS', proxy.fingerprint);
+  getInfoMock.mockResolvedValue({
+    keys: [{ kid: 'kp-test', alg: 'ECDH-ES-P256+HKDF-SHA256+A256GCM', spki: spkiB64 }],
+    sub: 'john',
+  });
+  validateMock.mockResolvedValue({ valid: true, provider: 'anthropic', key_hint: '…abcd' });
+});
+
+describe('keyValidationScope', () => {
+  it('is a single-call, zero-mutation, short-TTL scope', () => {
+    expect(keyValidationScope('anthropic')).toEqual({
+      v: 1,
+      provider: 'anthropic',
+      action: 'key.validate',
+      params: {},
+      budget: { max_calls: 1, max_mutations: 0, ttl: 60 },
+    });
+  });
+});
+
+describe('sealAndValidateKey', () => {
+  it('seals to the newest pinned key with sub/provider/scope_hash-bound AAD', async () => {
+    const result = await sealAndValidateKey('anthropic', API_KEY);
+    expect(result.valid).toBe(true);
+
+    expect(validateMock).toHaveBeenCalledTimes(1);
+    const [envelope, scope] = validateMock.mock.calls[0] as [Envelope, unknown];
+    expect(scope).toEqual(keyValidationScope('anthropic'));
+    expect(envelope.kid).toBe('kp-test');
+    expect(envelope.aad.sub).toBe('john');
+    expect(envelope.aad.provider).toBe('anthropic');
+    expect(envelope.aad.scope_hash).toBe(await computeScopeHash(scope));
+    expect(envelope.aad.jti).toMatch(/^[0-9a-f-]{36}$/);
+    expect(Math.abs(envelope.aad.iat - Date.now() / 1000)).toBeLessThan(60);
+  });
+
+  it('never puts the plaintext key on the wire (never-log)', async () => {
+    await sealAndValidateKey('anthropic', API_KEY);
+    const [envelope] = validateMock.mock.calls[0];
+    expect(JSON.stringify(envelope)).not.toContain(API_KEY);
+  });
+
+  it('throws user-facing copy when the provider rejects the key', async () => {
+    validateMock.mockResolvedValue({ valid: false, provider: 'anthropic', key_hint: '' });
+    await expect(sealAndValidateKey('anthropic', API_KEY)).rejects.toThrow(
+      'The provider rejected this key. Check that you pasted it completely.',
+    );
+  });
+
+  it('throws when the proxy returns no public keys', async () => {
+    getInfoMock.mockResolvedValue({ keys: [], sub: 'john' });
+    await expect(sealAndValidateKey('anthropic', API_KEY)).rejects.toThrow(
+      'The key proxy returned no public keys; try again later.',
+    );
+    expect(validateMock).not.toHaveBeenCalled();
+  });
+
+  it('refuses a proxy key whose fingerprint is not pinned', async () => {
+    // Rotate the pin away from the served key: encryption must refuse it.
+    const other = await generateProxyKey();
+    vi.stubEnv('VITE_KEYPROXY_SPKI_PINS', other.fingerprint);
+    await expect(sealAndValidateKey('anthropic', API_KEY)).rejects.toThrow(
+      'recipient public key is not in the SPKI pin list; refusing to encrypt',
+    );
+    expect(validateMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/hooks/useKeyProxy.test.ts
+++ b/frontend/src/hooks/useKeyProxy.test.ts
@@ -12,7 +12,12 @@ import {
   spkiFingerprint,
   type Envelope,
 } from '../vault/envelope';
-import { keyValidationScope, sealAndValidateKey } from './useKeyProxy';
+import {
+  chatTurnScope,
+  keyValidationScope,
+  sealAndValidateKey,
+  sealKeyForTurn,
+} from './useKeyProxy';
 import { getKeyProxyInfo, validateKey } from '../api/keyproxy';
 
 vi.mock('../api/keyproxy', async () => {
@@ -58,6 +63,50 @@ describe('keyValidationScope', () => {
       params: {},
       budget: { max_calls: 1, max_mutations: 0, ttl: 60 },
     });
+  });
+});
+
+describe('chatTurnScope', () => {
+  it('is the ambient chat tier: reads only, zero mutations, hard token ceiling', () => {
+    expect(chatTurnScope('anthropic')).toEqual({
+      v: 1,
+      provider: 'anthropic',
+      action: 'chat.turn',
+      params: {},
+      budget: { max_calls: 20, max_mutations: 0, max_tokens: 250000, ttl: 300 },
+    });
+  });
+});
+
+describe('sealKeyForTurn', () => {
+  it('seals to the newest pinned key under the chat.turn scope', async () => {
+    const { envelope, scope } = await sealKeyForTurn('anthropic', API_KEY);
+    expect(scope).toEqual(chatTurnScope('anthropic'));
+    expect(envelope.kid).toBe('kp-test');
+    expect(envelope.aad.sub).toBe('john');
+    expect(envelope.aad.provider).toBe('anthropic');
+    expect(envelope.aad.scope_hash).toBe(await computeScopeHash(scope));
+    expect(envelope.aad.jti).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('mints a fresh jti per call — one user action, one single-use envelope', async () => {
+    const first = await sealKeyForTurn('anthropic', API_KEY);
+    const second = await sealKeyForTurn('anthropic', API_KEY);
+    expect(first.envelope.aad.jti).not.toBe(second.envelope.aad.jti);
+    expect(first.envelope.ct).not.toBe(second.envelope.ct);
+  });
+
+  it('never puts the plaintext key in the serialized turn payload (never-log)', async () => {
+    const { envelope, scope } = await sealKeyForTurn('anthropic', API_KEY);
+    expect(JSON.stringify({ key_envelope: envelope, scope })).not.toContain(API_KEY);
+  });
+
+  it('refuses a proxy key whose fingerprint is not pinned', async () => {
+    const other = await generateProxyKey();
+    vi.stubEnv('VITE_KEYPROXY_SPKI_PINS', other.fingerprint);
+    await expect(sealKeyForTurn('anthropic', API_KEY)).rejects.toThrow(
+      'recipient public key is not in the SPKI pin list; refusing to encrypt',
+    );
   });
 });
 

--- a/frontend/src/hooks/useKeyProxy.ts
+++ b/frontend/src/hooks/useKeyProxy.ts
@@ -1,0 +1,85 @@
+/**
+ * Key-proxy hooks (BYOK 5a): cached pubkey info + the Settings validation
+ * flow — seal the pasted key to the pinned proxy public key, relay it through
+ * POST /api/keyproxy/validate, and surface the result.
+ *
+ * The plaintext key exists here only as a function argument on its way into
+ * WebCrypto — never state, never storage, never logged. Envelope encryption
+ * refuses any proxy key whose SPKI fingerprint is not in the build-time pin
+ * list (VITE_KEYPROXY_SPKI_PINS).
+ */
+import { useMutation, useQuery } from '@tanstack/react-query';
+
+import {
+  KEYPROXY_INFO_CACHE_MS,
+  getKeyProxyInfo,
+  validateKey,
+  type KeyScope,
+  type KeyValidationResult,
+} from '../api/keyproxy';
+import {
+  b64urlDecode,
+  computeScopeHash,
+  encryptEnvelope,
+  importPinnedPublicKey,
+} from '../vault/envelope';
+
+export function useKeyProxyInfo() {
+  return useQuery({
+    queryKey: ['keyproxy-info'],
+    queryFn: getKeyProxyInfo,
+    staleTime: KEYPROXY_INFO_CACHE_MS,
+  });
+}
+
+/** Scope for a Settings-flow validation: exactly one read call, short TTL. */
+export function keyValidationScope(provider: string): KeyScope {
+  return {
+    v: 1,
+    provider,
+    action: 'key.validate',
+    params: {},
+    budget: { max_calls: 1, max_mutations: 0, ttl: 60 },
+  };
+}
+
+/**
+ * Seal `apiKey` into a single-use envelope bound to the caller's `sub` and a
+ * `key.validate` scope, then relay it for validation. Throws with safe,
+ * user-facing copy on every failure path.
+ */
+export async function sealAndValidateKey(
+  provider: string,
+  apiKey: string,
+): Promise<KeyValidationResult> {
+  const info = await getKeyProxyInfo();
+  const [newest] = info.keys;
+  if (newest === undefined) {
+    throw new Error('The key proxy returned no public keys; try again later.');
+  }
+  const recipientKey = await importPinnedPublicKey(b64urlDecode(newest.spki));
+  const scope = keyValidationScope(provider);
+  const envelope = await encryptEnvelope(apiKey, recipientKey, {
+    kid: newest.kid,
+    aad: {
+      sub: info.sub,
+      provider,
+      iat: Math.floor(Date.now() / 1000),
+      jti: crypto.randomUUID(),
+      scope_hash: await computeScopeHash(scope),
+    },
+  });
+  const result = await validateKey(envelope, scope);
+  if (!result.valid) {
+    throw new Error('The provider rejected this key. Check that you pasted it completely.');
+  }
+  return result;
+}
+
+/** Mutation wrapper for the add/rotate dialogs. */
+export function useValidateKey() {
+  return useMutation({
+    mutationFn: ({ provider, apiKey }: { provider: string; apiKey: string }) =>
+      sealAndValidateKey(provider, apiKey),
+  });
+}

--- a/frontend/src/hooks/useKeyProxy.ts
+++ b/frontend/src/hooks/useKeyProxy.ts
@@ -44,21 +44,31 @@ export function keyValidationScope(provider: string): KeyScope {
 }
 
 /**
- * Seal `apiKey` into a single-use envelope bound to the caller's `sub` and a
- * `key.validate` scope, then relay it for validation. Throws with safe,
- * user-facing copy on every failure path.
+ * Scope for one chat turn: ambient tier — read-only tool calls allowed, zero
+ * mutations, a hard token ceiling, and a TTL covering a single streamed turn.
  */
-export async function sealAndValidateKey(
-  provider: string,
-  apiKey: string,
-): Promise<KeyValidationResult> {
+export function chatTurnScope(provider: string): KeyScope {
+  return {
+    v: 1,
+    provider,
+    action: 'chat.turn',
+    params: {},
+    budget: { max_calls: 20, max_mutations: 0, max_tokens: 250000, ttl: 300 },
+  };
+}
+
+/**
+ * Seal `apiKey` under `scope` into a single-use envelope bound to the
+ * caller's `sub` and the pinned proxy public key. Fresh jti/iat per call —
+ * every envelope is one-shot by construction (replay cache rejects reuse).
+ */
+async function sealKey(provider: string, apiKey: string, scope: KeyScope) {
   const info = await getKeyProxyInfo();
   const [newest] = info.keys;
   if (newest === undefined) {
     throw new Error('The key proxy returned no public keys; try again later.');
   }
   const recipientKey = await importPinnedPublicKey(b64urlDecode(newest.spki));
-  const scope = keyValidationScope(provider);
   const envelope = await encryptEnvelope(apiKey, recipientKey, {
     kid: newest.kid,
     aad: {
@@ -69,6 +79,27 @@ export async function sealAndValidateKey(
       scope_hash: await computeScopeHash(scope),
     },
   });
+  return { envelope, scope };
+}
+
+/**
+ * Seal `apiKey` for a single chat turn. Called fresh on every send — one
+ * user action, one envelope.
+ */
+export async function sealKeyForTurn(provider: string, apiKey: string) {
+  return sealKey(provider, apiKey, chatTurnScope(provider));
+}
+
+/**
+ * Seal `apiKey` into a single-use envelope bound to the caller's `sub` and a
+ * `key.validate` scope, then relay it for validation. Throws with safe,
+ * user-facing copy on every failure path.
+ */
+export async function sealAndValidateKey(
+  provider: string,
+  apiKey: string,
+): Promise<KeyValidationResult> {
+  const { envelope, scope } = await sealKey(provider, apiKey, keyValidationScope(provider));
   const result = await validateKey(envelope, scope);
   if (!result.valid) {
     throw new Error('The provider rejected this key. Check that you pasted it completely.');

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,3 +1,13 @@
+// Self-hosted fonts (formerly Google Fonts links in index.html): bundled by
+// Vite so they serve same-origin under the strict CSP.
+import '@fontsource/orbitron/400.css';
+import '@fontsource/orbitron/600.css';
+import '@fontsource/orbitron/700.css';
+import '@fontsource/orbitron/900.css';
+import '@fontsource/inter/400.css';
+import '@fontsource/inter/500.css';
+import '@fontsource/inter/600.css';
+import '@fontsource/inter/700.css';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AppThemeProvider } from './ThemeContext';
+import { KeyVaultProvider } from './vault/KeyVaultContext';
 import { ChatProvider } from './chat/ChatContext';
 import App from './App';
 
@@ -21,9 +22,11 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
         <AppThemeProvider>
-          <ChatProvider>
-            <App />
-          </ChatProvider>
+          <KeyVaultProvider>
+            <ChatProvider>
+              <App />
+            </ChatProvider>
+          </KeyVaultProvider>
         </AppThemeProvider>
       </BrowserRouter>
     </QueryClientProvider>

--- a/frontend/src/vault/KeyVaultContext.test.tsx
+++ b/frontend/src/vault/KeyVaultContext.test.tsx
@@ -1,0 +1,267 @@
+/**
+ * KeyVaultContext lifecycle tests (Phase 4): absent → add → unlocked ⇄
+ * locked → remove → absent, the one-passphrase rule, and the 30-minute
+ * sliding auto-lock (fake timers limited to setTimeout/clearTimeout so
+ * fake-indexeddb's own scheduling stays real).
+ *
+ * Real crypto with production KDF parameters — the round-trips here are the
+ * proof that what the context stores, a fresh session can unlock.
+ */
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { IDBFactory } from 'fake-indexeddb';
+import type { ReactNode } from 'react';
+
+import {
+  AUTO_LOCK_MS,
+  KeyVaultProvider,
+  useKeyVault,
+  useKeyVaultOptional,
+} from './KeyVaultContext';
+import { WRONG_PASSPHRASE_MESSAGE } from './vaultCrypto';
+import { getAllRecords } from './vaultStore';
+
+const API_KEY = 'sk-ant-test-key-abcd';
+const PASSPHRASE = 'correct horse battery staple';
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <KeyVaultProvider>{children}</KeyVaultProvider>
+);
+
+/** Mount under real timers (the initial IndexedDB read needs them); tests
+ * that exercise the auto-lock switch to fake timers AFTER this returns. */
+async function renderVault() {
+  const view = renderHook(() => useKeyVault(), { wrapper });
+  await waitFor(() => expect(view.result.current.ready).toBe(true));
+  return view;
+}
+
+async function addAnthropicKey(
+  result: { current: ReturnType<typeof useKeyVault> },
+  overrides: Partial<Parameters<ReturnType<typeof useKeyVault>['addKey']>[0]> = {},
+) {
+  await act(async () => {
+    await result.current.addKey({
+      provider: 'anthropic',
+      apiKey: API_KEY,
+      passphrase: PASSPHRASE,
+      label: 'Personal key',
+      ...overrides,
+    });
+  });
+}
+
+describe('KeyVaultContext', () => {
+  beforeEach(() => {
+    Object.defineProperty(globalThis, 'indexedDB', {
+      value: new IDBFactory(),
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('starts absent with no keys', async () => {
+    const { result } = await renderVault();
+    expect(result.current.status('anthropic')).toBe('absent');
+    expect(result.current.keys).toEqual([]);
+    expect(result.current.getPlaintextKey('anthropic')).toBeNull();
+  });
+
+  it('addKey stores the wrapped record, exposes metadata, and unlocks', async () => {
+    const persist = vi.fn().mockResolvedValue(true);
+    Object.defineProperty(navigator, 'storage', {
+      value: { persist },
+      configurable: true,
+    });
+    const { result } = await renderVault();
+    await addAnthropicKey(result);
+
+    expect(result.current.status('anthropic')).toBe('unlocked');
+    expect(result.current.getPlaintextKey('anthropic')).toBe(API_KEY);
+    expect(result.current.keys).toEqual([
+      expect.objectContaining({
+        provider: 'anthropic',
+        label: 'Personal key',
+        last4: 'abcd',
+        status: 'unlocked',
+      }),
+    ]);
+    // Vault creation asks the browser for durable storage.
+    expect(persist).toHaveBeenCalledTimes(1);
+    // What hit IndexedDB is ciphertext, not the key.
+    const [record] = await getAllRecords();
+    expect(JSON.stringify(record)).not.toContain(API_KEY);
+    expect(JSON.stringify(record)).not.toContain(PASSPHRASE);
+  });
+
+  it('a fresh session sees the stored key locked and unlocks it', async () => {
+    const first = await renderVault();
+    await addAnthropicKey(first.result);
+    first.unmount();
+
+    const { result } = await renderVault();
+    expect(result.current.status('anthropic')).toBe('locked');
+    expect(result.current.getPlaintextKey('anthropic')).toBeNull();
+
+    await act(async () => {
+      await result.current.unlock(PASSPHRASE);
+    });
+    expect(result.current.status('anthropic')).toBe('unlocked');
+    expect(result.current.getPlaintextKey('anthropic')).toBe(API_KEY);
+  });
+
+  it('unlock with the wrong passphrase fails and stays locked', async () => {
+    const first = await renderVault();
+    await addAnthropicKey(first.result);
+    first.unmount();
+
+    const { result } = await renderVault();
+    await expect(
+      act(async () => {
+        await result.current.unlock('not the passphrase');
+      }),
+    ).rejects.toThrow(WRONG_PASSPHRASE_MESSAGE);
+    expect(result.current.status('anthropic')).toBe('locked');
+    expect(result.current.getPlaintextKey('anthropic')).toBeNull();
+  });
+
+  it('one passphrase covers the vault: a second provider must match it', async () => {
+    const { result } = await renderVault();
+    await addAnthropicKey(result);
+
+    await expect(
+      act(async () => {
+        await result.current.addKey({
+          provider: 'openai',
+          apiKey: 'sk-openai-test-wxyz',
+          passphrase: 'a different passphrase',
+          label: 'Other',
+        });
+      }),
+    ).rejects.toThrow(WRONG_PASSPHRASE_MESSAGE);
+    expect(result.current.status('openai')).toBe('absent');
+
+    await act(async () => {
+      await result.current.addKey({
+        provider: 'openai',
+        apiKey: 'sk-openai-test-wxyz',
+        passphrase: PASSPHRASE,
+        label: 'Other',
+      });
+    });
+    expect(result.current.status('openai')).toBe('unlocked');
+    // ...and one unlock opens both.
+    act(() => result.current.lock());
+    await act(async () => {
+      await result.current.unlock(PASSPHRASE);
+    });
+    expect(result.current.getPlaintextKey('anthropic')).toBe(API_KEY);
+    expect(result.current.getPlaintextKey('openai')).toBe('sk-openai-test-wxyz');
+  });
+
+  it('rotateKey replaces the material under the existing passphrase', async () => {
+    const { result } = await renderVault();
+    await addAnthropicKey(result);
+
+    await expect(
+      act(async () => {
+        await result.current.rotateKey({
+          provider: 'anthropic',
+          apiKey: 'sk-ant-new-key-wxyz',
+          passphrase: 'not the passphrase',
+        });
+      }),
+    ).rejects.toThrow(WRONG_PASSPHRASE_MESSAGE);
+    expect(result.current.getPlaintextKey('anthropic')).toBe(API_KEY);
+
+    await act(async () => {
+      await result.current.rotateKey({
+        provider: 'anthropic',
+        apiKey: 'sk-ant-new-key-wxyz',
+        passphrase: PASSPHRASE,
+      });
+    });
+    expect(result.current.getPlaintextKey('anthropic')).toBe('sk-ant-new-key-wxyz');
+    expect(result.current.keys[0]).toMatchObject({ label: 'Personal key', last4: 'wxyz' });
+  });
+
+  it('rotateKey refuses a provider with no stored key', async () => {
+    const { result } = await renderVault();
+    await expect(
+      act(async () => {
+        await result.current.rotateKey({
+          provider: 'anthropic',
+          apiKey: API_KEY,
+          passphrase: PASSPHRASE,
+        });
+      }),
+    ).rejects.toThrow('no stored key for this provider');
+  });
+
+  it('removeKey deletes the record and returns to absent', async () => {
+    const { result } = await renderVault();
+    await addAnthropicKey(result);
+    await act(async () => {
+      await result.current.removeKey('anthropic');
+    });
+    expect(result.current.status('anthropic')).toBe('absent');
+    expect(result.current.getPlaintextKey('anthropic')).toBeNull();
+    expect(await getAllRecords()).toEqual([]);
+  });
+
+  it('manual lock clears plaintext access', async () => {
+    const { result } = await renderVault();
+    await addAnthropicKey(result);
+    act(() => result.current.lock());
+    expect(result.current.status('anthropic')).toBe('locked');
+    expect(result.current.getPlaintextKey('anthropic')).toBeNull();
+  });
+
+  it('auto-locks 30 minutes after the last use', async () => {
+    const { result } = await renderVault();
+    // Fake only the timer functions: the auto-lock arms on setTimeout, while
+    // fake-indexeddb and PBKDF2 keep their real (off-timer) scheduling.
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    await addAnthropicKey(result);
+    expect(result.current.status('anthropic')).toBe('unlocked');
+
+    act(() => {
+      vi.advanceTimersByTime(AUTO_LOCK_MS);
+    });
+    expect(result.current.status('anthropic')).toBe('locked');
+    expect(result.current.getPlaintextKey('anthropic')).toBeNull();
+  });
+
+  it('the auto-lock window slides on plaintext access', async () => {
+    const { result } = await renderVault();
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    await addAnthropicKey(result);
+
+    act(() => {
+      vi.advanceTimersByTime(AUTO_LOCK_MS - 60_000);
+    });
+    // Using the key inside the window restarts the 30-minute clock…
+    expect(result.current.getPlaintextKey('anthropic')).toBe(API_KEY);
+    act(() => {
+      vi.advanceTimersByTime(AUTO_LOCK_MS - 60_000);
+    });
+    expect(result.current.status('anthropic')).toBe('unlocked');
+    // …and it still expires once the full window passes untouched.
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(result.current.status('anthropic')).toBe('locked');
+  });
+
+  it('useKeyVault throws outside the provider; the optional variant is null', () => {
+    expect(() => renderHook(() => useKeyVault())).toThrow(
+      'useKeyVault must be used inside <KeyVaultProvider>',
+    );
+    const { result } = renderHook(() => useKeyVaultOptional());
+    expect(result.current).toBeNull();
+  });
+});

--- a/frontend/src/vault/KeyVaultContext.tsx
+++ b/frontend/src/vault/KeyVaultContext.tsx
@@ -1,0 +1,280 @@
+/**
+ * BYOK browser vault — React state (Phase 4).
+ *
+ * Per-provider key lifecycle: absent → (add) → unlocked ⇄ locked → (remove)
+ * → absent. One passphrase covers the whole vault: unlock opens every stored
+ * provider key, and adding a key while others exist requires the same
+ * passphrase (verified against an existing record before anything is
+ * written).
+ *
+ * Plaintext keys live only in a ref — never React state, never storage — so
+ * no render, devtools serialization, or persistence path ever carries them.
+ * A 30-minute sliding auto-lock (reset by unlock/add and by every plaintext
+ * read) clears the ref; `unlockedProviders` state mirrors just the *fact* of
+ * unlockedness for rendering.
+ *
+ * Never-log policy: nothing here logs; errors surface to the caller with
+ * constant messages from vaultCrypto/vaultStore.
+ */
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import { unwrapKey, wrapKey } from './vaultCrypto';
+import {
+  deleteRecord,
+  getAllRecords,
+  putRecord,
+  type VaultRecord,
+} from './vaultStore';
+
+/** 30-minute sliding auto-lock (decided 2026-07-16; revisit after user testing). */
+export const AUTO_LOCK_MS = 30 * 60 * 1000;
+
+export type VaultKeyStatus = 'absent' | 'locked' | 'unlocked';
+
+/** Display metadata for one stored provider key — no secret material. */
+export interface VaultKeyMeta {
+  provider: string;
+  label: string;
+  last4: string;
+  createdAt: number;
+  status: VaultKeyStatus;
+}
+
+interface AddKeyArgs {
+  provider: string;
+  apiKey: string;
+  passphrase: string;
+  label: string;
+}
+
+interface RotateKeyArgs {
+  provider: string;
+  apiKey: string;
+  passphrase: string;
+}
+
+interface KeyVaultContextValue {
+  /** One entry per stored provider key, lifecycle status included. */
+  keys: VaultKeyMeta[];
+  /** True once the initial IndexedDB read has completed. */
+  ready: boolean;
+  status: (provider: string) => VaultKeyStatus;
+  /** Store a new provider key; the vault's passphrase when records already
+   * exist, or the vault-creating passphrase when it's the first. Leaves the
+   * provider unlocked. */
+  addKey: (args: AddKeyArgs) => Promise<void>;
+  /** Replace a provider's key material under the existing passphrase
+   * (verified against the stored record before overwriting). */
+  rotateKey: (args: RotateKeyArgs) => Promise<void>;
+  removeKey: (provider: string) => Promise<void>;
+  /** Open every stored key with the vault passphrase. */
+  unlock: (passphrase: string) => Promise<void>;
+  lock: () => void;
+  /** Plaintext for an unlocked provider (null otherwise). Reading slides the
+   * auto-lock window. Callers must not persist or log the value. */
+  getPlaintextKey: (provider: string) => string | null;
+}
+
+const KeyVaultContext = createContext<KeyVaultContextValue | null>(null);
+
+export function KeyVaultProvider({ children }: { children: ReactNode }) {
+  const [records, setRecords] = useState<VaultRecord[]>([]);
+  const [ready, setReady] = useState(false);
+  const [unlockedProviders, setUnlockedProviders] = useState<string[]>([]);
+  const plaintextRef = useRef<Map<string, string>>(new Map());
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    getAllRecords()
+      .then((stored) => {
+        if (!cancelled) setRecords(stored);
+      })
+      .catch(() => {
+        /* unreadable vault behaves as empty; adding a key rewrites it */
+      })
+      .finally(() => {
+        if (!cancelled) setReady(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const lock = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    plaintextRef.current.clear();
+    setUnlockedProviders([]);
+  }, []);
+
+  // Unmount is "tab close" in the lifecycle diagram: drop plaintext.
+  useEffect(() => {
+    const plaintext = plaintextRef.current;
+    return () => {
+      if (timerRef.current !== null) clearTimeout(timerRef.current);
+      plaintext.clear();
+    };
+  }, []);
+
+  const armAutoLock = useCallback(() => {
+    if (timerRef.current !== null) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(lock, AUTO_LOCK_MS);
+  }, [lock]);
+
+  /** One-passphrase rule: prove the given passphrase opens the vault. */
+  const verifyPassphrase = useCallback(
+    async (passphrase: string, against: VaultRecord) => {
+      await unwrapKey(against, passphrase); // throws WRONG_PASSPHRASE_MESSAGE
+    },
+    [],
+  );
+
+  const addKey = useCallback(
+    async ({ provider, apiKey, passphrase, label }: AddKeyArgs) => {
+      const existing = records.find((record) => record.provider !== provider) ?? records[0];
+      if (existing !== undefined) {
+        await verifyPassphrase(passphrase, existing);
+      }
+      const wrapped = await wrapKey(apiKey, passphrase);
+      const record: VaultRecord = {
+        provider,
+        ...wrapped,
+        label,
+        last4: apiKey.slice(-4),
+        createdAt: Date.now(),
+      };
+      await putRecord(record);
+      if (records.length === 0) {
+        // First key = vault creation: ask the browser not to evict the store
+        // (best effort — the key is per-browser either way; see plan tradeoff).
+        try {
+          await navigator.storage?.persist?.();
+        } catch {
+          /* ignore */
+        }
+      }
+      setRecords((prev) => [...prev.filter((r) => r.provider !== provider), record]);
+      plaintextRef.current.set(provider, apiKey);
+      setUnlockedProviders((prev) => (prev.includes(provider) ? prev : [...prev, provider]));
+      armAutoLock();
+    },
+    [records, verifyPassphrase, armAutoLock],
+  );
+
+  const rotateKey = useCallback(
+    async ({ provider, apiKey, passphrase }: RotateKeyArgs) => {
+      const current = records.find((record) => record.provider === provider);
+      if (current === undefined) {
+        throw new Error('no stored key for this provider; add one instead');
+      }
+      await verifyPassphrase(passphrase, current);
+      const wrapped = await wrapKey(apiKey, passphrase);
+      const record: VaultRecord = {
+        provider,
+        ...wrapped,
+        label: current.label,
+        last4: apiKey.slice(-4),
+        createdAt: Date.now(),
+      };
+      await putRecord(record);
+      setRecords((prev) => [...prev.filter((r) => r.provider !== provider), record]);
+      plaintextRef.current.set(provider, apiKey);
+      setUnlockedProviders((prev) => (prev.includes(provider) ? prev : [...prev, provider]));
+      armAutoLock();
+    },
+    [records, verifyPassphrase, armAutoLock],
+  );
+
+  const removeKey = useCallback(async (provider: string) => {
+    await deleteRecord(provider);
+    plaintextRef.current.delete(provider);
+    setRecords((prev) => prev.filter((record) => record.provider !== provider));
+    setUnlockedProviders((prev) => prev.filter((p) => p !== provider));
+  }, []);
+
+  const unlock = useCallback(
+    async (passphrase: string) => {
+      if (records.length === 0) {
+        throw new Error('the vault is empty; add a key instead');
+      }
+      // All-or-nothing: one passphrase opens every record, so any failure
+      // (first record included) leaves the vault fully locked.
+      const opened = new Map<string, string>();
+      for (const record of records) {
+        opened.set(record.provider, await unwrapKey(record, passphrase));
+      }
+      plaintextRef.current = opened;
+      setUnlockedProviders([...opened.keys()]);
+      armAutoLock();
+    },
+    [records, armAutoLock],
+  );
+
+  const status = useCallback(
+    (provider: string): VaultKeyStatus => {
+      if (!records.some((record) => record.provider === provider)) return 'absent';
+      return unlockedProviders.includes(provider) ? 'unlocked' : 'locked';
+    },
+    [records, unlockedProviders],
+  );
+
+  const getPlaintextKey = useCallback(
+    (provider: string): string | null => {
+      const plaintext = plaintextRef.current.get(provider);
+      if (plaintext === undefined) return null;
+      armAutoLock(); // sliding window: every use extends the session
+      return plaintext;
+    },
+    [armAutoLock],
+  );
+
+  const keys: VaultKeyMeta[] = records
+    .map((record) => ({
+      provider: record.provider,
+      label: record.label,
+      last4: record.last4,
+      createdAt: record.createdAt,
+      status: status(record.provider),
+    }))
+    .sort((a, b) => a.provider.localeCompare(b.provider));
+
+  return (
+    <KeyVaultContext.Provider
+      value={{
+        keys,
+        ready,
+        status,
+        addKey,
+        rotateKey,
+        removeKey,
+        unlock,
+        lock,
+        getPlaintextKey,
+      }}
+    >
+      {children}
+    </KeyVaultContext.Provider>
+  );
+}
+
+export function useKeyVault(): KeyVaultContextValue {
+  const value = useContext(KeyVaultContext);
+  if (!value) throw new Error('useKeyVault must be used inside <KeyVaultProvider>');
+  return value;
+}
+
+/** Like useKeyVault, but safe outside <KeyVaultProvider> — returns null so
+ * components stay renderable in isolation/tests. */
+export function useKeyVaultOptional(): KeyVaultContextValue | null {
+  return useContext(KeyVaultContext);
+}

--- a/frontend/src/vault/vaultCrypto.test.ts
+++ b/frontend/src/vault/vaultCrypto.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Vault passphrase crypto tests (Phase 4).
+ *
+ * Round-trips use a lowered iteration count (the KDF parameters ride in the
+ * record, so unwrap honors whatever wrap wrote) — one test pins the
+ * production default at 600k. Never-log policy: failure messages must not
+ * carry the API key or passphrase.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  VAULT_IV_LENGTH,
+  VAULT_KDF_ALG,
+  VAULT_PBKDF2_ITERATIONS,
+  VaultCryptoError,
+  WRONG_PASSPHRASE_MESSAGE,
+  unwrapKey,
+  wrapKey,
+} from './vaultCrypto';
+import { b64urlDecode, b64urlEncode } from './envelope';
+
+const API_KEY = 'sk-ant-test-key-abcd';
+const PASSPHRASE = 'correct horse battery staple';
+// Fast KDF for tests; production default is pinned separately below.
+const TEST_ITERATIONS = 1_000;
+
+describe('vaultCrypto', () => {
+  it('pins the production KDF parameters', async () => {
+    expect(VAULT_PBKDF2_ITERATIONS).toBe(600_000);
+    const wrapped = await wrapKey(API_KEY, PASSPHRASE); // default iterations
+    expect(wrapped.kdf).toEqual({ alg: VAULT_KDF_ALG, iterations: 600_000 });
+  });
+
+  it('round-trips an API key under the right passphrase', async () => {
+    const wrapped = await wrapKey(API_KEY, PASSPHRASE, TEST_ITERATIONS);
+    expect(wrapped.kdf.iterations).toBe(TEST_ITERATIONS);
+    expect(b64urlDecode(wrapped.iv)).toHaveLength(VAULT_IV_LENGTH);
+    await expect(unwrapKey(wrapped, PASSPHRASE)).resolves.toBe(API_KEY);
+  });
+
+  it('uses a fresh salt and iv per wrap', async () => {
+    const first = await wrapKey(API_KEY, PASSPHRASE, TEST_ITERATIONS);
+    const second = await wrapKey(API_KEY, PASSPHRASE, TEST_ITERATIONS);
+    expect(first.salt).not.toBe(second.salt);
+    expect(first.iv).not.toBe(second.iv);
+    expect(first.ct).not.toBe(second.ct);
+  });
+
+  it('rejects the wrong passphrase with the constant safe message', async () => {
+    const wrapped = await wrapKey(API_KEY, PASSPHRASE, TEST_ITERATIONS);
+    const error = await unwrapKey(wrapped, 'not the passphrase').then(
+      () => null,
+      (exc: unknown) => exc as VaultCryptoError,
+    );
+    expect(error).toBeInstanceOf(VaultCryptoError);
+    expect(error!.message).toBe(WRONG_PASSPHRASE_MESSAGE);
+    // Never-log policy: the failure names no secret material.
+    expect(error!.message).not.toContain(API_KEY);
+    expect(error!.message).not.toContain(PASSPHRASE);
+  });
+
+  it('rejects tampered ciphertext identically to a wrong passphrase', async () => {
+    const wrapped = await wrapKey(API_KEY, PASSPHRASE, TEST_ITERATIONS);
+    const ct = b64urlDecode(wrapped.ct);
+    ct[0] ^= 0xff;
+    const tampered = { ...wrapped, ct: b64urlEncode(ct) };
+    await expect(unwrapKey(tampered, PASSPHRASE)).rejects.toThrow(WRONG_PASSPHRASE_MESSAGE);
+  });
+
+  it('rejects an unsupported KDF fail-closed', async () => {
+    const wrapped = await wrapKey(API_KEY, PASSPHRASE, TEST_ITERATIONS);
+    const downgraded = { ...wrapped, kdf: { alg: 'PBKDF1' as never, iterations: 1 } };
+    await expect(unwrapKey(downgraded, PASSPHRASE)).rejects.toThrow(
+      'vault record has an unsupported KDF',
+    );
+  });
+
+  it('rejects a corrupted iteration count', async () => {
+    const wrapped = await wrapKey(API_KEY, PASSPHRASE, TEST_ITERATIONS);
+    const corrupted = { ...wrapped, kdf: { alg: VAULT_KDF_ALG, iterations: 0 } as const };
+    await expect(unwrapKey(corrupted, PASSPHRASE)).rejects.toThrow(
+      'vault record has an invalid KDF iteration count',
+    );
+  });
+
+  it('rejects non-b64url record fields', async () => {
+    const wrapped = await wrapKey(API_KEY, PASSPHRASE, TEST_ITERATIONS);
+    await expect(unwrapKey({ ...wrapped, salt: '!!!' }, PASSPHRASE)).rejects.toThrow(
+      'vault record salt is not valid b64url',
+    );
+  });
+
+  it('rejects empty inputs', async () => {
+    await expect(wrapKey('', PASSPHRASE)).rejects.toThrow(VaultCryptoError);
+    await expect(wrapKey(API_KEY, '')).rejects.toThrow(VaultCryptoError);
+    const wrapped = await wrapKey(API_KEY, PASSPHRASE, TEST_ITERATIONS);
+    await expect(unwrapKey(wrapped, '')).rejects.toThrow(VaultCryptoError);
+  });
+});

--- a/frontend/src/vault/vaultCrypto.ts
+++ b/frontend/src/vault/vaultCrypto.ts
@@ -1,0 +1,148 @@
+/**
+ * BYOK browser vault — passphrase wrap/unwrap (Phase 4).
+ *
+ * PBKDF2-SHA256 (600k iterations, fresh 16-byte salt per wrap) derives an
+ * AES-256-GCM key from the vault passphrase; the API key is sealed under a
+ * fresh 12-byte IV. The salt/iterations ride in the stored record, so unwrap
+ * always honors the parameters the record was written with.
+ *
+ * The IndexedDB blob is offline-brute-forceable if exfiltrated — the
+ * iteration count is the brake, and Phase 5's passphrase-strength minimum is
+ * the real control. Never lower VAULT_PBKDF2_ITERATIONS for new wraps.
+ *
+ * Never-log policy: nothing here logs, and no error may carry the API key,
+ * the passphrase, or ciphertext — every failure maps to a constant message.
+ */
+
+import { EnvelopeError, b64urlDecode, b64urlEncode } from './envelope';
+import type { VaultKdfParams, VaultRecord } from './vaultStore';
+
+export const VAULT_KDF_ALG = 'PBKDF2-SHA256';
+export const VAULT_PBKDF2_ITERATIONS = 600_000;
+export const VAULT_SALT_LENGTH = 16;
+export const VAULT_IV_LENGTH = 12;
+
+/** The one user-facing unwrap failure — wrong passphrase and a corrupted
+ * record are deliberately indistinguishable (GCM authentication failure). */
+export const WRONG_PASSPHRASE_MESSAGE = 'Incorrect passphrase (or the stored key is corrupted).';
+
+/** Thrown for every wrap/unwrap failure; never carries key material. */
+export class VaultCryptoError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'VaultCryptoError';
+  }
+}
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+async function deriveAesKey(
+  passphrase: string,
+  salt: Uint8Array,
+  iterations: number,
+): Promise<CryptoKey> {
+  const material = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(passphrase) as BufferSource,
+    'PBKDF2',
+    false,
+    ['deriveKey'],
+  );
+  return crypto.subtle.deriveKey(
+    { name: 'PBKDF2', hash: 'SHA-256', salt: salt as BufferSource, iterations },
+    material,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt'],
+  );
+}
+
+/** The encrypted fields of a VaultRecord (metadata is the caller's job). */
+export type WrappedKey = Pick<VaultRecord, 'ct' | 'iv' | 'salt' | 'kdf'>;
+
+/**
+ * Seal an API key under the vault passphrase. `iterations` is overridable
+ * for tests only — production callers must use the default.
+ */
+export async function wrapKey(
+  apiKey: string,
+  passphrase: string,
+  iterations: number = VAULT_PBKDF2_ITERATIONS,
+): Promise<WrappedKey> {
+  if (typeof apiKey !== 'string' || apiKey.length === 0) {
+    throw new VaultCryptoError('apiKey must be a non-empty string');
+  }
+  if (typeof passphrase !== 'string' || passphrase.length === 0) {
+    throw new VaultCryptoError('passphrase must be a non-empty string');
+  }
+  if (!Number.isSafeInteger(iterations) || iterations <= 0) {
+    throw new VaultCryptoError('iterations must be a positive integer');
+  }
+  const salt = crypto.getRandomValues(new Uint8Array(VAULT_SALT_LENGTH));
+  const iv = crypto.getRandomValues(new Uint8Array(VAULT_IV_LENGTH));
+  const aesKey = await deriveAesKey(passphrase, salt, iterations);
+  const ciphertext = new Uint8Array(
+    await crypto.subtle.encrypt(
+      { name: 'AES-GCM', iv: iv as BufferSource },
+      aesKey,
+      encoder.encode(apiKey) as BufferSource,
+    ),
+  );
+  return {
+    ct: b64urlEncode(ciphertext),
+    iv: b64urlEncode(iv),
+    salt: b64urlEncode(salt),
+    kdf: { alg: VAULT_KDF_ALG, iterations },
+  };
+}
+
+function decodeField(record: WrappedKey, field: 'ct' | 'iv' | 'salt'): Uint8Array {
+  const value = record[field];
+  if (typeof value !== 'string') {
+    throw new VaultCryptoError(`vault record ${field} must be a string`);
+  }
+  try {
+    return b64urlDecode(value);
+  } catch (exc) {
+    if (exc instanceof EnvelopeError) {
+      throw new VaultCryptoError(`vault record ${field} is not valid b64url`);
+    }
+    throw exc;
+  }
+}
+
+function validateKdf(kdf: VaultKdfParams): void {
+  if (typeof kdf !== 'object' || kdf === null || kdf.alg !== VAULT_KDF_ALG) {
+    throw new VaultCryptoError('vault record has an unsupported KDF');
+  }
+  if (!Number.isSafeInteger(kdf.iterations) || kdf.iterations <= 0) {
+    throw new VaultCryptoError('vault record has an invalid KDF iteration count');
+  }
+}
+
+/** Recover the plaintext API key, or throw WRONG_PASSPHRASE_MESSAGE. */
+export async function unwrapKey(record: WrappedKey, passphrase: string): Promise<string> {
+  if (typeof passphrase !== 'string' || passphrase.length === 0) {
+    throw new VaultCryptoError('passphrase must be a non-empty string');
+  }
+  validateKdf(record.kdf);
+  const ct = decodeField(record, 'ct');
+  const iv = decodeField(record, 'iv');
+  const salt = decodeField(record, 'salt');
+  if (iv.length !== VAULT_IV_LENGTH) {
+    throw new VaultCryptoError('vault record iv has the wrong length');
+  }
+  const aesKey = await deriveAesKey(passphrase, salt, record.kdf.iterations);
+  let plaintext: ArrayBuffer;
+  try {
+    plaintext = await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv: iv as BufferSource },
+      aesKey,
+      ct as BufferSource,
+    );
+  } catch {
+    throw new VaultCryptoError(WRONG_PASSPHRASE_MESSAGE);
+  }
+  return decoder.decode(plaintext);
+}

--- a/frontend/src/vault/vaultStore.test.ts
+++ b/frontend/src/vault/vaultStore.test.ts
@@ -1,0 +1,74 @@
+/**
+ * IndexedDB vault store tests (Phase 4) — fake-indexeddb per test, so every
+ * test starts from an empty browser profile.
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import { IDBFactory } from 'fake-indexeddb';
+
+import {
+  deleteRecord,
+  getAllRecords,
+  getRecord,
+  putRecord,
+  type VaultRecord,
+} from './vaultStore';
+
+function makeRecord(overrides: Partial<VaultRecord> = {}): VaultRecord {
+  return {
+    provider: 'anthropic',
+    ct: 'Y3QtYnl0ZXM',
+    iv: 'aXYtYnl0ZXM',
+    salt: 'c2FsdC1ieXRlcw',
+    kdf: { alg: 'PBKDF2-SHA256', iterations: 600_000 },
+    label: 'Personal key',
+    last4: 'abcd',
+    createdAt: 1_752_800_000_000,
+    ...overrides,
+  };
+}
+
+describe('vaultStore', () => {
+  beforeEach(() => {
+    Object.defineProperty(globalThis, 'indexedDB', {
+      value: new IDBFactory(),
+      configurable: true,
+    });
+  });
+
+  it('round-trips a record by provider', async () => {
+    const record = makeRecord();
+    await putRecord(record);
+    expect(await getRecord('anthropic')).toEqual(record);
+  });
+
+  it('returns null for a provider with no record', async () => {
+    expect(await getRecord('anthropic')).toBeNull();
+  });
+
+  it('put overwrites the existing record for the same provider', async () => {
+    await putRecord(makeRecord({ last4: 'abcd' }));
+    await putRecord(makeRecord({ last4: 'wxyz' }));
+    const all = await getAllRecords();
+    expect(all).toHaveLength(1);
+    expect(all[0].last4).toBe('wxyz');
+  });
+
+  it('getAllRecords returns every provider record', async () => {
+    await putRecord(makeRecord({ provider: 'anthropic' }));
+    await putRecord(makeRecord({ provider: 'openai', last4: 'wxyz' }));
+    const providers = (await getAllRecords()).map((record) => record.provider).sort();
+    expect(providers).toEqual(['anthropic', 'openai']);
+  });
+
+  it('deleteRecord removes only the named provider', async () => {
+    await putRecord(makeRecord({ provider: 'anthropic' }));
+    await putRecord(makeRecord({ provider: 'openai' }));
+    await deleteRecord('anthropic');
+    expect(await getRecord('anthropic')).toBeNull();
+    expect(await getRecord('openai')).not.toBeNull();
+  });
+
+  it('deleteRecord on a missing provider is a no-op', async () => {
+    await expect(deleteRecord('anthropic')).resolves.toBeUndefined();
+  });
+});

--- a/frontend/src/vault/vaultStore.ts
+++ b/frontend/src/vault/vaultStore.ts
@@ -1,0 +1,98 @@
+/**
+ * BYOK browser vault — IndexedDB persistence (Phase 4).
+ *
+ * Promise-wrapped IndexedDB: database `hl-keyvault`, object store `keys`
+ * keyed by provider (one wrapped key per provider). Records hold only
+ * passphrase-encrypted material plus display metadata (label, last4) — the
+ * plaintext API key never touches this module.
+ *
+ * The `indexedDB` global is resolved at call time so tests can substitute
+ * fake-indexeddb's IDBFactory per test.
+ *
+ * Never-log policy: nothing here logs, and no error message may carry record
+ * contents — messages describe structure only.
+ */
+
+export const VAULT_DB_NAME = 'hl-keyvault';
+export const VAULT_STORE_NAME = 'keys';
+const VAULT_DB_VERSION = 1;
+
+export interface VaultKdfParams {
+  alg: 'PBKDF2-SHA256';
+  iterations: number;
+}
+
+/** One passphrase-wrapped provider key; ct/iv/salt are b64url strings. */
+export interface VaultRecord {
+  provider: string;
+  ct: string;
+  iv: string;
+  salt: string;
+  kdf: VaultKdfParams;
+  label: string;
+  last4: string;
+  createdAt: number;
+}
+
+/** Thrown for vault storage failures; never carries record contents. */
+export class VaultStoreError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'VaultStoreError';
+  }
+}
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(VAULT_DB_NAME, VAULT_DB_VERSION);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(VAULT_STORE_NAME)) {
+        db.createObjectStore(VAULT_STORE_NAME, { keyPath: 'provider' });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(new VaultStoreError('could not open the key vault database'));
+    request.onblocked = () => reject(new VaultStoreError('the key vault database is blocked by another tab'));
+  });
+}
+
+/** Run one request in its own transaction; the db closes either way. */
+async function withStore<T>(
+  mode: IDBTransactionMode,
+  operation: (store: IDBObjectStore) => IDBRequest<T>,
+): Promise<T> {
+  const db = await openDb();
+  return new Promise<T>((resolve, reject) => {
+    let request: IDBRequest<T>;
+    try {
+      const tx = db.transaction(VAULT_STORE_NAME, mode);
+      tx.onabort = () => reject(new VaultStoreError('the key vault transaction was aborted'));
+      request = operation(tx.objectStore(VAULT_STORE_NAME));
+    } catch {
+      db.close();
+      reject(new VaultStoreError('the key vault operation could not start'));
+      return;
+    }
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(new VaultStoreError('the key vault operation failed'));
+  }).finally(() => db.close());
+}
+
+/** Insert or overwrite the record for its provider. */
+export async function putRecord(record: VaultRecord): Promise<void> {
+  await withStore('readwrite', (store) => store.put(record));
+}
+
+export async function getRecord(provider: string): Promise<VaultRecord | null> {
+  const result = await withStore<VaultRecord | undefined>('readonly', (store) => store.get(provider));
+  return result ?? null;
+}
+
+export async function getAllRecords(): Promise<VaultRecord[]> {
+  return withStore<VaultRecord[]>('readonly', (store) => store.getAll());
+}
+
+export async function deleteRecord(provider: string): Promise<void> {
+  await withStore('readwrite', (store) => store.delete(provider));
+}

--- a/keyproxy/auth.py
+++ b/keyproxy/auth.py
@@ -1,14 +1,18 @@
-"""Bearer-JWT verification for the Key Proxy (packet 2a).
+"""Bearer-JWT verification for the Key Proxy (packet 2a; ES256-only since 7a).
 
-Mirrors ``api/auth.py`` semantics at keyproxy scale: auth is inert until a
-verification key is configured (``QUANTCORE_JWT_SECRET``), and
+Auth is inert until the ES256 verification key is configured
+(``QUANTCORE_JWT_PUBLIC_KEY``, a PEM public key), and
 ``KEYPROXY_AUTH_DISABLED`` is the compose-parity override that forces auth
-off even when a secret is present. When auth is inactive the dependency
+off even when a key is present. When auth is inactive the dependency
 returns a synthetic local caller instead of rejecting, so route code is
 identical in both modes.
 
-HS256 only for now — packet 7a swaps this module to ES256-only verification
-(public key, no signing material).
+ES256-only, by design (decision #13): the keyproxy holds no signing
+material at all — only the public half of the quantui Express signing key —
+so a compromised verifier cannot mint identities. Tokens must carry
+``aud`` including ``"quantcore-keyproxy"``; a token scoped to another
+service replays nowhere here. HS256 service tokens (the MCP wrappers')
+are rejected: those authenticate to quantcore-api, never to the keyproxy.
 
 Logging policy: every rejection is a uniform 401 with the same constant
 detail string. Token contents and PyJWT error text never reach the response
@@ -33,12 +37,16 @@ _bearer = HTTPBearer(auto_error=False)
 
 _REJECT = "invalid or missing bearer token"
 
+# The audience this verifier answers to. Hardcoded, not env-driven: a
+# quantcore-api-only token must never redeem an envelope here.
+_AUDIENCE = "quantcore-keyproxy"
+
 
 def _auth_active() -> bool:
-    """Enforce JWT only when a secret is configured and not force-disabled."""
+    """Enforce JWT only when the public key is configured and not force-disabled."""
     if os.environ.get("KEYPROXY_AUTH_DISABLED", "").strip().lower() in _TRUTHY:
         return False
-    return bool(os.environ.get("QUANTCORE_JWT_SECRET"))
+    return bool(os.environ.get("QUANTCORE_JWT_PUBLIC_KEY"))
 
 
 @dataclass(frozen=True)
@@ -77,8 +85,9 @@ def require_caller(
     try:
         claims = jwt.decode(
             credentials.credentials,
-            os.environ["QUANTCORE_JWT_SECRET"],
-            algorithms=["HS256"],
+            os.environ["QUANTCORE_JWT_PUBLIC_KEY"],
+            algorithms=["ES256"],
+            audience=_AUDIENCE,
         )
     except jwt.PyJWTError:
         raise _reject() from None

--- a/keyproxy/auth.py
+++ b/keyproxy/auth.py
@@ -1,0 +1,91 @@
+"""Bearer-JWT verification for the Key Proxy (packet 2a).
+
+Mirrors ``api/auth.py`` semantics at keyproxy scale: auth is inert until a
+verification key is configured (``QUANTCORE_JWT_SECRET``), and
+``KEYPROXY_AUTH_DISABLED`` is the compose-parity override that forces auth
+off even when a secret is present. When auth is inactive the dependency
+returns a synthetic local caller instead of rejecting, so route code is
+identical in both modes.
+
+HS256 only for now — packet 7a swaps this module to ES256-only verification
+(public key, no signing material).
+
+Logging policy: every rejection is a uniform 401 with the same constant
+detail string. Token contents and PyJWT error text never reach the response
+or any log.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+import jwt
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+# auto_error=False so a missing header reaches this dependency (uniform 401)
+# rather than FastAPI's generic 403 — same choice as api/auth.py.
+_bearer = HTTPBearer(auto_error=False)
+
+_REJECT = "invalid or missing bearer token"
+
+
+def _auth_active() -> bool:
+    """Enforce JWT only when a secret is configured and not force-disabled."""
+    if os.environ.get("KEYPROXY_AUTH_DISABLED", "").strip().lower() in _TRUTHY:
+        return False
+    return bool(os.environ.get("QUANTCORE_JWT_SECRET"))
+
+
+@dataclass(frozen=True)
+class Caller:
+    """The verified caller identity — ``sub`` is what envelope AAD binds to."""
+
+    sub: str
+    claims: dict[str, Any] = field(default_factory=dict)
+    token: Optional[str] = None
+    is_local: bool = False
+
+    @classmethod
+    def local(cls) -> "Caller":
+        """Synthetic caller used when auth is inactive (local/compose)."""
+        return cls(sub="local", is_local=True)
+
+
+def _reject() -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail=_REJECT,
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+
+def require_caller(
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(_bearer),
+) -> Caller:
+    """FastAPI dependency: verify the Bearer JWT and return the ``Caller``."""
+    if not _auth_active():
+        return Caller.local()
+
+    if credentials is None or not credentials.credentials:
+        raise _reject()
+
+    try:
+        claims = jwt.decode(
+            credentials.credentials,
+            os.environ["QUANTCORE_JWT_SECRET"],
+            algorithms=["HS256"],
+        )
+    except jwt.PyJWTError:
+        raise _reject() from None
+
+    # Same subject resolution as api/auth.py's Principal — the envelope's
+    # aad.sub must match what quantcore-api attributes work to.
+    sub = str(claims.get("sub") or claims.get("email") or "")
+    if not sub:
+        raise _reject()
+    return Caller(sub=sub, claims=claims, token=credentials.credentials)

--- a/keyproxy/main.py
+++ b/keyproxy/main.py
@@ -23,21 +23,29 @@ nothing at all.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
+import queue
+import threading
 import time
-from typing import Optional
+from typing import Any, Optional
 
 from fastapi import Depends, FastAPI, HTTPException, Request, Response
 from fastapi.exceptions import RequestValidationError
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel
 
 from keyproxy import crypto
 from keyproxy.auth import Caller, require_caller
 from keyproxy.providers import get_provider
 from keyproxy.replay import JtiReplaySet, ReplayCapacityError, SubRateLimiter
-from keyproxy.scopes import Scope, ScopeError, validate_scope
+from keyproxy.scopes import (
+    BudgetExceededError,
+    Scope,
+    ScopeError,
+    validate_scope,
+)
 from keyproxy.sessions import (
     HARD_LIFETIME_CAP_SECONDS,
     SessionError,
@@ -53,12 +61,25 @@ _UNAVAILABLE = "temporarily unavailable"
 DEV_KID = "kp-dev-ephemeral"
 
 
+DEFAULT_HEARTBEAT_SECONDS = 15.0
+
+
 def _max_iat_skew() -> int:
     return int(
         os.environ.get(
             "KEYPROXY_MAX_SKEW", str(crypto.DEFAULT_MAX_IAT_SKEW_SECONDS)
         )
     )
+
+
+def _heartbeat_secs() -> float:
+    return float(
+        os.environ.get("KEYPROXY_HEARTBEAT_SECS", str(DEFAULT_HEARTBEAT_SECONDS))
+    )
+
+
+def _sse(event: str, data: dict) -> str:
+    return f"event: {event}\ndata: {json.dumps(data, separators=(',', ':'))}\n\n"
 
 
 def _parse_key_bundle(text: str) -> list[tuple[str, object]]:
@@ -142,6 +163,18 @@ class RedemptionRequest(BaseModel):
     provider: str
     envelope: dict
     scope: dict
+
+
+class StreamTurnRequest(BaseModel):
+    # Mirrors AnthropicChatClient.stream_turn's surface; betas/fallbacks are
+    # fixed provider-side (keyproxy.providers.anthropic) — not caller inputs.
+    session_id: str
+    model: str
+    effort: str
+    max_tokens: int = 8192
+    system: Any = None
+    tools: list = []
+    messages: list
 
 
 class SessionResponse(BaseModel):
@@ -292,6 +325,110 @@ def create_app() -> FastAPI:
             session.provider,
         )
         return Response(status_code=204)
+
+    @app.post("/v1/providers/anthropic/messages/stream")
+    def stream_messages(
+        body: StreamTurnRequest, caller: Caller = Depends(require_caller)
+    ) -> StreamingResponse:
+        # Per-call gate, all BEFORE the key is attached: session live + sub
+        # match, the operation classifies as a read, and the call budget has
+        # room. Every rejection is the same generic 400 (except budget
+        # exhaustion, whose messages name no values and — for the token
+        # ceiling — must reach the user verbatim).
+        provider = get_provider("anthropic")
+        try:
+            session = state.sessions.get(body.session_id, sub=caller.sub)
+        except SessionError:
+            raise HTTPException(status_code=400, detail=_INVALID) from None
+        if session.provider != provider.PROVIDER:
+            raise HTTPException(status_code=400, detail=_INVALID)
+        if provider.classify("messages.stream") != provider.READ:
+            raise HTTPException(status_code=400, detail=_INVALID)
+        try:
+            session.budget.charge_call()
+        except BudgetExceededError as exc:
+            state.sessions.delete(session.session_id)
+            raise HTTPException(status_code=400, detail=str(exc)) from None
+        try:
+            api_key = session.api_key
+        except SessionError:
+            raise HTTPException(status_code=400, detail=_INVALID) from None
+
+        heartbeat = _heartbeat_secs()
+        started = time.monotonic()
+
+        def worker(out: queue.Queue) -> None:
+            try:
+                for kind, payload in provider.stream_turn(
+                    api_key,
+                    model=body.model,
+                    effort=body.effort,
+                    max_tokens=body.max_tokens,
+                    system=body.system,
+                    tools=body.tools,
+                    messages=body.messages,
+                ):
+                    out.put((kind, payload))
+                    if kind == "final":
+                        return
+                out.put(("error", None))  # stream ended without a final
+            except Exception:
+                # Never let a provider exception (which may echo request
+                # material) reach the wire or a log — generic error frame.
+                out.put(("error", None))
+
+        def event_stream():
+            out: queue.Queue = queue.Queue()
+            threading.Thread(target=worker, args=(out,), daemon=True).start()
+            while True:
+                try:
+                    kind, payload = out.get(timeout=heartbeat)
+                except queue.Empty:
+                    # SSE comment — invisible to parsers, keeps idle-timeout
+                    # appliances from dropping the wire during thinking pauses.
+                    yield ": ping\n\n"
+                    continue
+                if kind == "delta":
+                    yield _sse("delta", {"text": payload})
+                elif kind == "final":
+                    usage = payload.get("usage") if isinstance(payload, dict) else None
+                    tokens = sum(
+                        v
+                        for v in (
+                            (usage or {}).get("input_tokens"),
+                            (usage or {}).get("output_tokens"),
+                        )
+                        if isinstance(v, int) and not isinstance(v, bool)
+                    )
+                    try:
+                        session.budget.charge_tokens(tokens)
+                    except BudgetExceededError:
+                        # Cumulative ceiling crossed: this response already
+                        # streamed, but the session is dead for future calls.
+                        state.sessions.delete(session.session_id)
+                    yield _sse("final", payload)
+                    logger.info(
+                        "turn streamed correlation_id=%s sub=%s provider=%s "
+                        "tokens=%s latency_ms=%s",
+                        session.correlation_id,
+                        caller.sub,
+                        provider.PROVIDER,
+                        tokens,
+                        int((time.monotonic() - started) * 1000),
+                    )
+                    return
+                else:
+                    yield _sse("error", {"detail": "provider error"})
+                    return
+
+        # No compression middleware may ever touch text/event-stream — a
+        # compressor buffers until its window fills, which looks exactly like
+        # broken streaming. This app deliberately adds none.
+        return StreamingResponse(
+            event_stream(),
+            media_type="text/event-stream",
+            headers={"Cache-Control": "no-store", "X-Accel-Buffering": "no"},
+        )
 
     @app.post("/v1/keys/validate", response_model=ValidateResponse)
     def validate_key(

--- a/keyproxy/main.py
+++ b/keyproxy/main.py
@@ -1,0 +1,337 @@
+"""Key Proxy FastAPI app (packet 2b).
+
+The tiny app factory assembling the packet 2a security core (auth, replay,
+sessions, scopes) and the provider registry behind the endpoint surface from
+docs/proposals/byok-key-proxy-plan.md ("Endpoints"):
+
+* ``GET  /healthz``                — liveness, no auth
+* ``GET  /v1/publickey``           — envelope encryption keys, newest first
+* ``POST /v1/sessions``            — redeem an envelope (exactly once) into a session
+* ``DELETE /v1/sessions/{id}``     — best-effort teardown, 204 either way
+* ``POST /v1/keys/validate``       — redeem + probe the key, immediate teardown
+
+Run with:  uvicorn keyproxy.main:app --host 127.0.0.1 --port 5002
+       or:  python -m keyproxy.main
+
+Logging policy (enforced by tests): every rejection is a generic 400/401/429
+with a constant detail string; request bodies are never echoed (the default
+FastAPI 422, which reflects input back, is overridden). The only log lines
+this module emits are the allowlist lines — correlation id, sub, provider,
+status — on *successful* redemption/validation/teardown; failure paths log
+nothing at all.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Optional
+
+from fastapi import Depends, FastAPI, HTTPException, Request, Response
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from keyproxy import crypto
+from keyproxy.auth import Caller, require_caller
+from keyproxy.providers import get_provider
+from keyproxy.replay import JtiReplaySet, ReplayCapacityError, SubRateLimiter
+from keyproxy.scopes import Scope, ScopeError, validate_scope
+from keyproxy.sessions import (
+    HARD_LIFETIME_CAP_SECONDS,
+    SessionError,
+    SessionStore,
+)
+
+logger = logging.getLogger("keyproxy")
+
+_INVALID = "invalid request"
+_RATE_LIMITED = "rate limit exceeded"
+_UNAVAILABLE = "temporarily unavailable"
+
+DEV_KID = "kp-dev-ephemeral"
+
+
+def _max_iat_skew() -> int:
+    return int(
+        os.environ.get(
+            "KEYPROXY_MAX_SKEW", str(crypto.DEFAULT_MAX_IAT_SKEW_SECONDS)
+        )
+    )
+
+
+def _parse_key_bundle(text: str) -> list[tuple[str, object]]:
+    """Parse ``KEYPROXY_PRIVATE_KEYS`` — the generate-script output format.
+
+    Each private key PEM is associated with the closest preceding
+    ``kid: <value>`` line (exactly what ``scripts/generate_keyproxy_keypair.py``
+    prints; rotation appends another rendered block). Public-key PEMs and
+    commentary lines are ignored. Fail closed: a private key without a kid,
+    an unparseable PEM, or an empty bundle refuses startup.
+    """
+    entries: list[tuple[str, object]] = []
+    current_kid: Optional[str] = None
+    pem_lines: Optional[list[str]] = None
+    for line in text.splitlines():
+        stripped = line.strip()
+        if pem_lines is not None:
+            pem_lines.append(stripped)
+            if stripped == "-----END PRIVATE KEY-----":
+                if not current_kid:
+                    raise RuntimeError(
+                        "KEYPROXY_PRIVATE_KEYS: private key without a kid line"
+                    )
+                try:
+                    key = crypto.load_private_key_pem("\n".join(pem_lines))
+                except Exception:
+                    raise RuntimeError(
+                        "KEYPROXY_PRIVATE_KEYS: unparseable private key PEM"
+                    ) from None
+                entries.append((current_kid, key))
+                pem_lines = None
+        elif stripped.lower().startswith("kid:"):
+            current_kid = stripped.split(":", 1)[1].strip()
+        elif stripped == "-----BEGIN PRIVATE KEY-----":
+            pem_lines = [stripped]
+    if pem_lines is not None:
+        raise RuntimeError("KEYPROXY_PRIVATE_KEYS: truncated private key PEM")
+    if not entries:
+        raise RuntimeError("KEYPROXY_PRIVATE_KEYS: no private keys found")
+    return entries
+
+
+class KeyProxyState:
+    """Per-app singletons: key material + the packet 2a security stores."""
+
+    def __init__(self) -> None:
+        bundle = os.environ.get("KEYPROXY_PRIVATE_KEYS")
+        if bundle:
+            entries = _parse_key_bundle(bundle)
+        else:
+            # Local/compose convenience: an ephemeral dev keypair. Envelopes
+            # minted against it only work for this process's lifetime, which
+            # is exactly the property a dev stack wants.
+            entries = [(DEV_KID, crypto.generate_private_key())]
+        self.private_keys: dict[str, object] = {}
+        self._key_order: list[str] = []
+        for kid, key in entries:
+            if kid in self.private_keys:
+                self._key_order.remove(kid)
+            self.private_keys[kid] = key
+            self._key_order.append(kid)
+        self.sessions = SessionStore()
+        self.replay = JtiReplaySet()
+        self.rate_limiter = SubRateLimiter()
+
+    def public_keys_newest_first(self) -> list[dict[str, str]]:
+        """Advertised keys — rotation appends to the bundle, so reverse it."""
+        return [
+            {
+                "kid": kid,
+                "alg": crypto.ENVELOPE_ALG,
+                "spki": crypto.b64url_encode(
+                    crypto.public_key_spki_der(self.private_keys[kid].public_key())
+                ),
+            }
+            for kid in reversed(self._key_order)
+        ]
+
+
+class RedemptionRequest(BaseModel):
+    provider: str
+    envelope: dict
+    scope: dict
+
+
+class SessionResponse(BaseModel):
+    session_id: str
+    expires_at: int
+
+
+class ValidateResponse(BaseModel):
+    valid: bool
+    provider: str
+    key_hint: str
+
+
+def _redeem(
+    state: KeyProxyState,
+    caller: Caller,
+    body: RedemptionRequest,
+    *,
+    expected_action: Optional[str] = None,
+):
+    """Shared redemption path: rate limit → scope → decrypt → burn jti.
+
+    Returns ``(provider_module, scope, api_key)``. Every rejection is a
+    generic constant-detail HTTPException; nothing on any failure path logs.
+    """
+    if not state.rate_limiter.allow(caller.sub):
+        raise HTTPException(status_code=429, detail=_RATE_LIMITED)
+
+    provider = get_provider(body.provider)
+    if provider is None:
+        raise HTTPException(status_code=400, detail=_INVALID)
+
+    try:
+        scope = validate_scope(body.scope)
+    except ScopeError as exc:
+        # Scope error text names fields only — except the token-budget copy,
+        # which the plan requires to reach the user verbatim.
+        raise HTTPException(status_code=400, detail=str(exc)) from None
+
+    if scope.provider != provider.PROVIDER:
+        raise HTTPException(status_code=400, detail=_INVALID)
+    if expected_action is not None and scope.action != expected_action:
+        raise HTTPException(status_code=400, detail=_INVALID)
+    if not provider.supports_scope(
+        action=scope.action, max_mutations=scope.max_mutations
+    ):
+        raise HTTPException(status_code=400, detail=_INVALID)
+
+    try:
+        api_key = crypto.decrypt_envelope(
+            body.envelope,
+            state.private_keys,
+            expected_sub=caller.sub,
+            expected_provider=provider.PROVIDER,
+            scope=dict(scope.raw),
+            max_iat_skew=_max_iat_skew(),
+        )
+    except crypto.EnvelopeError:
+        raise HTTPException(status_code=400, detail=_INVALID) from None
+
+    # Burn the jti only after a successful decrypt (crypto.py contract):
+    # exactly one concurrent redemption wins; a burned jti is a replay.
+    try:
+        fresh = state.replay.burn(body.envelope["aad"]["jti"])
+    except ReplayCapacityError:
+        raise HTTPException(status_code=503, detail=_UNAVAILABLE) from None
+    if not fresh:
+        raise HTTPException(status_code=400, detail=_INVALID)
+
+    return provider, scope, api_key
+
+
+def _create_session(
+    state: KeyProxyState, *, sub: str, provider: str, api_key: str, scope: Scope
+):
+    try:
+        return state.sessions.create(
+            sub=sub, provider=provider, api_key=api_key, scope=scope
+        )
+    except SessionError:
+        raise HTTPException(status_code=503, detail=_UNAVAILABLE) from None
+
+
+def create_app() -> FastAPI:
+    """Application factory — mirrors ``api/main.py``'s conventions at micro scale."""
+    app = FastAPI(title="QuantCore Key Proxy", version="1.0.0")
+    state = KeyProxyState()
+    app.state.keyproxy = state
+
+    @app.exception_handler(RequestValidationError)
+    async def _validation_handler(
+        request: Request, exc: RequestValidationError
+    ) -> JSONResponse:
+        # FastAPI's default 422 echoes the offending input back — for this
+        # service that could reflect an envelope. Generic 400, constant body.
+        return JSONResponse(status_code=400, content={"detail": _INVALID})
+
+    @app.get("/healthz")
+    def healthz() -> dict:
+        return {"status": "ok"}
+
+    @app.get("/v1/publickey")
+    def publickey() -> dict:
+        return {"keys": state.public_keys_newest_first()}
+
+    @app.post("/v1/sessions", response_model=SessionResponse)
+    def create_session(
+        body: RedemptionRequest, caller: Caller = Depends(require_caller)
+    ) -> SessionResponse:
+        provider, scope, api_key = _redeem(state, caller, body)
+        session = _create_session(
+            state,
+            sub=caller.sub,
+            provider=provider.PROVIDER,
+            api_key=api_key,
+            scope=scope,
+        )
+        logger.info(
+            "session redeemed correlation_id=%s sub=%s provider=%s ttl=%ss",
+            session.correlation_id,
+            caller.sub,
+            provider.PROVIDER,
+            int(session.ttl),
+        )
+        expires_at = int(
+            time.time() + min(session.ttl, HARD_LIFETIME_CAP_SECONDS)
+        )
+        return SessionResponse(
+            session_id=session.session_id, expires_at=expires_at
+        )
+
+    @app.delete("/v1/sessions/{session_id}", status_code=204)
+    def delete_session(
+        session_id: str, caller: Caller = Depends(require_caller)
+    ) -> Response:
+        # Best effort: 204 whether or not the session exists or is the
+        # caller's — existence must not be probeable. Only the owning sub's
+        # request actually tears the session down.
+        try:
+            session = state.sessions.get(session_id, sub=caller.sub)
+        except SessionError:
+            return Response(status_code=204)
+        state.sessions.delete(session_id)
+        logger.info(
+            "session deleted correlation_id=%s sub=%s provider=%s",
+            session.correlation_id,
+            caller.sub,
+            session.provider,
+        )
+        return Response(status_code=204)
+
+    @app.post("/v1/keys/validate", response_model=ValidateResponse)
+    def validate_key(
+        body: RedemptionRequest, caller: Caller = Depends(require_caller)
+    ) -> ValidateResponse:
+        provider, scope, api_key = _redeem(
+            state, caller, body, expected_action="key.validate"
+        )
+        # Immediate-teardown session: the key rides the same session
+        # machinery as every other redemption, then is discarded.
+        session = _create_session(
+            state,
+            sub=caller.sub,
+            provider=provider.PROVIDER,
+            api_key=api_key,
+            scope=scope,
+        )
+        try:
+            valid = provider.validate_key(session.api_key)
+            hint = provider.key_hint(session.api_key)
+        finally:
+            state.sessions.delete(session.session_id)
+        logger.info(
+            "key validated correlation_id=%s sub=%s provider=%s valid=%s",
+            session.correlation_id,
+            caller.sub,
+            provider.PROVIDER,
+            valid,
+        )
+        return ValidateResponse(
+            valid=valid, provider=provider.PROVIDER, key_hint=hint
+        )
+
+    return app
+
+
+app = create_app()
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="127.0.0.1", port=5002)

--- a/keyproxy/providers/__init__.py
+++ b/keyproxy/providers/__init__.py
@@ -1,0 +1,23 @@
+"""Provider modules for the Key Proxy (packet 2b).
+
+Each provider module owns the operation taxonomy and egress for exactly one
+upstream credential consumer. Lookup is a closed registry: an unknown
+provider name yields ``None`` and the caller fails closed — new providers
+become reachable only by being consciously added here.
+"""
+
+from __future__ import annotations
+
+from types import ModuleType
+from typing import Optional
+
+from keyproxy.providers import anthropic
+
+_PROVIDERS: dict[str, ModuleType] = {anthropic.PROVIDER: anthropic}
+
+
+def get_provider(name: object) -> Optional[ModuleType]:
+    """Return the provider module for ``name``, or ``None`` (fail closed)."""
+    if not isinstance(name, str):
+        return None
+    return _PROVIDERS.get(name)

--- a/keyproxy/providers/anthropic.py
+++ b/keyproxy/providers/anthropic.py
@@ -30,6 +30,11 @@ ANTHROPIC_VERSION = "2023-06-01"
 
 VALIDATE_TIMEOUT_SECONDS = 10.0
 
+# Fixed turn parameters, mirroring AnthropicChatClient.stream_turn — callers
+# supply model/effort/max_tokens/system/tools/messages; nothing else.
+STREAM_BETAS = ["server-side-fallback-2026-06-01"]
+STREAM_FALLBACKS = [{"model": "claude-opus-4-8"}]
+
 READ = "read"
 MUTATE = "mutate"
 
@@ -72,6 +77,38 @@ def supports_scope(*, action: object, max_mutations: int) -> bool:
 def key_hint(api_key: str) -> str:
     """The displayable hint for a key — last 4 chars only, never more."""
     return "…" + api_key[-4:]
+
+
+def stream_turn(api_key, *, model, effort, max_tokens, system, tools, messages):
+    """Stream one model turn — the keyproxy-side mirror of
+    ``AnthropicChatClient.stream_turn`` (quantcore/gateways/anthropic_gateway.py).
+
+    Yields ``("delta", text)`` for each text delta, then ``("final",
+    message_dict)`` exactly once. ``base_url`` is passed explicitly so the
+    SDK's ``ANTHROPIC_BASE_URL`` environment override can never redirect
+    egress. The SDK import is lazy — dev/CI environments don't ship it; the
+    keyproxy image pins it in keyproxy/requirements.txt.
+    """
+    import anthropic  # lazy — see docstring
+
+    client = anthropic.Anthropic(api_key=api_key, base_url=BASE_URL)
+    with client.beta.messages.stream(
+        model=model,
+        max_tokens=max_tokens,
+        system=system,
+        tools=tools,
+        messages=messages,
+        output_config={"effort": effort},
+        betas=STREAM_BETAS,
+        fallbacks=STREAM_FALLBACKS,
+    ) as stream:
+        for event in stream:
+            if (
+                event.type == "content_block_delta"
+                and getattr(event.delta, "type", "") == "text_delta"
+            ):
+                yield ("delta", event.delta.text)
+        yield ("final", stream.get_final_message().model_dump(mode="json"))
 
 
 def validate_key(api_key: str, *, timeout: float = VALIDATE_TIMEOUT_SECONDS) -> bool:

--- a/keyproxy/providers/anthropic.py
+++ b/keyproxy/providers/anthropic.py
@@ -1,0 +1,96 @@
+"""Anthropic provider module for the Key Proxy (packet 2b).
+
+Owns the operation taxonomy and the egress allowlist for Anthropic keys, per
+the plan's "Provider modules classify every call — fail closed" section:
+
+* **Egress is allowlisted by construction** — ``BASE_URL`` is hardcoded; no
+  request field, scope param, header, or environment override may influence
+  where a decrypted key is sent.
+* **The taxonomy is closed** — v1 permits exactly ``messages.stream`` (the
+  streaming model turn, packet 3a) and ``key.validate`` (a ``models.list``
+  probe), both reads. Anything else is unclassifiable and the caller must
+  reject. Ambient chat scopes carry ``max_mutations: 0`` and this module has
+  no mutate operations at all.
+
+Logging policy: nothing here logs; the API key appears only in the outbound
+``x-api-key`` header and is never part of any exception or return value.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import requests
+
+PROVIDER = "anthropic"
+
+# Hardcoded egress target — the allowlist-by-construction guarantee.
+BASE_URL = "https://api.anthropic.com"
+ANTHROPIC_VERSION = "2023-06-01"
+
+VALIDATE_TIMEOUT_SECONDS = 10.0
+
+READ = "read"
+MUTATE = "mutate"
+
+# operation name -> classification. Closed: absence means unclassifiable.
+_OPERATIONS: dict[str, str] = {
+    "messages.stream": READ,
+    "key.validate": READ,
+}
+
+# Scope actions this provider will open a session for. ``chat.turn`` is the
+# ambient chat scope (fans out into messages.stream calls); ``key.validate``
+# is the immediate-teardown validation probe.
+_ACTIONS = frozenset({"chat.turn", "key.validate"})
+
+
+def classify(operation: object) -> Optional[str]:
+    """Classify an outgoing operation as ``read``/``mutate``, or ``None``.
+
+    ``None`` means unclassifiable — the caller must fail closed.
+    """
+    if not isinstance(operation, str):
+        return None
+    return _OPERATIONS.get(operation)
+
+
+def supports_action(action: object) -> bool:
+    """Whether this provider opens sessions for the given scope ``action``."""
+    return isinstance(action, str) and action in _ACTIONS
+
+
+def supports_scope(*, action: object, max_mutations: int) -> bool:
+    """Vet a validated scope: known action, and no mutation budget at all.
+
+    Anthropic v1 has zero mutate operations, so any scope asking for a
+    mutation budget is unclassifiable intent — reject (fail closed).
+    """
+    return supports_action(action) and max_mutations == 0
+
+
+def key_hint(api_key: str) -> str:
+    """The displayable hint for a key — last 4 chars only, never more."""
+    return "…" + api_key[-4:]
+
+
+def validate_key(api_key: str, *, timeout: float = VALIDATE_TIMEOUT_SECONDS) -> bool:
+    """Probe the key with the cheapest read: ``models.list(limit=1)``.
+
+    Returns ``True`` only on HTTP 200. Auth failures, network errors, and
+    provider outages all yield ``False`` (fail closed) — no exception ever
+    propagates carrying the key or the provider response body.
+    """
+    try:
+        response = requests.get(
+            f"{BASE_URL}/v1/models",
+            params={"limit": 1},
+            headers={
+                "x-api-key": api_key,
+                "anthropic-version": ANTHROPIC_VERSION,
+            },
+            timeout=timeout,
+        )
+        return response.status_code == 200
+    except requests.RequestException:
+        return False

--- a/keyproxy/replay.py
+++ b/keyproxy/replay.py
@@ -1,0 +1,144 @@
+"""Replay protection + per-sub redemption rate limiting (packet 2a).
+
+Two small in-memory, thread-safe structures for the trust boundary:
+
+* :class:`JtiReplaySet` — the burned-``jti`` set that makes every envelope
+  redeemable exactly once. Entries are TTL'd: a ``jti`` only needs to be
+  remembered while its envelope could still pass the ``iat`` skew check
+  (``|now - iat| <= KEYPROXY_MAX_SKEW``), so the default retention is twice
+  the skew window.
+* :class:`SubRateLimiter` — a per-``sub`` token bucket counting **envelope
+  redemptions (user actions), not fan-out calls** — an 8-turn chat costs 1.
+
+Both are size-capped and fail closed: when a cap is hit, new work is refused
+rather than old security state evicted. Coherence across requests relies on
+the single-instance deployment (``--max-instances=1``, decision #5).
+
+Logging policy: nothing in this module logs; error messages are constant and
+carry no ``jti``/``sub`` values.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from typing import Callable, Optional
+
+DEFAULT_MAX_SKEW_SECONDS = 60
+DEFAULT_RATE_LIMIT_PER_MIN = 30
+
+
+class ReplayCapacityError(RuntimeError):
+    """The replay set is full — refuse new redemptions (fail closed)."""
+
+    def __init__(self) -> None:
+        super().__init__("replay protection at capacity")
+
+
+def _default_jti_ttl() -> float:
+    skew = int(os.environ.get("KEYPROXY_MAX_SKEW", str(DEFAULT_MAX_SKEW_SECONDS)))
+    return 2.0 * skew
+
+
+class JtiReplaySet:
+    """TTL'd set of burned envelope ``jti`` values.
+
+    ``burn`` is the single atomic operation: it returns ``True`` when the
+    ``jti`` was fresh (and is now burned) and ``False`` when it was already
+    burned — under concurrency, exactly one caller wins.
+
+    Entries share a uniform TTL, so insertion order == expiry order and
+    pruning pops from the front of the (insertion-ordered) dict.
+    """
+
+    def __init__(
+        self,
+        ttl_seconds: Optional[float] = None,
+        max_entries: int = 100_000,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._ttl = _default_jti_ttl() if ttl_seconds is None else float(ttl_seconds)
+        self._max_entries = max_entries
+        self._clock = clock
+        self._lock = threading.Lock()
+        self._burned: dict[str, float] = {}  # jti -> expiry
+
+    def burn(self, jti: str) -> bool:
+        with self._lock:
+            now = self._clock()
+            self._prune(now)
+            if jti in self._burned:
+                return False
+            if len(self._burned) >= self._max_entries:
+                raise ReplayCapacityError()
+            self._burned[jti] = now + self._ttl
+            return True
+
+    def _prune(self, now: float) -> None:
+        while self._burned:
+            oldest = next(iter(self._burned))
+            if self._burned[oldest] > now:
+                break
+            del self._burned[oldest]
+
+
+class SubRateLimiter:
+    """Per-``sub`` token bucket over envelope redemptions.
+
+    Capacity and refill rate both come from ``per_minute`` (default
+    ``KEYPROXY_RATE_LIMIT_PER_MIN``, 30): a full bucket holds ``per_minute``
+    redemptions and refills continuously at ``per_minute``/60 per second.
+
+    The bucket map is size-capped; when full, idle (fully refilled) buckets
+    are pruned, and if none can be freed a *new* sub is refused (fail
+    closed) — existing subs keep their state.
+    """
+
+    def __init__(
+        self,
+        per_minute: Optional[int] = None,
+        max_subs: int = 10_000,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        if per_minute is None:
+            per_minute = int(
+                os.environ.get(
+                    "KEYPROXY_RATE_LIMIT_PER_MIN", str(DEFAULT_RATE_LIMIT_PER_MIN)
+                )
+            )
+        self._capacity = float(per_minute)
+        self._rate = per_minute / 60.0
+        self._max_subs = max_subs
+        self._clock = clock
+        self._lock = threading.Lock()
+        self._buckets: dict[str, list[float]] = {}  # sub -> [tokens, last_refill]
+
+    def allow(self, sub: str) -> bool:
+        with self._lock:
+            now = self._clock()
+            bucket = self._buckets.get(sub)
+            if bucket is None:
+                if len(self._buckets) >= self._max_subs:
+                    self._prune(now)
+                if len(self._buckets) >= self._max_subs:
+                    return False
+                bucket = [self._capacity, now]
+                self._buckets[sub] = bucket
+            else:
+                tokens, last = bucket
+                bucket[0] = min(self._capacity, tokens + (now - last) * self._rate)
+                bucket[1] = now
+            if bucket[0] >= 1.0:
+                bucket[0] -= 1.0
+                return True
+            return False
+
+    def _prune(self, now: float) -> None:
+        idle = [
+            sub
+            for sub, (tokens, last) in self._buckets.items()
+            if tokens + (now - last) * self._rate >= self._capacity
+        ]
+        for sub in idle:
+            del self._buckets[sub]

--- a/keyproxy/requirements.txt
+++ b/keyproxy/requirements.txt
@@ -4,7 +4,9 @@
 # material and the code that can touch it stay confined to this service).
 fastapi>=0.110.0
 uvicorn[standard]>=0.29.0
+pydantic>=2.0.0
 httpx>=0.27.0
+requests>=2.25.0
 PyJWT>=2.8.0
 cryptography>=42.0.0
 anthropic>=0.40.0

--- a/keyproxy/requirements.txt
+++ b/keyproxy/requirements.txt
@@ -1,7 +1,8 @@
 # Key Proxy service dependencies. Dockerfile.keyproxy (packet 2c) installs
-# THIS file only — the proxy container does not get requirements-base.txt,
-# and quantcore-api never gains `cryptography` (the envelope private-key
-# material and the code that can touch it stay confined to this service).
+# THIS file only — the proxy container does not get requirements-base.txt.
+# The envelope private-key material and the decryption code path stay
+# confined to this service (invariant #1); since packet 7a quantcore-api
+# also carries the `cryptography` lib, but only for ES256 JWT verification.
 fastapi>=0.110.0
 uvicorn[standard]>=0.29.0
 pydantic>=2.0.0

--- a/keyproxy/scopes.py
+++ b/keyproxy/scopes.py
@@ -1,0 +1,205 @@
+"""Scope v1 validation, canonical hashing, and budget counters (packet 2a).
+
+The scope is the cleartext object accompanying every envelope; its canonical
+SHA-256 rides inside the GCM-authenticated AAD (``aad.scope_hash``), so the
+proxy can read it while tampering breaks decryption. Canonicalization
+delegates to :mod:`keyproxy.crypto` — the same functions pinned by the
+Phase 1 cross-runtime vectors — so the scope a browser hashed is the scope
+this module hashes, byte for byte.
+
+Validation is fail closed: unknown top-level or budget keys, any version
+other than 1, non-integer budgets, and non-canonicalizable content are all
+rejected. ``budget.max_tokens`` may narrow but never widen the server-side
+ceiling (``KEYPROXY_MAX_SESSION_TOKENS``); minting a scope above it — or a
+session's cumulative usage crossing it — yields the system-threshold
+rejection copy verbatim.
+
+Logging policy: error messages name fields, never values — no scope
+contents, subs, or key material appear in any exception text.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Mapping, Optional
+
+from keyproxy import crypto
+
+SCOPE_VERSION = 1
+DEFAULT_MAX_SESSION_TOKENS = 250_000
+
+# Verbatim rejection copy required by the plan ("Scope schema (v1)"): the cap
+# is a breach-exposure ceiling, not spend throttling, and user testing tunes
+# the default through exactly this feedback loop.
+TOKEN_BUDGET_MESSAGE = (
+    "Session token budget rejected: you hit a system-imposed threshold. "
+    "Please contact the development team to have it raised."
+)
+
+_SCOPE_KEYS = frozenset({"v", "provider", "action", "params", "budget"})
+_BUDGET_KEYS = frozenset({"max_calls", "max_mutations", "max_tokens", "ttl"})
+_BUDGET_REQUIRED = frozenset({"max_calls", "max_mutations", "ttl"})
+
+# Re-exported so the rest of the keyproxy hashes scopes through this module.
+canonical_scope_json = crypto.canonical_json
+compute_scope_hash = crypto.compute_scope_hash
+
+
+class ScopeError(ValueError):
+    """A scope failed validation. Messages name fields, never values."""
+
+
+class BudgetExceededError(Exception):
+    """A session budget line was crossed — the session must be killed."""
+
+
+def _max_session_tokens() -> int:
+    return int(
+        os.environ.get("KEYPROXY_MAX_SESSION_TOKENS", str(DEFAULT_MAX_SESSION_TOKENS))
+    )
+
+
+def _require_positive_int(budget: Mapping, field: str, minimum: int) -> int:
+    value = budget[field]
+    if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+        raise ScopeError(f"invalid scope budget field: {field}")
+    return value
+
+
+@dataclass(frozen=True)
+class Scope:
+    """A validated v1 scope. ``raw`` is the exact dict the hash covers."""
+
+    provider: str
+    action: str
+    params: Mapping
+    max_calls: int
+    max_mutations: int
+    max_tokens: int
+    ttl: int
+    raw: Mapping
+
+    @property
+    def scope_hash(self) -> str:
+        return compute_scope_hash(dict(self.raw))
+
+
+def validate_scope(
+    scope_obj: object, *, max_session_tokens: Optional[int] = None
+) -> Scope:
+    """Validate a wire scope object into a :class:`Scope` (fail closed)."""
+    if max_session_tokens is None:
+        max_session_tokens = _max_session_tokens()
+
+    if not isinstance(scope_obj, dict) or set(scope_obj.keys()) != _SCOPE_KEYS:
+        raise ScopeError("invalid scope structure")
+    version = scope_obj["v"]
+    if isinstance(version, bool) or version != SCOPE_VERSION:
+        raise ScopeError("unsupported scope version")
+    provider = scope_obj["provider"]
+    action = scope_obj["action"]
+    if not isinstance(provider, str) or not provider:
+        raise ScopeError("invalid scope field: provider")
+    if not isinstance(action, str) or not action:
+        raise ScopeError("invalid scope field: action")
+    params = scope_obj["params"]
+    if not isinstance(params, dict):
+        raise ScopeError("invalid scope field: params")
+
+    budget = scope_obj["budget"]
+    if not isinstance(budget, dict):
+        raise ScopeError("invalid scope field: budget")
+    keys = set(budget.keys())
+    if not _BUDGET_REQUIRED <= keys or not keys <= _BUDGET_KEYS:
+        raise ScopeError("invalid scope budget structure")
+    max_calls = _require_positive_int(budget, "max_calls", 1)
+    max_mutations = _require_positive_int(budget, "max_mutations", 0)
+    ttl = _require_positive_int(budget, "ttl", 1)
+    if "max_tokens" in budget:
+        max_tokens = _require_positive_int(budget, "max_tokens", 1)
+        if max_tokens > max_session_tokens:
+            raise ScopeError(TOKEN_BUDGET_MESSAGE)
+    else:
+        # Absent means "no narrower than the server allows" — still bounded.
+        max_tokens = max_session_tokens
+
+    try:
+        canonical_scope_json(scope_obj)
+    except crypto.EnvelopeError:
+        raise ScopeError("scope is not canonicalizable") from None
+
+    return Scope(
+        provider=provider,
+        action=action,
+        params=MappingProxyType(dict(params)),
+        max_calls=max_calls,
+        max_mutations=max_mutations,
+        max_tokens=max_tokens,
+        ttl=ttl,
+        raw=MappingProxyType(dict(scope_obj)),
+    )
+
+
+class BudgetTracker:
+    """Thread-safe budget counters for one session.
+
+    Calls and mutations are charged *before* the key is attached; token usage
+    is charged *after* each call from provider-reported usage (the plan's
+    "sums the provider-reported usage ... kills the session when the total
+    crosses the line"). Once any line is crossed the tracker latches
+    exhausted and every subsequent charge fails — the session is dead.
+    """
+
+    def __init__(self, scope: Scope) -> None:
+        self._scope = scope
+        self._lock = threading.Lock()
+        self._calls = 0
+        self._mutations = 0
+        self._tokens = 0
+        self._exhausted: Optional[str] = None
+
+    @property
+    def calls_used(self) -> int:
+        return self._calls
+
+    @property
+    def mutations_used(self) -> int:
+        return self._mutations
+
+    @property
+    def tokens_used(self) -> int:
+        return self._tokens
+
+    def _check_latch(self) -> None:
+        if self._exhausted is not None:
+            raise BudgetExceededError(self._exhausted)
+
+    def _exhaust(self, message: str) -> None:
+        self._exhausted = message
+        raise BudgetExceededError(message)
+
+    def charge_call(self) -> None:
+        with self._lock:
+            self._check_latch()
+            if self._calls >= self._scope.max_calls:
+                self._exhaust("session call budget exhausted")
+            self._calls += 1
+
+    def charge_mutation(self) -> None:
+        with self._lock:
+            self._check_latch()
+            if self._mutations >= self._scope.max_mutations:
+                self._exhaust("session mutation budget exhausted")
+            self._mutations += 1
+
+    def charge_tokens(self, count: int) -> None:
+        if not isinstance(count, int) or isinstance(count, bool) or count < 0:
+            raise ValueError("token count must be a non-negative integer")
+        with self._lock:
+            self._check_latch()
+            self._tokens += count
+            if self._tokens > self._scope.max_tokens:
+                self._exhaust(TOKEN_BUDGET_MESSAGE)

--- a/keyproxy/sessions.py
+++ b/keyproxy/sessions.py
@@ -1,0 +1,167 @@
+"""In-memory scoped session store (packet 2a).
+
+A session is what an envelope redeems into — ``{plaintext key, scope,
+verified sub, budget counters}`` held in process memory under a 128-bit
+random id, alive for one user action's fan-out:
+
+* **Sliding TTL** — each successful ``get`` extends the session by the
+  effective TTL, which is ``min(KEYPROXY_SESSION_TTL, scope.budget.ttl)``
+  (a scope may narrow but never widen the server default).
+* **Hard lifetime cap** — ~900 s from creation regardless of activity.
+* **Teardown discards plaintext** — explicit ``delete`` (best-effort from
+  quantcore-api) or expiry both drop the key reference; a stale
+  :class:`Session` object cannot read the key afterwards.
+
+The store is thread-safe, size-capped (fail closed), and deliberately
+in-memory only: session state holds plaintext keys and must never leave
+process memory (architectural-standard Rule 4 deviation, documented in the
+plan). Coherence relies on ``--max-instances=1``.
+
+Logging policy: nothing here logs; every rejection raises
+:class:`SessionError` with the same generic message, so a missing session,
+an expired session, and a ``sub`` mismatch are indistinguishable to callers.
+"""
+
+from __future__ import annotations
+
+import hmac
+import os
+import secrets
+import threading
+import time
+import uuid
+from typing import Callable, Optional
+
+from keyproxy.scopes import BudgetTracker, Scope
+
+DEFAULT_SESSION_TTL_SECONDS = 300.0
+HARD_LIFETIME_CAP_SECONDS = 900.0
+
+_REJECT = "invalid session"
+
+
+class SessionError(Exception):
+    """Any session rejection. The message is always the same generic text."""
+
+    def __init__(self) -> None:
+        super().__init__(_REJECT)
+
+
+def _default_ttl() -> float:
+    return float(
+        os.environ.get("KEYPROXY_SESSION_TTL", str(DEFAULT_SESSION_TTL_SECONDS))
+    )
+
+
+class Session:
+    """One redeemed envelope: identity, scope, budget, and the plaintext key."""
+
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        correlation_id: str,
+        sub: str,
+        provider: str,
+        api_key: str,
+        scope: Scope,
+        created_at: float,
+        ttl: float,
+    ) -> None:
+        self.session_id = session_id
+        self.correlation_id = correlation_id
+        self.sub = sub
+        self.provider = provider
+        self.scope = scope
+        self.budget = BudgetTracker(scope)
+        self.created_at = created_at
+        self.ttl = ttl
+        self._api_key: Optional[str] = api_key
+        self._last_activity = created_at
+
+    @property
+    def api_key(self) -> str:
+        key = self._api_key
+        if key is None:
+            raise SessionError()
+        return key
+
+    def expires_at(self) -> float:
+        """Sliding expiry, clamped by the hard lifetime cap."""
+        return min(
+            self._last_activity + self.ttl,
+            self.created_at + HARD_LIFETIME_CAP_SECONDS,
+        )
+
+    def _touch(self, now: float) -> None:
+        self._last_activity = now
+
+    def _teardown(self) -> None:
+        self._api_key = None
+
+
+class SessionStore:
+    """Thread-safe, size-capped, TTL'd map of live sessions."""
+
+    def __init__(
+        self,
+        ttl_seconds: Optional[float] = None,
+        max_sessions: int = 1_000,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._ttl = _default_ttl() if ttl_seconds is None else float(ttl_seconds)
+        self._max_sessions = max_sessions
+        self._clock = clock
+        self._lock = threading.Lock()
+        self._sessions: dict[str, Session] = {}
+
+    def create(self, *, sub: str, provider: str, api_key: str, scope: Scope) -> Session:
+        with self._lock:
+            now = self._clock()
+            self._sweep(now)
+            if len(self._sessions) >= self._max_sessions:
+                raise SessionError()
+            session = Session(
+                session_id=secrets.token_hex(16),
+                correlation_id=str(uuid.uuid4()),
+                sub=sub,
+                provider=provider,
+                api_key=api_key,
+                scope=scope,
+                created_at=now,
+                ttl=min(self._ttl, float(scope.ttl)),
+            )
+            self._sessions[session.session_id] = session
+            return session
+
+    def get(self, session_id: str, *, sub: str) -> Session:
+        """Look up a live session for ``sub`` and slide its TTL."""
+        with self._lock:
+            now = self._clock()
+            session = self._sessions.get(session_id)
+            if session is None or now > session.expires_at():
+                if session is not None:
+                    session._teardown()
+                    del self._sessions[session_id]
+                raise SessionError()
+            if not hmac.compare_digest(
+                session.sub.encode("utf-8"), sub.encode("utf-8")
+            ):
+                raise SessionError()
+            session._touch(now)
+            return session
+
+    def delete(self, session_id: str) -> None:
+        """Best-effort teardown — idempotent, never raises for unknown ids."""
+        with self._lock:
+            session = self._sessions.pop(session_id, None)
+            if session is not None:
+                session._teardown()
+
+    def _sweep(self, now: float) -> None:
+        expired = [
+            sid for sid, s in self._sessions.items() if now > s.expires_at()
+        ]
+        for sid in expired:
+            self._sessions[sid]._teardown()
+            del self._sessions[sid]

--- a/quantcore/gateways/keyproxy_fake.py
+++ b/quantcore/gateways/keyproxy_fake.py
@@ -1,0 +1,76 @@
+"""FakeKeyProxyGateway — canned in-process keyproxy for route tests (3c).
+
+KEYPROXY_FAKE=1 swaps this in for the real gateway module so /api/keyproxy
+routes can be exercised with zero network: it generates a REAL P-256 keypair
+and runs the REAL envelope decrypt (keyproxy/crypto.py), so tests mint
+genuine envelopes against ``.public_key`` and the full seal→unseal path is
+covered. What it fakes is only the transport and the provider probe.
+
+Never-log policy applies here exactly as in the keyproxy: no key material,
+envelope contents, or tokens are logged or embedded in exceptions —
+rejections raise KeyProxyError with the gateway's canned user-safe copy.
+"""
+from __future__ import annotations
+
+import jwt
+
+from keyproxy import crypto
+
+from .keyproxy_gateway import KeyProxyError, RESEND_MESSAGE
+
+_FAKE_KID = "kp-fake-1"
+
+
+class FakeKeyProxyGateway:
+    """Drop-in for the keyproxy gateway module: same three functions."""
+
+    def __init__(self):
+        self._private_key = crypto.generate_private_key()
+        self.public_key = self._private_key.public_key()
+
+    def is_configured(self) -> bool:
+        return True
+
+    def get_public_keys(self) -> list[dict]:
+        return [
+            {
+                "kid": _FAKE_KID,
+                "alg": crypto.ENVELOPE_ALG,
+                "spki": crypto.b64url_encode(
+                    crypto.public_key_spki_der(self.public_key)
+                ),
+            }
+        ]
+
+    def validate_key(self, *, envelope: dict, scope: dict, auth_token: str) -> dict:
+        expected_sub = None
+        if auth_token:
+            try:
+                claims = jwt.decode(auth_token, options={"verify_signature": False})
+                expected_sub = claims.get("sub")
+            except Exception:
+                expected_sub = None
+        if expected_sub is None:
+            # No token (auth-off local mode): trust the envelope's own sub,
+            # exactly what a keyproxy without upstream auth cannot do — this
+            # shortcut is why the fake is test-only.
+            try:
+                expected_sub = envelope["aad"]["sub"]
+            except Exception:
+                raise KeyProxyError(RESEND_MESSAGE) from None
+        try:
+            api_key = crypto.decrypt_envelope(
+                envelope,
+                {_FAKE_KID: self._private_key},
+                expected_sub=expected_sub,
+                expected_provider=scope.get("provider"),
+                scope=scope,
+                max_iat_skew=crypto.DEFAULT_MAX_IAT_SKEW_SECONDS,
+            )
+        except crypto.EnvelopeError:
+            raise KeyProxyError(RESEND_MESSAGE) from None
+        return {
+            "valid": True,
+            "provider": scope.get("provider"),
+            "key_hint": "…" + api_key[-4:],
+        }

--- a/quantcore/gateways/keyproxy_gateway.py
+++ b/quantcore/gateways/keyproxy_gateway.py
@@ -1,0 +1,345 @@
+"""Key Proxy gateway — the api-side client for the BYOK keyproxy (packet 3b).
+
+Architectural-standard-v2 §5.3 / plan Rule 3: API calls, auth forwarding,
+streaming, and error translation ONLY — no validation rules, no decisions
+(anti-pattern 8 guard: this module must never grow logic).
+
+``KeyProxyChatClient`` implements the ``ChatClient`` protocol
+(quantcore/services/chat.py) against the keyproxy's streaming endpoint,
+carrying the session exchange from the plan's Session mechanics:
+
+* the envelope is redeemed **exactly once per client instance** —
+  ``POST /v1/sessions`` lazily before the first turn;
+* every turn presents the resulting ``session_id`` (plus the caller's JWT);
+* teardown (``DELETE /v1/sessions/{id}``) is best-effort — fired when a turn
+  is terminal for the ChatService loop (no tool_use blocks, or a refusal) and
+  on every error path; the keyproxy TTL is the backstop.
+
+Streaming hardening (decision #11): all requests ride one **persistent pooled
+``httpx.Client``** (module-level, keep-alive), so turns 2+ — and later sends —
+reuse the warm connection to the single keyproxy instance instead of paying
+TCP setup per turn.
+
+Content blocks from the provider's final message are wrapped in an attribute
+view (``ContentBlock``) so ChatService's tool loop can keep its ``getattr``
+access pattern, while the underlying dict is kept byte-exact — thinking-block
+``signature`` fields must survive the echo back into the conversation and the
+serialization onto the next turn's request unchanged.
+
+Error policy: nothing here logs, and no exception raised from this module
+carries envelope, key, token, or request material — only the keyproxy's own
+constant-detail strings (which name no values; the token-budget copy must
+reach the user verbatim) or this module's canned user-facing messages.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from typing import Iterator, Optional
+
+import httpx
+
+DEFAULT_BASE_URL = "http://127.0.0.1:5002"
+
+# Read timeout must comfortably exceed the keyproxy's heartbeat interval
+# (~15 s): during provider thinking pauses the only bytes on the wire are the
+# `: ping` comments, and each one resets this clock.
+DEFAULT_TIMEOUT = httpx.Timeout(10.0, read=60.0)
+
+# The keyproxy's constant rejection detail (keyproxy/main.py `_INVALID`).
+_KEYPROXY_GENERIC = "invalid request"
+
+# User-facing translations (ChatService surfaces str(exc) as the ErrorEvent).
+RESEND_MESSAGE = (
+    "Your chat session expired or was rejected — please re-send your message."
+)
+PROVIDER_ERROR_MESSAGE = "The model provider returned an error — please try again."
+UNAVAILABLE_MESSAGE = (
+    "The key service is temporarily unavailable — please try again shortly."
+)
+RATE_LIMITED_MESSAGE = (
+    "Rate limit exceeded — please wait a moment and re-send your message."
+)
+
+
+class KeyProxyError(RuntimeError):
+    """A keyproxy interaction failed; the message is safe to show the user."""
+
+
+def _base_url() -> str:
+    return os.environ.get("KEYPROXY_URL", DEFAULT_BASE_URL).rstrip("/")
+
+
+def is_configured() -> bool:
+    """Whether a keyproxy has been wired in (registry precedence, packet 3c)."""
+    return bool(os.environ.get("KEYPROXY_URL"))
+
+
+_client_lock = threading.Lock()
+_client: Optional[httpx.Client] = None
+
+
+def _shared_client() -> httpx.Client:
+    """The persistent pooled client (decision #11). No base_url is bound so
+    requests always target the current ``KEYPROXY_URL``; httpx pools
+    keep-alive connections per host underneath."""
+    global _client
+    with _client_lock:
+        if _client is None or _client.is_closed:
+            _client = httpx.Client(timeout=DEFAULT_TIMEOUT)
+        return _client
+
+
+def _headers(auth_token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {auth_token}"}
+
+
+def _error_message(status_code: int, detail: object) -> str:
+    """Translate a keyproxy rejection into user-facing copy.
+
+    Non-generic 400 details are passed through verbatim: by the keyproxy's
+    logging/response policy they name no values, and the token-budget copy is
+    contractually required to reach the user unchanged.
+    """
+    if status_code == 400:
+        if isinstance(detail, str) and detail and detail != _KEYPROXY_GENERIC:
+            return detail
+        return RESEND_MESSAGE
+    if status_code == 429:
+        return RATE_LIMITED_MESSAGE
+    return UNAVAILABLE_MESSAGE
+
+
+def _response_detail(response: httpx.Response) -> object:
+    try:
+        return response.json().get("detail")
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Message wrappers — attribute access for the tool loop, byte-exact raw dicts
+# ---------------------------------------------------------------------------
+
+class ContentBlock:
+    """Attribute view over one provider content-block dict.
+
+    ``raw`` is the exact dict off the wire; it is what gets serialized back
+    onto the next turn's request, so every field — including thinking-block
+    ``signature`` values — round-trips unchanged.
+    """
+
+    __slots__ = ("raw",)
+
+    def __init__(self, raw: dict):
+        self.raw = raw
+
+    def __getattr__(self, name: str):
+        try:
+            return self.raw[name]
+        except KeyError:
+            raise AttributeError(name) from None
+
+
+class KeyProxyMessage:
+    """The final message of one turn, shaped for ChatService's loop."""
+
+    __slots__ = ("raw", "stop_reason", "content")
+
+    def __init__(self, raw: dict):
+        self.raw = raw
+        self.stop_reason = raw.get("stop_reason")
+        self.content = [
+            ContentBlock(block) if isinstance(block, dict) else block
+            for block in (raw.get("content") or [])
+        ]
+
+
+def _wire_messages(messages: list[dict]) -> list[dict]:
+    """Unwrap ContentBlock views back to their raw dicts for the request body."""
+    out = []
+    for message in messages:
+        content = message["content"]
+        if isinstance(content, list):
+            content = [
+                block.raw if isinstance(block, ContentBlock) else block
+                for block in content
+            ]
+        out.append({"role": message["role"], "content": content})
+    return out
+
+
+def _is_terminal(message: KeyProxyMessage) -> bool:
+    """Whether ChatService's loop ends after this turn (Done or refusal)."""
+    if message.stop_reason == "refusal":
+        return True
+    return not any(
+        getattr(block, "type", None) == "tool_use" for block in message.content
+    )
+
+
+def _iter_sse(lines) -> Iterator[tuple[str, dict]]:
+    """Parse SSE lines into (event, data) pairs; comments (`: ping`) skipped."""
+    event: Optional[str] = None
+    data_lines: list[str] = []
+    for line in lines:
+        if line == "":
+            if event is not None:
+                yield event, json.loads("\n".join(data_lines))
+            event, data_lines = None, []
+        elif line.startswith(":"):
+            continue
+        elif line.startswith("event:"):
+            event = line.split(":", 1)[1].strip()
+        elif line.startswith("data:"):
+            data_lines.append(line.split(":", 1)[1].lstrip())
+
+
+# ---------------------------------------------------------------------------
+# The ChatClient
+# ---------------------------------------------------------------------------
+
+class KeyProxyChatClient:
+    """ChatClient over the keyproxy: one instance covers one chat send."""
+
+    def __init__(
+        self,
+        *,
+        envelope: dict,
+        scope: dict,
+        auth_token: str,
+        model: str,
+        effort: str,
+        max_tokens: int = 8192,
+    ):
+        self._envelope = envelope
+        self._scope = scope
+        self._auth_token = auth_token
+        self._model = model
+        self._effort = effort
+        self._max_tokens = max_tokens
+        self._session_id: Optional[str] = None
+
+    # -- session exchange ---------------------------------------------------
+
+    def _ensure_session(self) -> str:
+        if self._session_id is not None:
+            return self._session_id
+        try:
+            response = _shared_client().post(
+                f"{_base_url()}/v1/sessions",
+                json={
+                    "provider": self._scope.get("provider"),
+                    "envelope": self._envelope,
+                    "scope": self._scope,
+                },
+                headers=_headers(self._auth_token),
+            )
+        except httpx.HTTPError:
+            raise KeyProxyError(UNAVAILABLE_MESSAGE) from None
+        if response.status_code != 200:
+            raise KeyProxyError(
+                _error_message(response.status_code, _response_detail(response))
+            )
+        self._session_id = response.json()["session_id"]
+        return self._session_id
+
+    def close(self) -> None:
+        """Best-effort session teardown; the keyproxy TTL is the backstop."""
+        session_id, self._session_id = self._session_id, None
+        if session_id is None:
+            return
+        try:
+            _shared_client().delete(
+                f"{_base_url()}/v1/sessions/{session_id}",
+                headers=_headers(self._auth_token),
+            )
+        except httpx.HTTPError:
+            pass
+
+    # -- the protocol method ------------------------------------------------
+
+    def stream_turn(self, *, system, tools, messages):
+        session_id = self._ensure_session()
+        body = {
+            "session_id": session_id,
+            "model": self._model,
+            "effort": self._effort,
+            "max_tokens": self._max_tokens,
+            "system": system,
+            "tools": tools,
+            "messages": _wire_messages(messages),
+        }
+        try:
+            with _shared_client().stream(
+                "POST",
+                f"{_base_url()}/v1/providers/anthropic/messages/stream",
+                json=body,
+                headers=_headers(self._auth_token),
+            ) as response:
+                if response.status_code != 200:
+                    response.read()
+                    # The session is unusable (expired / budget-exhausted /
+                    # killed) — a clean re-send error, never a hang.
+                    self._session_id = None
+                    raise KeyProxyError(
+                        _error_message(
+                            response.status_code, _response_detail(response)
+                        )
+                    )
+                for event, data in _iter_sse(response.iter_lines()):
+                    if event == "delta":
+                        yield ("delta", data.get("text", ""))
+                    elif event == "final":
+                        message = KeyProxyMessage(data)
+                        if _is_terminal(message):
+                            self.close()
+                        yield ("final", message)
+                        return
+                    elif event == "error":
+                        self.close()
+                        raise KeyProxyError(PROVIDER_ERROR_MESSAGE)
+        except httpx.HTTPError:
+            self.close()
+            raise KeyProxyError(UNAVAILABLE_MESSAGE) from None
+        # Stream ended without a final frame.
+        self.close()
+        raise KeyProxyError(PROVIDER_ERROR_MESSAGE)
+
+
+# ---------------------------------------------------------------------------
+# Pubkey / validate calls (consumed by quantcore/services/keyproxy.py)
+# ---------------------------------------------------------------------------
+
+def get_public_keys() -> list[dict]:
+    """``GET /v1/publickey`` — the envelope encryption keys, newest first."""
+    try:
+        response = _shared_client().get(f"{_base_url()}/v1/publickey")
+    except httpx.HTTPError:
+        raise KeyProxyError(UNAVAILABLE_MESSAGE) from None
+    if response.status_code != 200:
+        raise KeyProxyError(UNAVAILABLE_MESSAGE)
+    return response.json()["keys"]
+
+
+def validate_key(*, envelope: dict, scope: dict, auth_token: str) -> dict:
+    """``POST /v1/keys/validate`` — redeem + probe, immediate teardown."""
+    try:
+        response = _shared_client().post(
+            f"{_base_url()}/v1/keys/validate",
+            json={
+                "provider": scope.get("provider"),
+                "envelope": envelope,
+                "scope": scope,
+            },
+            headers=_headers(auth_token),
+        )
+    except httpx.HTTPError:
+        raise KeyProxyError(UNAVAILABLE_MESSAGE) from None
+    if response.status_code != 200:
+        raise KeyProxyError(
+            _error_message(response.status_code, _response_detail(response))
+        )
+    return response.json()

--- a/quantcore/gateways/keyproxy_gateway.py
+++ b/quantcore/gateways/keyproxy_gateway.py
@@ -93,6 +93,11 @@ def _shared_client() -> httpx.Client:
 
 
 def _headers(auth_token: str) -> dict[str, str]:
+    # An empty token (AUTH_DISABLED dev stacks) must omit the header entirely:
+    # "Bearer " with no token is an illegal header value that h11 rejects
+    # client-side before the request is ever sent.
+    if not auth_token:
+        return {}
     return {"Authorization": f"Bearer {auth_token}"}
 
 

--- a/quantcore/services/chat.py
+++ b/quantcore/services/chat.py
@@ -107,6 +107,34 @@ ChatEvent = TextDelta | ToolStatus | Directive | ErrorEvent | Done
 
 
 # ---------------------------------------------------------------------------
+# Per-request turn context (BYOK packet 3c)
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class TurnContext:
+    """Per-request identity + key material handed from the route to the
+    client factory. The envelope/scope are opaque dicts here — the keyproxy
+    owns every decision about them; ChatService never inspects or logs them."""
+
+    key_envelope: dict | None = None
+    scope: dict | None = None
+    auth_token: str | None = None
+    subject: str = "local"
+
+
+ENVELOPE_REQUIRED_MESSAGE = (
+    "Add your Anthropic API key in Settings to use the sidekick."
+)
+CHAT_NOT_CONFIGURED_MESSAGE = (
+    "The chat sidekick is not configured on this deployment."
+)
+
+
+class ChatKeyRequired(RuntimeError):
+    """No usable key for this turn — surfaced as a clean ErrorEvent, no log."""
+
+
+# ---------------------------------------------------------------------------
 # Client protocol (the provider adapter itself lives in
 # quantcore/gateways/anthropic_gateway.py per architectural-standard-v2 §5.3)
 # ---------------------------------------------------------------------------
@@ -187,7 +215,7 @@ class ChatService:
         model: str = "claude-fable-5",
         effort: str = "medium",
         max_iterations: int = 8,
-        client_factory: Callable[[], ChatClient] | None = None,
+        client_factory: Callable[[TurnContext], ChatClient] | None = None,
     ):
         self._prices = prices
         self._fundamentals = fundamentals
@@ -197,7 +225,7 @@ class ChatService:
         self._effort = effort
         self._max_iterations = max_iterations
         self._client_factory = client_factory or (
-            lambda: _default_client_factory(self._model, self._effort)
+            lambda context: _default_client_factory(self._model, self._effort)
         )
         # Tool name -> bound dispatch. Positional args mirror the service
         # signatures so tests can assert exact calls.
@@ -227,7 +255,10 @@ class ChatService:
         }
 
     def stream_chat(
-        self, messages: list[dict], interactions: list[dict] | None = None
+        self,
+        messages: list[dict],
+        interactions: list[dict] | None = None,
+        context: TurnContext | None = None,
     ) -> Iterator[ChatEvent]:
         convo = [{"role": m["role"], "content": m["content"]} for m in messages]
         if interactions:
@@ -238,7 +269,7 @@ class ChatService:
                     return
             _fold_interactions(convo, interactions)
         try:
-            client = self._client_factory()
+            client = self._client_factory(context or TurnContext())
             for _ in range(self._max_iterations):
                 final = None
                 for kind, payload in client.stream_turn(
@@ -307,6 +338,10 @@ class ChatService:
             yield ErrorEvent(
                 message=f"Tool iteration limit ({self._max_iterations}) reached."
             )
+        except ChatKeyRequired as exc:
+            # Expected keyless state, not a failure — clean event, no log noise
+            # (and nothing from the context may ever reach a log anyway).
+            yield ErrorEvent(message=str(exc))
         except Exception as exc:  # noqa: BLE001 — stream must end with a frame
             logger.exception("chat stream failed")
             yield ErrorEvent(message=str(exc))

--- a/quantcore/services/keyproxy.py
+++ b/quantcore/services/keyproxy.py
@@ -1,0 +1,30 @@
+"""KeyProxyService — thin pass-through over the keyproxy gateway (packet 3b).
+
+Per architectural-standard-v2 the REST tier is exactly one service call deep,
+so even pure relays to the keyproxy (pubkey discovery for envelope minting,
+key validation for the Settings save flow) go through a service. No logic
+lives here — the gateway owns transport and error translation, the keyproxy
+owns every decision.
+"""
+
+from __future__ import annotations
+
+
+class KeyProxyService:
+    """Relays keyproxy calls for the REST tier (router lands in packet 3c)."""
+
+    def __init__(self, gateway=None):
+        if gateway is None:
+            from quantcore.gateways import keyproxy_gateway as gateway
+        self._gateway = gateway
+
+    def is_configured(self) -> bool:
+        return self._gateway.is_configured()
+
+    def get_public_keys(self) -> list[dict]:
+        return self._gateway.get_public_keys()
+
+    def validate_key(self, *, envelope: dict, scope: dict, auth_token: str) -> dict:
+        return self._gateway.validate_key(
+            envelope=envelope, scope=scope, auth_token=auth_token
+        )

--- a/quantcore/services/registry.py
+++ b/quantcore/services/registry.py
@@ -28,8 +28,15 @@ from quantcore.repositories.options_repository import OptionsStore
 from quantcore.repositories.portfolio_repository import PortfolioRepository
 from quantcore.repositories.sentiment_repository import SentimentStore
 from quantcore.services.fundamentals import FundamentalsService
-from quantcore.services.chat import ChatService
+from quantcore.services.chat import (
+    CHAT_NOT_CONFIGURED_MESSAGE,
+    ENVELOPE_REQUIRED_MESSAGE,
+    ChatKeyRequired,
+    ChatService,
+    TurnContext,
+)
 from quantcore.services.harvester import HarvesterService
+from quantcore.services.keyproxy import KeyProxyService
 from quantcore.services.microstructure import MicrostructureService
 from quantcore.services.options import OptionsService
 from quantcore.services.options_screening import OptionsScreeningService
@@ -37,6 +44,10 @@ from quantcore.services.portfolio import PortfolioService
 from quantcore.services.prices import PricesService
 from quantcore.services.recommendations import RecommendationsService
 from quantcore.services.sentiment import SentimentService
+
+
+def _truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 @dataclass(frozen=True)
@@ -64,6 +75,7 @@ class Services:
     portfolio: PortfolioService
     recommendations: RecommendationsService
     chat: ChatService
+    keyproxy: KeyProxyService
 
 
 @lru_cache(maxsize=1)
@@ -108,25 +120,59 @@ def get_services() -> Services:
         fundamentals_repository=fundamentals_repository,
         yfinance_gateway=yfinance_gateway,
     )
-    # CHAT_FAKE=1 swaps the Anthropic client for the deterministic scripted
-    # FakeChatClient (keyless route tests + Playwright E2E). The real client
-    # lazy-imports the anthropic SDK on first use, never at registry import.
-    if os.environ.get("CHAT_FAKE", "").strip().lower() in {"1", "true", "yes", "on"}:
+    # Chat client factory precedence (BYOK packet 3c):
+    #   CHAT_FAKE=1            → deterministic scripted FakeChatClient
+    #   KEYPROXY_URL set       → per-turn KeyProxyChatClient (BYOK; a turn
+    #                            without an envelope gets the Settings prompt)
+    #   CHAT_ENV_KEY_FALLBACK  → legacy server-side env key (default OFF)
+    #   otherwise              → keyless deployment; every turn errors cleanly
+    # Real clients lazy-import their SDK on first use, never at registry import.
+    chat_model = os.environ.get("CHAT_MODEL", "claude-fable-5")
+    chat_effort = os.environ.get("CHAT_EFFORT", "medium")
+    if _truthy(os.environ.get("CHAT_FAKE")):
         from quantcore.services.chat_fake import FakeChatClient
 
-        chat_client_factory = FakeChatClient
+        chat_client_factory = lambda context: FakeChatClient()  # noqa: E731
+    elif os.environ.get("KEYPROXY_URL"):
+
+        def chat_client_factory(context: TurnContext):
+            if not context.key_envelope:
+                raise ChatKeyRequired(ENVELOPE_REQUIRED_MESSAGE)
+            from quantcore.gateways.keyproxy_gateway import KeyProxyChatClient
+
+            return KeyProxyChatClient(
+                envelope=context.key_envelope,
+                scope=context.scope or {},
+                auth_token=context.auth_token or "",
+                model=chat_model,
+                effort=chat_effort,
+            )
+
+    elif _truthy(os.environ.get("CHAT_ENV_KEY_FALLBACK")):
+        chat_client_factory = None  # ChatService default: env-key Anthropic
     else:
-        chat_client_factory = None
+
+        def chat_client_factory(context: TurnContext):
+            raise ChatKeyRequired(CHAT_NOT_CONFIGURED_MESSAGE)
+
     chat = ChatService(
         prices=prices,
         fundamentals=fundamentals,
         sentiment=sentiment,
         options=options,
-        model=os.environ.get("CHAT_MODEL", "claude-fable-5"),
-        effort=os.environ.get("CHAT_EFFORT", "medium"),
+        model=chat_model,
+        effort=chat_effort,
         max_iterations=int(os.environ.get("CHAT_MAX_TOOL_ITERATIONS", "8")),
         client_factory=chat_client_factory,
     )
+    # KEYPROXY_FAKE=1 swaps a canned in-process gateway (real keypair, real
+    # envelope decrypt, no network) so /api/keyproxy routes are testable.
+    if _truthy(os.environ.get("KEYPROXY_FAKE")):
+        from quantcore.gateways.keyproxy_fake import FakeKeyProxyGateway
+
+        keyproxy = KeyProxyService(gateway=FakeKeyProxyGateway())
+    else:
+        keyproxy = KeyProxyService()
     return Services(
         yfinance_gateway=yfinance_gateway,
         polygon_gateway=polygon_gateway,
@@ -163,4 +209,5 @@ def get_services() -> Services:
             yfinance_gateway=yfinance_gateway,
         ),
         chat=chat,
+        keyproxy=keyproxy,
     )

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -22,3 +22,8 @@ httpx>=0.27.0
 feedparser>=6.0.0
 psycopg2-binary>=2.9
 PyJWT>=2.8.0
+# BYOK packet 7a: api/auth.py verifies ES256 user tokens (decision #13), and
+# PyJWT needs `cryptography` for any asymmetric algorithm. Public-key
+# verification only — the envelope private-key material and the decryption
+# code path remain confined to the keyproxy service (invariant #1).
+cryptography>=42.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,6 @@
 -r requirements-base.txt
 coverage
 diff-cover
-# test_keyproxy_crypto.py needs the envelope crypto's `cryptography` lib; the
-# keyproxy service pins it in keyproxy/requirements.txt, and quantcore-api's
-# image never gains it (requirements-base.txt stays cryptography-free).
-cryptography>=42.0.0
+# `cryptography` moved into requirements-base.txt in BYOK packet 7a (ES256
+# JWT verification in api/auth.py needs it), so it arrives via the -r above.
+# The envelope-decryption code path still lives only in the keyproxy service.

--- a/runUI-CONTAINERS.sh
+++ b/runUI-CONTAINERS.sh
@@ -37,6 +37,27 @@ if [[ ! -f "$GCLOUD_ADC" ]]; then
   exit 1
 fi
 
+# --- BYOK dev keypair (packet 6): persistent so the pin baked into the quantui ---
+# bundle at build time matches the private key the keyproxy container loads at
+# boot. Generated ONCE into a git-ignored file; delete .keyproxy-dev-keys.txt to
+# rotate (then rerun with --build so the UI bundle picks up the new pin).
+KEYPROXY_DEV_KEYFILE=".keyproxy-dev-keys.txt"
+if [[ ! -f "$KEYPROXY_DEV_KEYFILE" ]]; then
+  PY="python3"; [[ -x .venv/bin/python ]] && PY=".venv/bin/python"
+  echo "→ Generating local BYOK dev keypair (kid kp-local-dev) → $KEYPROXY_DEV_KEYFILE"
+  "$PY" scripts/generate_keyproxy_keypair.py --kid kp-local-dev > "$KEYPROXY_DEV_KEYFILE"
+  chmod 600 "$KEYPROXY_DEV_KEYFILE"
+fi
+# SPKI pin = last field of the fingerprint line (public value, safe in build args).
+SPKI_PIN="$(awk '/^spki_fingerprint/ {print $NF}' "$KEYPROXY_DEV_KEYFILE")"
+# Flatten `kid:` line + PKCS8 private block into ONE \n-escaped line: compose-go's
+# dotenv parser expands \n inside double-quoted values back into real newlines.
+KEYPROXY_DEV_PRIVATE_KEYS="$(awk 'BEGIN{ORS="\\n"} /^kid: /{print} /-----BEGIN PRIVATE KEY-----/,/-----END PRIVATE KEY-----/{print}' "$KEYPROXY_DEV_KEYFILE")"
+if [[ -z "$SPKI_PIN" || -z "$KEYPROXY_DEV_PRIVATE_KEYS" ]]; then
+  echo "ERROR: could not parse $KEYPROXY_DEV_KEYFILE (delete it and rerun to regenerate)." >&2
+  exit 1
+fi
+
 # --- Parse the TEST DSN (postgresql://user:pass@host:port/db) — single source of truth ---
 TEST_DSN="$(grep '^QUANTCORE_TEST_DB_DSN=' .env | cut -d= -f2-)"
 if [[ -z "$TEST_DSN" ]]; then
@@ -57,6 +78,9 @@ GCLOUD_ADC=$GCLOUD_ADC
 QUANTCORE_DB_USER=$DB_USER
 QUANTCORE_DB_PASSWORD=$DB_PASS
 QUANTCORE_DB_NAME=$DB_NAME
+# BYOK (packet 6): pin baked into the quantui bundle + matching keyproxy private key.
+VITE_KEYPROXY_SPKI_PINS=$SPKI_PIN
+KEYPROXY_DEV_PRIVATE_KEYS="$KEYPROXY_DEV_PRIVATE_KEYS"
 EOF
 chmod 600 .env.docker
 

--- a/scripts/restart_local_stack.sh
+++ b/scripts/restart_local_stack.sh
@@ -11,6 +11,12 @@
 # What it does: restarts the Cloud SQL proxy (it caches credentials, so a
 # fresh ADC needs a fresh proxy), restarts the FastAPI tier with
 # ANTHROPIC_API_KEY loaded from .env, and makes sure vite is serving.
+#
+# BYOK note (packet 6): the chat sidekick no longer reads ANTHROPIC_API_KEY
+# from the environment by default — keys arrive per turn as encrypted
+# envelopes via the key proxy. This dev stack runs without a keyproxy, so it
+# opts back into the env key with CHAT_ENV_KEY_FALLBACK=1 (dev-only escape
+# hatch; never set it in a deployed environment).
 
 set -u
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
@@ -48,7 +54,7 @@ KEY="$(grep '^ANTHROPIC_API_KEY=' .env | cut -d= -f2- || true)"
 # .env may quote the value (ANTHROPIC_API_KEY="sk-ant-..."); strip surrounding
 # quotes so they don't end up INSIDE the key and cause a 401 invalid x-api-key.
 KEY="${KEY%\"}"; KEY="${KEY#\"}"; KEY="${KEY%\'}"; KEY="${KEY#\'}"
-ANTHROPIC_API_KEY="$KEY" nohup uvicorn api.main:app --host 127.0.0.1 --port 5001 \
+ANTHROPIC_API_KEY="$KEY" CHAT_ENV_KEY_FALLBACK=1 nohup uvicorn api.main:app --host 127.0.0.1 --port 5001 \
     > "$REPO/api.log" 2>&1 &
 echo "  API starting (slow first boot is normal)..."
 for i in $(seq 1 30); do

--- a/test_auth.py
+++ b/test_auth.py
@@ -2,20 +2,40 @@
 
 Exercises ``api.auth.require_principal`` against a minimal FastAPI app so the suite
 needs no database (the full ``api.main.create_app`` runs ``init_schema()``). Covers the
-AUTH_DISABLED bypass, valid/invalid/missing/expired tokens, and issuer/audience checks.
+AUTH_DISABLED bypass, valid/invalid/missing/expired tokens, and issuer/audience checks,
+plus the packet-7a dual mode: ES256 user tokens (public key, own name in ``aud``)
+alongside the HS256 service-token path, with the algorithm-confusion probe rejected.
 """
 
+import base64
+import hashlib
+import hmac
+import json
 import os
 import unittest
 from datetime import datetime, timedelta, timezone
 
 import jwt
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
 from fastapi import Depends, FastAPI
 from fastapi.testclient import TestClient
 
 from api.auth import Principal, require_principal
 
 SECRET = "test-secret-key-at-least-32-bytes-long-000"
+
+_EC_KEY = ec.generate_private_key(ec.SECP256R1())
+EC_PRIVATE_PEM = _EC_KEY.private_bytes(
+    serialization.Encoding.PEM,
+    serialization.PrivateFormat.PKCS8,
+    serialization.NoEncryption(),
+).decode()
+EC_PUBLIC_PEM = _EC_KEY.public_key().public_bytes(
+    serialization.Encoding.PEM,
+    serialization.PublicFormat.SubjectPublicKeyInfo,
+).decode()
+USER_AUDIENCE = ["quantcore-api", "quantcore-keyproxy"]
 
 _AUTH_ENV_KEYS = (
     "AUTH_DISABLED",
@@ -46,6 +66,28 @@ def _make_app() -> FastAPI:
 
 def _token(claims: dict, *, secret: str = SECRET, alg: str = "HS256") -> str:
     return jwt.encode(claims, secret, algorithm=alg)
+
+
+def _user_token(claims: dict, *, key: str = EC_PRIVATE_PEM, aud=USER_AUDIENCE) -> str:
+    if aud is not None:
+        claims = {**claims, "aud": aud}
+    return jwt.encode(claims, key, algorithm="ES256")
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+
+def _forge_hs256(claims: dict, hmac_secret: str) -> str:
+    """Hand-rolled HS256 token — PyJWT refuses to HMAC-sign with PEM-looking
+    keys precisely because of the confusion attack, so build it manually."""
+    header = _b64url(json.dumps({"alg": "HS256", "typ": "JWT"}).encode())
+    payload = _b64url(json.dumps(claims).encode())
+    signing_input = f"{header}.{payload}"
+    sig = hmac.new(
+        hmac_secret.encode(), signing_input.encode(), hashlib.sha256
+    ).digest()
+    return f"{signing_input}.{_b64url(sig)}"
 
 
 class AuthDependencyTests(unittest.TestCase):
@@ -146,6 +188,99 @@ class AuthDependencyTests(unittest.TestCase):
         r = self.client.get("/protected")
         self.assertEqual(r.status_code, 200)
         self.assertTrue(r.json()["is_local"])
+
+
+class DualModeES256Tests(unittest.TestCase):
+    """Packet 7a: ES256 user tokens verified alongside HS256 service tokens.
+
+    Cloud config after Phase 7: BOTH keys are set — the public key for the
+    quantui-minted user tokens, the shared secret for the MCP wrappers'
+    long-lived service tokens. Routing is by the token's declared ``alg``,
+    each branch pinned to its own key and algorithm family.
+    """
+
+    def setUp(self):
+        self._saved = {k: os.environ.get(k) for k in _AUTH_ENV_KEYS}
+        for k in _AUTH_ENV_KEYS:
+            os.environ.pop(k, None)
+        os.environ["QUANTCORE_JWT_SECRET"] = SECRET
+        os.environ["QUANTCORE_JWT_PUBLIC_KEY"] = EC_PUBLIC_PEM
+        self.client = TestClient(_make_app(), raise_server_exceptions=False)
+
+    def tearDown(self):
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def _get(self, token: str):
+        return self.client.get(
+            "/protected", headers={"Authorization": f"Bearer {token}"}
+        )
+
+    def test_valid_es256_user_token_resolves_sub(self):
+        r = self._get(_user_token({"sub": "john@funkyinnovations.com"}))
+        self.assertEqual(r.status_code, 200)
+        body = r.json()
+        self.assertEqual(body["subject"], "john@funkyinnovations.com")
+        self.assertFalse(body["is_local"])
+
+    def test_es256_wrong_audience_rejected(self):
+        # A token minted for the keyproxy only must not authenticate here.
+        r = self._get(_user_token({"sub": "john"}, aud=["quantcore-keyproxy"]))
+        self.assertEqual(r.status_code, 401)
+
+    def test_es256_missing_audience_rejected(self):
+        r = self._get(_user_token({"sub": "john"}, aud=None))
+        self.assertEqual(r.status_code, 401)
+
+    def test_es256_wrong_key_rejected(self):
+        other = ec.generate_private_key(ec.SECP256R1())
+        other_pem = other.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        ).decode()
+        r = self._get(_user_token({"sub": "john"}, key=other_pem))
+        self.assertEqual(r.status_code, 401)
+
+    def test_es256_expired_rejected(self):
+        exp = datetime.now(timezone.utc) - timedelta(hours=1)
+        r = self._get(_user_token({"sub": "john", "exp": exp}))
+        self.assertEqual(r.status_code, 401)
+
+    def test_hs256_service_token_still_accepted(self):
+        # The MCP wrappers' long-lived tokens keep working unchanged.
+        r = self._get(_token({"sub": "svc-wrapper"}))
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.json()["subject"], "svc-wrapper")
+
+    def test_algorithm_confusion_probe_rejected(self):
+        # HS256 signed with the ES256 *public* PEM as the HMAC secret — a
+        # verifier that routes the public key into HMAC would accept this.
+        probe = _forge_hs256({"sub": "mallory", "aud": "quantcore-api"}, EC_PUBLIC_PEM)
+        self.assertEqual(self._get(probe).status_code, 401)
+
+    def test_es256_token_rejected_when_no_public_key_configured(self):
+        os.environ.pop("QUANTCORE_JWT_PUBLIC_KEY")
+        r = self._get(_user_token({"sub": "john"}))
+        self.assertEqual(r.status_code, 401)
+
+    def test_hs256_rejected_when_only_public_key_configured(self):
+        # Public-key-only deployment: no secret means no HS path at all —
+        # the public key must never be used for HMAC verification.
+        os.environ.pop("QUANTCORE_JWT_SECRET")
+        r = self._get(_token({"sub": "svc-wrapper"}))
+        self.assertEqual(r.status_code, 401)
+
+    def test_configured_asymmetric_algorithms_do_not_reach_hs_path(self):
+        # Even if QUANTCORE_JWT_ALGORITHMS lists non-HS algorithms, the
+        # service-token branch stays HS-only (confusion-attack hygiene).
+        os.environ["QUANTCORE_JWT_ALGORITHMS"] = "HS256,ES256,RS256"
+        self.assertEqual(self._get(_token({"sub": "svc"})).status_code, 200)
+        probe = _forge_hs256({"sub": "mallory", "aud": "quantcore-api"}, EC_PUBLIC_PEM)
+        self.assertEqual(self._get(probe).status_code, 401)
 
 
 if __name__ == "__main__":

--- a/test_chat_service.py
+++ b/test_chat_service.py
@@ -15,12 +15,14 @@ from types import SimpleNamespace
 from unittest.mock import Mock
 
 from quantcore.services.chat import (
+    ChatKeyRequired,
     ChatService,
     Directive,
     Done,
     ErrorEvent,
     TextDelta,
     ToolStatus,
+    TurnContext,
 )
 from quantcore.services.chat_fake import FakeChatClient
 
@@ -75,7 +77,7 @@ class ChatServiceTestBase(unittest.TestCase):
             sentiment=self.sentiment,
             options=self.options,
             max_iterations=max_iterations,
-            client_factory=lambda: client,
+            client_factory=lambda context: client,
         )
 
     def run_chat(self, client, **kwargs):
@@ -501,7 +503,7 @@ class TestFakeChatClient(unittest.TestCase):
             fundamentals=Mock(),
             sentiment=Mock(),
             options=Mock(),
-            client_factory=FakeChatClient,
+            client_factory=lambda context: FakeChatClient(),
         )
         events = list(
             service.stream_chat([{"role": "user", "content": "How's INTC looking?"}])
@@ -529,7 +531,7 @@ class TestFakeChatClient(unittest.TestCase):
             fundamentals=Mock(),
             sentiment=Mock(),
             options=Mock(),
-            client_factory=FakeChatClient,
+            client_factory=lambda context: FakeChatClient(),
         )
         events = list(
             service.stream_chat(
@@ -555,7 +557,7 @@ class TestFakeChatClient(unittest.TestCase):
             fundamentals=Mock(),
             sentiment=Mock(),
             options=Mock(),
-            client_factory=FakeChatClient,
+            client_factory=lambda context: FakeChatClient(),
         )
         events = list(
             service.stream_chat(
@@ -575,6 +577,84 @@ class TestFakeChatClient(unittest.TestCase):
         joined = "".join(e.delta for e in events if isinstance(e, TextDelta))
         self.assertIn("120", joined)
         self.assertIn("selection", joined.lower())
+
+
+class TestTurnContext(ChatServiceTestBase):
+    """BYOK packet 3c: the per-request TurnContext reaches the client factory."""
+
+    def make_recording_service(self, client):
+        seen = []
+
+        def factory(context):
+            seen.append(context)
+            return client
+
+        service = ChatService(
+            prices=self.prices,
+            fundamentals=self.fundamentals,
+            sentiment=self.sentiment,
+            options=self.options,
+            client_factory=factory,
+        )
+        return service, seen
+
+    def test_factory_receives_the_context_passed_to_stream_chat(self):
+        client = ScriptedClient(
+            [{"deltas": ["hi"], "final": final("end_turn", text_block("hi"))}]
+        )
+        service, seen = self.make_recording_service(client)
+        context = TurnContext(
+            key_envelope={"v": 1},
+            scope={"provider": "anthropic"},
+            auth_token="tok",
+            subject="alice",
+        )
+        events = list(
+            service.stream_chat(
+                [{"role": "user", "content": "hi"}], context=context
+            )
+        )
+        self.assertIsInstance(events[-1], Done)
+        self.assertEqual(seen, [context])
+
+    def test_default_context_when_none_passed(self):
+        client = ScriptedClient(
+            [{"deltas": ["hi"], "final": final("end_turn", text_block("hi"))}]
+        )
+        service, seen = self.make_recording_service(client)
+        list(service.stream_chat([{"role": "user", "content": "hi"}]))
+        self.assertEqual(len(seen), 1)
+        self.assertEqual(seen[0], TurnContext())
+        self.assertIsNone(seen[0].key_envelope)
+        self.assertEqual(seen[0].subject, "local")
+
+    def test_chat_key_required_yields_clean_error_without_logging(self):
+        """The keyless path is an expected state: exactly one ErrorEvent with
+        the factory's verbatim message, no Done, and — per the never-log
+        policy — no exception dump on the chat logger."""
+
+        def factory(context):
+            raise ChatKeyRequired(
+                "Add your Anthropic API key in Settings to use the sidekick."
+            )
+
+        service = ChatService(
+            prices=self.prices,
+            fundamentals=self.fundamentals,
+            sentiment=self.sentiment,
+            options=self.options,
+            client_factory=factory,
+        )
+        with self.assertNoLogs("quantcore.services.chat", level="WARNING"):
+            events = list(
+                service.stream_chat([{"role": "user", "content": "hi"}])
+            )
+        self.assertEqual(len(events), 1)
+        self.assertIsInstance(events[0], ErrorEvent)
+        self.assertEqual(
+            events[0].message,
+            "Add your Anthropic API key in Settings to use the sidekick.",
+        )
 
 
 if __name__ == "__main__":

--- a/test_keyproxy_api.py
+++ b/test_keyproxy_api.py
@@ -1,0 +1,266 @@
+"""Integration tests for the /api/keyproxy routes + chat BYOK wiring (3c).
+
+Runs the FastAPI app through TestClient with KEYPROXY_FAKE=1, so the real
+routes, schemas, registry wiring, and KeyProxyService relay are exercised
+against the canned in-process gateway — which uses a REAL generated P-256
+keypair and the REAL envelope decrypt, with zero network. DB-safety preamble
+mirrors test_chat_api.py.
+
+Never-log policy: rejection paths assert that no key material, envelope
+fields, or tokens reach any logger.
+"""
+
+import json
+import logging
+import os
+import time
+import unittest
+import uuid
+from pathlib import Path
+
+# Swap in the test DSN BEFORE quantcore.db is imported (it freezes DB_DSN at
+# import time), then let the guard abort if this process would reach prod. When
+# .env is absent (e.g. CI), keep whatever QUANTCORE_DB_DSN the environment set.
+_env_file = Path(__file__).parent / ".env"
+if _env_file.exists():
+    for _line in _env_file.read_text().splitlines():
+        if _line.strip().startswith("QUANTCORE_TEST_DB_DSN="):
+            os.environ["QUANTCORE_DB_DSN"] = _line.split("=", 1)[1].strip()
+            break
+
+# Registry precedence is read when get_services() first builds: the fake
+# keyproxy gateway for the relay routes, the fake LLM for any chat turns.
+os.environ["KEYPROXY_FAKE"] = "1"
+os.environ["CHAT_FAKE"] = "1"
+os.environ.pop("KEYPROXY_URL", None)
+
+from quantcore.db_safety import assert_not_production  # noqa: E402
+
+assert_not_production()
+
+import jwt  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from keyproxy import crypto  # noqa: E402
+from quantcore.services.chat import ENVELOPE_REQUIRED_MESSAGE  # noqa: E402
+from quantcore.services.registry import get_services  # noqa: E402
+from api.main import create_app  # noqa: E402
+
+SECRET = "test-secret-key-at-least-32-bytes-long-000"
+API_KEY = "sk-ant-test-key-abcd"
+
+_AUTH_ENV_KEYS = (
+    "AUTH_DISABLED",
+    "QUANTCORE_JWT_SECRET",
+    "QUANTCORE_JWT_PUBLIC_KEY",
+    "QUANTCORE_JWT_ALGORITHMS",
+    "QUANTCORE_JWT_ISSUER",
+    "QUANTCORE_JWT_AUDIENCE",
+    "QUANTCORE_JWT_LEEWAY",
+)
+
+
+def validate_scope(provider: str = "anthropic") -> dict:
+    return {
+        "v": 1,
+        "provider": provider,
+        "action": "key.validate",
+        "params": {},
+        "budget": {"max_calls": 1, "max_mutations": 0, "max_tokens": 0, "ttl": 60},
+    }
+
+
+def mint_envelope(
+    public_key,
+    scope: dict,
+    *,
+    sub: str = "local",
+    provider: str = "anthropic",
+    api_key: str = API_KEY,
+    iat: int | None = None,
+    kid: str = "kp-fake-1",
+) -> dict:
+    aad = {
+        "sub": sub,
+        "provider": provider,
+        "iat": int(time.time()) if iat is None else iat,
+        "jti": uuid.uuid4().hex,
+        "scope_hash": crypto.compute_scope_hash(scope),
+    }
+    return crypto.encrypt_envelope(api_key, public_key, kid=kid, aad=aad)
+
+
+class _RecordingHandler(logging.Handler):
+    def __init__(self):
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+
+class KeyProxyApiTestBase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        get_services.cache_clear()  # pick up KEYPROXY_FAKE=1 / CHAT_FAKE=1
+        cls.client = TestClient(create_app(), raise_server_exceptions=False)
+        cls.fake_gateway = get_services().keyproxy._gateway
+
+    def setUp(self):
+        self._saved = {k: os.environ.get(k) for k in _AUTH_ENV_KEYS}
+        for k in _AUTH_ENV_KEYS:
+            os.environ.pop(k, None)
+        self._log_handler = _RecordingHandler()
+        logging.getLogger().addHandler(self._log_handler)
+
+    def tearDown(self):
+        logging.getLogger().removeHandler(self._log_handler)
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def assert_never_logged(self, *needles: str) -> None:
+        for record in self._log_handler.records:
+            text = record.getMessage()
+            for needle in needles:
+                self.assertNotIn(
+                    needle, text, f"sensitive material reached a log: {record}"
+                )
+
+    def bearer(self, sub: str) -> dict:
+        os.environ["QUANTCORE_JWT_SECRET"] = SECRET
+        token = jwt.encode({"sub": sub}, SECRET, algorithm="HS256")
+        return {"Authorization": f"Bearer {token}"}
+
+
+class TestPublickey(KeyProxyApiTestBase):
+    def test_relays_keys_and_local_sub_when_auth_off(self):
+        resp = self.client.get("/api/keyproxy/publickey")
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertEqual(body["sub"], "local")
+        self.assertEqual(len(body["keys"]), 1)
+        key = body["keys"][0]
+        self.assertEqual(key["kid"], "kp-fake-1")
+        self.assertEqual(key["alg"], crypto.ENVELOPE_ALG)
+        # spki round-trips to the fake's actual public key.
+        spki = crypto.b64url_decode(key["spki"])
+        self.assertEqual(
+            spki, crypto.public_key_spki_der(self.fake_gateway.public_key)
+        )
+
+    def test_sub_is_the_jwt_subject_when_auth_on(self):
+        headers = self.bearer("alice")
+        resp = self.client.get("/api/keyproxy/publickey", headers=headers)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["sub"], "alice")
+
+    def test_401_without_token_when_auth_on(self):
+        os.environ["QUANTCORE_JWT_SECRET"] = SECRET
+        resp = self.client.get("/api/keyproxy/publickey")
+        self.assertEqual(resp.status_code, 401)
+
+
+class TestValidate(KeyProxyApiTestBase):
+    def post_validate(self, envelope: dict, scope: dict, headers: dict | None = None):
+        return self.client.post(
+            "/api/keyproxy/validate",
+            json={"envelope": envelope, "scope": scope},
+            headers=headers or {},
+        )
+
+    def test_happy_path_returns_key_hint(self):
+        scope = validate_scope()
+        envelope = mint_envelope(self.fake_gateway.public_key, scope)
+        resp = self.post_validate(envelope, scope)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            resp.json(),
+            {"valid": True, "provider": "anthropic", "key_hint": "…abcd"},
+        )
+
+    def test_happy_path_with_jwt_sub(self):
+        scope = validate_scope()
+        envelope = mint_envelope(self.fake_gateway.public_key, scope, sub="alice")
+        resp = self.post_validate(envelope, scope, headers=self.bearer("alice"))
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.json()["valid"])
+
+    def test_sub_mismatch_is_safe_400_and_never_logged(self):
+        scope = validate_scope()
+        envelope = mint_envelope(self.fake_gateway.public_key, scope, sub="mallory")
+        resp = self.post_validate(envelope, scope, headers=self.bearer("alice"))
+        self.assertEqual(resp.status_code, 400)
+        detail = resp.json()["message"]
+        # Safe user-facing copy — names no values.
+        self.assertNotIn("mallory", detail)
+        self.assertNotIn("sub", detail)
+        self.assert_never_logged(API_KEY, envelope["ct"], envelope["epk"], "mallory")
+
+    def test_tampered_ciphertext_is_safe_400_and_never_logged(self):
+        scope = validate_scope()
+        envelope = mint_envelope(self.fake_gateway.public_key, scope)
+        envelope["ct"] = crypto.b64url_encode(
+            bytes(64)
+        )  # garbage of plausible length
+        resp = self.post_validate(envelope, scope)
+        self.assertEqual(resp.status_code, 400)
+        self.assert_never_logged(API_KEY, envelope["ct"], envelope["epk"])
+
+    def test_malformed_body_is_422_and_never_logged(self):
+        resp = self.client.post(
+            "/api/keyproxy/validate", json={"envelope": {"v": 1}, "scope": {}}
+        )
+        self.assertEqual(resp.status_code, 422)
+        self.assert_never_logged(API_KEY)
+
+
+class TestChatEnvelopeRequired(unittest.TestCase):
+    """With a keyproxy configured (KEYPROXY_URL) and no envelope on the send,
+    the chat stream must open normally and carry exactly one error frame with
+    the Settings prompt — the factory raises before any network I/O (the URL
+    here is a black hole; a connection attempt would hang/fail loudly)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls._saved_env = {
+            k: os.environ.get(k) for k in ("CHAT_FAKE", "KEYPROXY_URL")
+        }
+        os.environ.pop("CHAT_FAKE", None)
+        os.environ["KEYPROXY_URL"] = "http://keyproxy.invalid:5002"
+        get_services.cache_clear()
+        cls.client = TestClient(create_app(), raise_server_exceptions=False)
+
+    @classmethod
+    def tearDownClass(cls):
+        for k, v in cls._saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        get_services.cache_clear()
+
+    def test_missing_envelope_yields_settings_prompt_error_frame(self):
+        resp = self.client.post(
+            "/api/chat",
+            json={"messages": [{"role": "user", "content": "hi"}]},
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(
+            resp.headers["content-type"].startswith("text/event-stream")
+        )
+        frames = [
+            chunk
+            for chunk in resp.text.split("\n\n")
+            if chunk.strip() and not chunk.startswith(":")
+        ]
+        self.assertEqual(len(frames), 1)
+        self.assertIn("event: error", frames[0])
+        data = json.loads(frames[0].split("data: ", 1)[1])
+        self.assertEqual(data["message"], ENVELOPE_REQUIRED_MESSAGE)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_keyproxy_auth.py
+++ b/test_keyproxy_auth.py
@@ -1,0 +1,112 @@
+"""Packet 2a tests: keyproxy Bearer-JWT verification (keyproxy/auth.py).
+
+Mirrors the api/auth.py semantics contract: inert until QUANTCORE_JWT_SECRET
+is configured, KEYPROXY_AUTH_DISABLED forces auth off, and every rejection
+is a uniform 401 whose detail never contains PyJWT error text or token
+material (never-log policy).
+"""
+
+import time
+import unittest
+from unittest.mock import patch
+
+import jwt
+from fastapi import HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
+
+from keyproxy import auth
+
+SECRET = "unit-test-secret"
+
+
+def creds(token):
+    return HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+
+def mint(claims, secret=SECRET, algorithm="HS256"):
+    return jwt.encode(claims, secret, algorithm=algorithm)
+
+
+class TestAuthInactive(unittest.TestCase):
+    def test_no_secret_configured_returns_local(self):
+        with patch.dict("os.environ", {}, clear=True):
+            caller = auth.require_caller(None)
+        self.assertTrue(caller.is_local)
+        self.assertEqual(caller.sub, "local")
+
+    def test_disabled_flag_overrides_configured_secret(self):
+        env = {"QUANTCORE_JWT_SECRET": SECRET, "KEYPROXY_AUTH_DISABLED": "1"}
+        with patch.dict("os.environ", env, clear=True):
+            caller = auth.require_caller(None)
+        self.assertTrue(caller.is_local)
+
+    def test_api_auth_disabled_var_does_not_disable_keyproxy(self):
+        # The keyproxy honors only its own override, not the api's.
+        env = {"QUANTCORE_JWT_SECRET": SECRET, "AUTH_DISABLED": "1"}
+        with patch.dict("os.environ", env, clear=True):
+            with self.assertRaises(HTTPException):
+                auth.require_caller(None)
+
+
+class TestAuthActive(unittest.TestCase):
+    def setUp(self):
+        patcher = patch.dict(
+            "os.environ", {"QUANTCORE_JWT_SECRET": SECRET}, clear=True
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def assert_uniform_401(self, credentials):
+        with self.assertRaises(HTTPException) as ctx:
+            auth.require_caller(credentials)
+        self.assertEqual(ctx.exception.status_code, 401)
+        self.assertEqual(ctx.exception.detail, "invalid or missing bearer token")
+        return ctx.exception
+
+    def test_valid_token_resolves_sub(self):
+        caller = auth.require_caller(creds(mint({"sub": "john"})))
+        self.assertEqual(caller.sub, "john")
+        self.assertFalse(caller.is_local)
+        self.assertEqual(caller.claims["sub"], "john")
+        self.assertIsNotNone(caller.token)
+
+    def test_email_fallback_matches_api_principal_semantics(self):
+        caller = auth.require_caller(creds(mint({"email": "a@b.com"})))
+        self.assertEqual(caller.sub, "a@b.com")
+
+    def test_missing_token_rejected(self):
+        self.assert_uniform_401(None)
+
+    def test_wrong_signature_rejected(self):
+        wrong = "wrong-secret-of-recommended-hmac-length!"
+        self.assert_uniform_401(creds(mint({"sub": "john"}, secret=wrong)))
+
+    def test_expired_token_rejected(self):
+        token = mint({"sub": "john", "exp": int(time.time()) - 3600})
+        self.assert_uniform_401(creds(token))
+
+    def test_unsigned_alg_none_rejected(self):
+        header_payload = jwt.encode({"sub": "john"}, SECRET, algorithm="HS256")
+        forged = header_payload.rsplit(".", 1)[0] + "."
+        self.assert_uniform_401(creds(forged))
+
+    def test_subless_token_rejected(self):
+        self.assert_uniform_401(creds(mint({"role": "admin"})))
+
+    def test_rejection_detail_never_leaks_jwt_error_text(self):
+        exc = self.assert_uniform_401(creds("not-even-a-jwt"))
+        detail = str(exc.detail).lower()
+        for fragment in ("signature", "segment", "decode", "expired"):
+            self.assertNotIn(fragment, detail)
+
+    def test_rejections_are_unchained(self):
+        # `from None` — the PyJWT exception (which embeds token detail) must
+        # not ride along as __cause__/__context__ into logs.
+        with self.assertRaises(HTTPException) as ctx:
+            auth.require_caller(creds("garbage"))
+        self.assertIsNone(ctx.exception.__cause__)
+        self.assertTrue(ctx.exception.__suppress_context__)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_keyproxy_auth.py
+++ b/test_keyproxy_auth.py
@@ -1,11 +1,18 @@
-"""Packet 2a tests: keyproxy Bearer-JWT verification (keyproxy/auth.py).
+"""Packet 7a tests: keyproxy Bearer-JWT verification (keyproxy/auth.py), ES256-only.
 
-Mirrors the api/auth.py semantics contract: inert until QUANTCORE_JWT_SECRET
-is configured, KEYPROXY_AUTH_DISABLED forces auth off, and every rejection
-is a uniform 401 whose detail never contains PyJWT error text or token
-material (never-log policy).
+The keyproxy holds no signing material — it verifies against the ES256 public
+key in QUANTCORE_JWT_PUBLIC_KEY and requires "quantcore-keyproxy" in ``aud``.
+Auth is inert until that key is configured, KEYPROXY_AUTH_DISABLED forces auth
+off, and every rejection is a uniform 401 whose detail never contains PyJWT
+error text or token material (never-log policy). HS256 service tokens (the MCP
+wrappers') must be rejected here, including the classic algorithm-confusion
+probe: an HS256 token whose HMAC secret is the ES256 public PEM itself.
 """
 
+import base64
+import hashlib
+import hmac
+import json
 import time
 import unittest
 from unittest.mock import patch
@@ -14,35 +21,67 @@ import jwt
 from fastapi import HTTPException
 from fastapi.security import HTTPAuthorizationCredentials
 
-from keyproxy import auth
+from keyproxy import auth, crypto
 
-SECRET = "unit-test-secret"
+_SIGNING_KEY = crypto.generate_private_key()
+PRIVATE_PEM = crypto.private_key_to_pem(_SIGNING_KEY)
+PUBLIC_PEM = crypto.public_key_to_pem(_SIGNING_KEY.public_key())
+AUDIENCE = ["quantcore-api", "quantcore-keyproxy"]
+
+HS_SECRET = "unit-test-service-token-secret-0123456789"
 
 
 def creds(token):
     return HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
 
 
-def mint(claims, secret=SECRET, algorithm="HS256"):
-    return jwt.encode(claims, secret, algorithm=algorithm)
+def mint(claims, key=PRIVATE_PEM, algorithm="ES256", aud=AUDIENCE):
+    if aud is not None:
+        claims = {**claims, "aud": aud}
+    return jwt.encode(claims, key, algorithm=algorithm)
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+
+def forge_hs256(claims, hmac_secret: str) -> str:
+    """Hand-rolled HS256 token — PyJWT refuses to HMAC-sign with PEM-looking
+    keys precisely because of the confusion attack, so the probe builds the
+    token manually."""
+    header = _b64url(json.dumps({"alg": "HS256", "typ": "JWT"}).encode())
+    payload = _b64url(json.dumps(claims).encode())
+    signing_input = f"{header}.{payload}"
+    sig = hmac.new(
+        hmac_secret.encode(), signing_input.encode(), hashlib.sha256
+    ).digest()
+    return f"{signing_input}.{_b64url(sig)}"
 
 
 class TestAuthInactive(unittest.TestCase):
-    def test_no_secret_configured_returns_local(self):
+    def test_no_public_key_configured_returns_local(self):
         with patch.dict("os.environ", {}, clear=True):
             caller = auth.require_caller(None)
         self.assertTrue(caller.is_local)
         self.assertEqual(caller.sub, "local")
 
-    def test_disabled_flag_overrides_configured_secret(self):
-        env = {"QUANTCORE_JWT_SECRET": SECRET, "KEYPROXY_AUTH_DISABLED": "1"}
+    def test_legacy_hs_secret_alone_does_not_activate_auth(self):
+        # Packet 7a: the keyproxy keys on the public key only — the HS
+        # secret is api-side service-token material it must not honor.
+        env = {"QUANTCORE_JWT_SECRET": HS_SECRET}
+        with patch.dict("os.environ", env, clear=True):
+            caller = auth.require_caller(None)
+        self.assertTrue(caller.is_local)
+
+    def test_disabled_flag_overrides_configured_key(self):
+        env = {"QUANTCORE_JWT_PUBLIC_KEY": PUBLIC_PEM, "KEYPROXY_AUTH_DISABLED": "1"}
         with patch.dict("os.environ", env, clear=True):
             caller = auth.require_caller(None)
         self.assertTrue(caller.is_local)
 
     def test_api_auth_disabled_var_does_not_disable_keyproxy(self):
         # The keyproxy honors only its own override, not the api's.
-        env = {"QUANTCORE_JWT_SECRET": SECRET, "AUTH_DISABLED": "1"}
+        env = {"QUANTCORE_JWT_PUBLIC_KEY": PUBLIC_PEM, "AUTH_DISABLED": "1"}
         with patch.dict("os.environ", env, clear=True):
             with self.assertRaises(HTTPException):
                 auth.require_caller(None)
@@ -51,7 +90,7 @@ class TestAuthInactive(unittest.TestCase):
 class TestAuthActive(unittest.TestCase):
     def setUp(self):
         patcher = patch.dict(
-            "os.environ", {"QUANTCORE_JWT_SECRET": SECRET}, clear=True
+            "os.environ", {"QUANTCORE_JWT_PUBLIC_KEY": PUBLIC_PEM}, clear=True
         )
         patcher.start()
         self.addCleanup(patcher.stop)
@@ -77,18 +116,37 @@ class TestAuthActive(unittest.TestCase):
     def test_missing_token_rejected(self):
         self.assert_uniform_401(None)
 
-    def test_wrong_signature_rejected(self):
-        wrong = "wrong-secret-of-recommended-hmac-length!"
-        self.assert_uniform_401(creds(mint({"sub": "john"}, secret=wrong)))
+    def test_wrong_audience_rejected(self):
+        token = mint({"sub": "john"}, aud=["quantcore-api"])
+        self.assert_uniform_401(creds(token))
+
+    def test_missing_audience_rejected(self):
+        self.assert_uniform_401(creds(mint({"sub": "john"}, aud=None)))
+
+    def test_wrong_signing_key_rejected(self):
+        other = crypto.private_key_to_pem(crypto.generate_private_key())
+        self.assert_uniform_401(creds(mint({"sub": "john"}, key=other)))
+
+    def test_hs256_service_token_rejected(self):
+        # The MCP wrappers' shared-secret tokens authenticate to
+        # quantcore-api only — never to the keyproxy.
+        token = forge_hs256({"sub": "svc", "aud": AUDIENCE}, HS_SECRET)
+        self.assert_uniform_401(creds(token))
+
+    def test_algorithm_confusion_probe_rejected(self):
+        # HS256 signed with the ES256 *public* PEM as the HMAC secret: a
+        # verifier that feeds its public key into HMAC would accept this.
+        token = forge_hs256({"sub": "mallory", "aud": AUDIENCE}, PUBLIC_PEM)
+        self.assert_uniform_401(creds(token))
 
     def test_expired_token_rejected(self):
         token = mint({"sub": "john", "exp": int(time.time()) - 3600})
         self.assert_uniform_401(creds(token))
 
     def test_unsigned_alg_none_rejected(self):
-        header_payload = jwt.encode({"sub": "john"}, SECRET, algorithm="HS256")
-        forged = header_payload.rsplit(".", 1)[0] + "."
-        self.assert_uniform_401(creds(forged))
+        header = _b64url(json.dumps({"alg": "none", "typ": "JWT"}).encode())
+        payload = _b64url(json.dumps({"sub": "john", "aud": AUDIENCE}).encode())
+        self.assert_uniform_401(creds(f"{header}.{payload}."))
 
     def test_subless_token_rejected(self):
         self.assert_uniform_401(creds(mint({"role": "admin"})))
@@ -96,7 +154,7 @@ class TestAuthActive(unittest.TestCase):
     def test_rejection_detail_never_leaks_jwt_error_text(self):
         exc = self.assert_uniform_401(creds("not-even-a-jwt"))
         detail = str(exc.detail).lower()
-        for fragment in ("signature", "segment", "decode", "expired"):
+        for fragment in ("signature", "segment", "decode", "expired", "audience"):
             self.assertNotIn(fragment, detail)
 
     def test_rejections_are_unchained(self):

--- a/test_keyproxy_gateway.py
+++ b/test_keyproxy_gateway.py
@@ -1,0 +1,365 @@
+"""Packet 3b tests: KeyProxyChatClient + session exchange.
+
+The keyproxy app runs under a REAL uvicorn server on a local port (not an
+in-process TestClient, which would bypass socket-level buffering), with the
+provider stubbed at ``keyproxy.providers.anthropic.stream_turn``. Covers:
+client SSE parse, the session exchange (envelope redeemed exactly once per
+send, turns 2+ reuse the session, teardown on Done and on error, expired
+session mid-chat -> clean re-send error), verbatim budget-message
+pass-through, pubkey/validate calls, the thin service — plus the two
+risk-pinning tests decided 2026-07-16: ``test_keyproxy_stream_no_buffering``
+and ``test_thinking_block_signature_roundtrip``.
+"""
+
+import os
+import threading
+import time
+import unittest
+
+from unittest.mock import Mock, patch
+
+import jwt
+import uvicorn
+
+from quantcore.gateways import keyproxy_gateway
+from quantcore.services.keyproxy import KeyProxyService
+from test_keyproxy_service import (
+    API_KEY,
+    SECRET,
+    KID,
+    KeyProxyServiceTestBase,
+    chat_scope,
+)
+
+TEXT_BLOCK = {"type": "text", "text": "hi there"}
+THINKING_BLOCK = {
+    "type": "thinking",
+    "thinking": "let me check the price",
+    "signature": "sig-Zm9vYmFyYmF6cXV4/+==",
+}
+TOOL_USE_BLOCK = {
+    "type": "tool_use",
+    "id": "toolu_1",
+    "name": "get_stock_price",
+    "input": {"symbol": "AAPL"},
+}
+
+
+def final_message(*blocks, stop_reason="end_turn", usage=None):
+    return {
+        "id": "msg_stub",
+        "role": "assistant",
+        "content": list(blocks),
+        "stop_reason": stop_reason,
+        "usage": usage or {"input_tokens": 10, "output_tokens": 5},
+    }
+
+
+class ScriptedProvider:
+    """Scripted stand-in for keyproxy.providers.anthropic.stream_turn.
+
+    Each turn dict: ``deltas`` (list of str), ``final`` (message dict),
+    ``delay`` (sleep before each emission), ``error`` (raise instead of
+    finishing). Records every call's params and each delta's emit time.
+    """
+
+    def __init__(self, turns):
+        self.turns = list(turns)
+        self.calls = []
+        self.emit_times = []
+
+    def __call__(self, api_key, **params):
+        turn = self.turns.pop(0)
+        self.calls.append({"api_key": api_key, **params})
+        for text in turn.get("deltas", []):
+            if turn.get("delay"):
+                time.sleep(turn["delay"])
+            self.emit_times.append(time.monotonic())
+            yield ("delta", text)
+        if turn.get("error"):
+            raise RuntimeError("provider exploded: " + api_key)
+        if turn.get("delay"):
+            time.sleep(turn["delay"])
+        yield ("final", turn["final"])
+
+
+class GatewayTestBase(KeyProxyServiceTestBase):
+    """Base harness + a real uvicorn server, KEYPROXY_URL pointed at it."""
+
+    def setUp(self):
+        super().setUp()
+        config = uvicorn.Config(
+            self.app, host="127.0.0.1", port=0, log_level="warning",
+            access_log=False,
+        )
+        self.server = uvicorn.Server(config)
+        thread = threading.Thread(target=self.server.run, daemon=True)
+        thread.start()
+        deadline = time.monotonic() + 10
+        while not self.server.started:
+            if time.monotonic() > deadline:
+                self.fail("uvicorn server did not start")
+            time.sleep(0.01)
+        port = self.server.servers[0].sockets[0].getsockname()[1]
+        os.environ["KEYPROXY_URL"] = f"http://127.0.0.1:{port}"
+
+        def stop():
+            self.server.should_exit = True
+            thread.join(timeout=5)
+
+        self.addCleanup(stop)
+
+    def auth_token(self, sub="alice"):
+        return jwt.encode({"sub": sub}, SECRET, algorithm="HS256")
+
+    def make_client(self, scope=None, sub="alice", **kwargs):
+        scope = scope or chat_scope()
+        return keyproxy_gateway.KeyProxyChatClient(
+            envelope=self.mint_envelope(scope, sub=sub),
+            scope=scope,
+            auth_token=self.auth_token(sub),
+            model="claude-fable-5",
+            effort="medium",
+            **kwargs,
+        )
+
+    def run_turn(self, client, messages=None):
+        return list(
+            client.stream_turn(
+                system="test system",
+                tools=[],
+                messages=messages or [{"role": "user", "content": "hi"}],
+            )
+        )
+
+
+class TestKeyProxyChatClient(GatewayTestBase):
+    def test_parses_deltas_and_final_and_tears_down_on_done(self):
+        provider = ScriptedProvider(
+            [{"deltas": ["Hel", "lo"], "final": final_message(TEXT_BLOCK)}]
+        )
+        with patch("keyproxy.providers.anthropic.stream_turn", provider):
+            events = self.run_turn(self.make_client())
+        self.assertEqual(events[0], ("delta", "Hel"))
+        self.assertEqual(events[1], ("delta", "lo"))
+        kind, message = events[2]
+        self.assertEqual(kind, "final")
+        self.assertEqual(message.stop_reason, "end_turn")
+        self.assertEqual(message.content[0].type, "text")
+        self.assertEqual(message.content[0].text, "hi there")
+        self.assertEqual(message.content[0].raw, TEXT_BLOCK)
+        # The stub got the plaintext key; the terminal turn tore the session down.
+        self.assertEqual(provider.calls[0]["api_key"], API_KEY)
+        self.assertEqual(self.state.sessions._sessions, {})
+
+    def test_envelope_redeemed_once_and_session_reused_across_turns(self):
+        provider = ScriptedProvider(
+            [
+                {"final": final_message(THINKING_BLOCK, TOOL_USE_BLOCK)},
+                {"final": final_message(TEXT_BLOCK)},
+            ]
+        )
+        client = self.make_client()
+        token = self.auth_token()
+        with patch("keyproxy.providers.anthropic.stream_turn", provider):
+            (_, first) = self.run_turn(client)[-1]
+            self.assertEqual(len(self.state.sessions._sessions), 1)
+            session_id_after_turn1 = client._session_id
+            self.run_turn(
+                client,
+                messages=[
+                    {"role": "user", "content": "hi"},
+                    {"role": "assistant", "content": first.content},
+                    {"role": "user", "content": [{"type": "tool_result",
+                                                  "tool_use_id": "toolu_1",
+                                                  "content": "{}"}]},
+                ],
+            )
+        # Turn 2 rode the same session (no second redemption), then tore down.
+        self.assertIsNotNone(session_id_after_turn1)
+        redemptions = [m for m in self.logged_messages() if "session redeemed" in m]
+        self.assertEqual(len(redemptions), 1)
+        self.assertEqual(self.state.sessions._sessions, {})
+        self.assert_never_logged(API_KEY, token)
+
+    def test_teardown_and_clean_message_on_provider_error(self):
+        provider = ScriptedProvider([{"deltas": ["partial"], "error": True}])
+        client = self.make_client()
+        with patch("keyproxy.providers.anthropic.stream_turn", provider):
+            with self.assertRaises(keyproxy_gateway.KeyProxyError) as ctx:
+                self.run_turn(client)
+        self.assertEqual(str(ctx.exception), keyproxy_gateway.PROVIDER_ERROR_MESSAGE)
+        self.assertNotIn(API_KEY, str(ctx.exception))
+        self.assertEqual(self.state.sessions._sessions, {})
+        self.assert_never_logged(API_KEY, "exploded")
+
+    def test_expired_session_mid_chat_surfaces_clean_resend_error(self):
+        provider = ScriptedProvider(
+            [{"final": final_message(THINKING_BLOCK, TOOL_USE_BLOCK)}]
+        )
+        client = self.make_client()
+        with patch("keyproxy.providers.anthropic.stream_turn", provider):
+            self.run_turn(client)
+            # The keyproxy expires the session between turns (TTL backstop).
+            self.state.sessions.delete(client._session_id)
+            with self.assertRaises(keyproxy_gateway.KeyProxyError) as ctx:
+                self.run_turn(client)
+        self.assertEqual(str(ctx.exception), keyproxy_gateway.RESEND_MESSAGE)
+
+    def test_budget_exhaustion_detail_passes_through_verbatim(self):
+        scope = chat_scope(
+            budget={"max_calls": 1, "max_mutations": 0, "max_tokens": 250_000, "ttl": 300}
+        )
+        provider = ScriptedProvider(
+            [{"final": final_message(THINKING_BLOCK, TOOL_USE_BLOCK)}]
+        )
+        client = self.make_client(scope)
+        with patch("keyproxy.providers.anthropic.stream_turn", provider):
+            self.run_turn(client)
+            with self.assertRaises(keyproxy_gateway.KeyProxyError) as ctx:
+                self.run_turn(client)
+        # Budget messages name no values and must reach the user as-is.
+        self.assertEqual(str(ctx.exception), "session call budget exhausted")
+
+    def test_rejected_redemption_is_a_clean_error(self):
+        scope = chat_scope()
+        client = keyproxy_gateway.KeyProxyChatClient(
+            envelope=self.mint_envelope(scope, sub="bob"),  # sub mismatch
+            scope=scope,
+            auth_token=self.auth_token("alice"),
+            model="claude-fable-5",
+            effort="medium",
+        )
+        with self.assertRaises(keyproxy_gateway.KeyProxyError) as ctx:
+            self.run_turn(client)
+        self.assertEqual(str(ctx.exception), keyproxy_gateway.RESEND_MESSAGE)
+
+    def test_keyproxy_stream_no_buffering(self):
+        # Risk-pinning test (2026-07-16): the api -> keyproxy hop must pass
+        # chunks through as they arrive. 5 deltas spaced ~200 ms apart; the
+        # first must arrive before the stub emits the last, and arrivals must
+        # be spread across the emission window, not clustered at the end.
+        provider = ScriptedProvider(
+            [{"deltas": ["d0", "d1", "d2", "d3", "d4"], "delay": 0.2,
+              "final": final_message(TEXT_BLOCK)}]
+        )
+        client = self.make_client()
+        arrivals = []
+        with patch("keyproxy.providers.anthropic.stream_turn", provider):
+            for kind, _payload in client.stream_turn(
+                system="s", tools=[], messages=[{"role": "user", "content": "hi"}]
+            ):
+                if kind == "delta":
+                    arrivals.append(time.monotonic())
+        self.assertEqual(len(arrivals), 5)
+        self.assertLess(
+            arrivals[0],
+            provider.emit_times[-1],
+            "first delta arrived only after the stub finished emitting — "
+            "something on the hop is buffering",
+        )
+        spread = arrivals[-1] - arrivals[0]
+        self.assertGreaterEqual(
+            spread,
+            0.4,
+            f"delta arrivals clustered within {spread:.3f}s of each other over a "
+            "~0.8s emission window — something on the hop is buffering",
+        )
+
+    def test_thinking_block_signature_roundtrip(self):
+        # Risk-pinning test (2026-07-16): a thinking block must survive
+        # keyproxy JSON -> SSE -> client parse -> ChatService echo -> the next
+        # turn's outbound payload BYTE-EXACTLY (signature included).
+        from quantcore.services.chat import ChatService, Done
+
+        provider = ScriptedProvider(
+            [
+                {"final": final_message(THINKING_BLOCK, TOOL_USE_BLOCK)},
+                {"final": final_message(TEXT_BLOCK)},
+            ]
+        )
+        prices = Mock()
+        prices.get_stock_price.return_value = {"symbol": "AAPL", "price": 123.45}
+        service = ChatService(
+            prices, Mock(), Mock(), Mock(),
+            client_factory=lambda context: self.make_client(),
+        )
+        with patch("keyproxy.providers.anthropic.stream_turn", provider):
+            events = list(
+                service.stream_chat([{"role": "user", "content": "price of AAPL?"}])
+            )
+        self.assertIsInstance(events[-1], Done)
+        prices.get_stock_price.assert_called_once_with("AAPL")
+        # What the keyproxy parsed off turn 2's request — the full round trip.
+        outbound = provider.calls[1]["messages"]
+        assistant = next(m for m in outbound if m["role"] == "assistant")
+        self.assertEqual(assistant["content"][0], THINKING_BLOCK)
+        self.assertEqual(assistant["content"][1], TOOL_USE_BLOCK)
+
+
+class TestClientHeartbeatTolerance(GatewayTestBase):
+    extra_env = {"KEYPROXY_HEARTBEAT_SECS": "0.05"}
+
+    def test_heartbeat_comments_are_invisible_to_the_parser(self):
+        provider = ScriptedProvider(
+            [{"deltas": ["slow"], "delay": 0.2, "final": final_message(TEXT_BLOCK)}]
+        )
+        with patch("keyproxy.providers.anthropic.stream_turn", provider):
+            events = self.run_turn(self.make_client())
+        # Pings were on the wire (~0.2s gaps vs 0.05s interval) yet the
+        # parsed event sequence is exactly delta + final.
+        self.assertEqual(events[0], ("delta", "slow"))
+        self.assertEqual(len(events), 2)
+        self.assertEqual(events[1][0], "final")
+
+
+class TestPubkeyAndValidate(GatewayTestBase):
+    def test_get_public_keys(self):
+        keys = keyproxy_gateway.get_public_keys()
+        self.assertEqual(keys[0]["kid"], KID)
+
+    def test_validate_key_round_trip(self):
+        scope = chat_scope(action="key.validate")
+        with patch("keyproxy.providers.anthropic.validate_key", return_value=True):
+            result = keyproxy_gateway.validate_key(
+                envelope=self.mint_envelope(scope),
+                scope=scope,
+                auth_token=self.auth_token(),
+            )
+        self.assertEqual(
+            result, {"valid": True, "provider": "anthropic", "key_hint": "…abcd"}
+        )
+        # Immediate teardown: the validation session never outlives the call.
+        self.assertEqual(self.state.sessions._sessions, {})
+
+    def test_validate_key_rejection_is_clean(self):
+        scope = chat_scope(action="key.validate")
+        with self.assertRaises(keyproxy_gateway.KeyProxyError) as ctx:
+            keyproxy_gateway.validate_key(
+                envelope=self.mint_envelope(scope, sub="bob"),
+                scope=scope,
+                auth_token=self.auth_token("alice"),
+            )
+        self.assertEqual(str(ctx.exception), keyproxy_gateway.RESEND_MESSAGE)
+
+
+class TestKeyProxyServiceThin(unittest.TestCase):
+    def test_passthrough(self):
+        gateway = Mock()
+        gateway.is_configured.return_value = True
+        gateway.get_public_keys.return_value = [{"kid": "k"}]
+        gateway.validate_key.return_value = {"valid": True}
+        service = KeyProxyService(gateway)
+        self.assertTrue(service.is_configured())
+        self.assertEqual(service.get_public_keys(), [{"kid": "k"}])
+        self.assertEqual(
+            service.validate_key(envelope={"e": 1}, scope={"s": 1}, auth_token="t"),
+            {"valid": True},
+        )
+        gateway.validate_key.assert_called_once_with(
+            envelope={"e": 1}, scope={"s": 1}, auth_token="t"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_keyproxy_gateway.py
+++ b/test_keyproxy_gateway.py
@@ -18,17 +18,16 @@ import unittest
 
 from unittest.mock import Mock, patch
 
-import jwt
 import uvicorn
 
 from quantcore.gateways import keyproxy_gateway
 from quantcore.services.keyproxy import KeyProxyService
 from test_keyproxy_service import (
     API_KEY,
-    SECRET,
     KID,
     KeyProxyServiceTestBase,
     chat_scope,
+    mint_user_token,
 )
 
 TEXT_BLOCK = {"type": "text", "text": "hi there"}
@@ -110,7 +109,7 @@ class GatewayTestBase(KeyProxyServiceTestBase):
         self.addCleanup(stop)
 
     def auth_token(self, sub="alice"):
-        return jwt.encode({"sub": sub}, SECRET, algorithm="HS256")
+        return mint_user_token(sub)
 
     def make_client(self, scope=None, sub="alice", **kwargs):
         scope = scope or chat_scope()

--- a/test_keyproxy_gateway.py
+++ b/test_keyproxy_gateway.py
@@ -343,6 +343,20 @@ class TestPubkeyAndValidate(GatewayTestBase):
         self.assertEqual(str(ctx.exception), keyproxy_gateway.RESEND_MESSAGE)
 
 
+class TestAuthHeaders(unittest.TestCase):
+    def test_empty_token_omits_the_header_entirely(self):
+        # AUTH_DISABLED dev stacks pass auth_token="" — "Bearer " with no
+        # token is an illegal header value that h11 rejects client-side, so
+        # the header must be absent, not empty.
+        self.assertEqual(keyproxy_gateway._headers(""), {})
+
+    def test_token_is_sent_as_bearer(self):
+        self.assertEqual(
+            keyproxy_gateway._headers("tok-123"),
+            {"Authorization": "Bearer tok-123"},
+        )
+
+
 class TestKeyProxyServiceThin(unittest.TestCase):
     def test_passthrough(self):
         gateway = Mock()

--- a/test_keyproxy_not_compressed.py
+++ b/test_keyproxy_not_compressed.py
@@ -1,0 +1,126 @@
+"""Packet 3c Verify: SSE compression + heartbeat pinning on BOTH hops.
+
+Sends stream requests **with ``Accept-Encoding: gzip``** to the keyproxy's
+stream endpoint and to ``POST /api/chat`` (the full browser path: api route →
+registry KeyProxyChatClient → real uvicorn keyproxy → stubbed provider) and
+asserts that no compression middleware touches ``text/event-stream`` (no
+``Content-Encoding``, plain chunks) and that ``: ping`` heartbeat comments
+appear on the wire during an artificially long provider pause — on each hop.
+
+The keyproxy runs under real uvicorn (GatewayTestBase); the api app runs under
+TestClient in the same process, so the provider stub patch reaches it.
+"""
+
+import os
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+# Swap in the test DSN BEFORE quantcore.db is imported (it freezes DB_DSN at
+# import time), then let the guard abort if this process would reach prod.
+_env_file = Path(__file__).parent / ".env"
+if _env_file.exists():
+    for _line in _env_file.read_text().splitlines():
+        if _line.strip().startswith("QUANTCORE_TEST_DB_DSN="):
+            os.environ["QUANTCORE_DB_DSN"] = _line.split("=", 1)[1].strip()
+            break
+
+from quantcore.db_safety import assert_not_production  # noqa: E402
+
+assert_not_production()
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from quantcore.services.registry import get_services  # noqa: E402
+from api.main import create_app  # noqa: E402
+from test_keyproxy_gateway import (  # noqa: E402
+    GatewayTestBase,
+    ScriptedProvider,
+    TEXT_BLOCK,
+    final_message,
+)
+from test_keyproxy_service import bearer, chat_scope  # noqa: E402
+
+# The base patches os.environ with clear=True; the api app (and any DB touch
+# inside a request) must keep seeing the test DSN inside that patched world.
+_TEST_DSN = os.environ.get("QUANTCORE_DB_DSN", "")
+
+
+class TestStreamNotCompressed(GatewayTestBase):
+    extra_env = {
+        "KEYPROXY_HEARTBEAT_SECS": "0.05",
+        "QUANTCORE_DB_DSN": _TEST_DSN,
+    }
+
+    def setUp(self):
+        super().setUp()  # uvicorn keyproxy up; KEYPROXY_URL now points at it
+        get_services.cache_clear()  # rebuild with the KeyProxyChatClient factory
+        self.addCleanup(get_services.cache_clear)
+        self.api = TestClient(create_app(), raise_server_exceptions=False)
+
+    def slow_provider(self):
+        # One ~0.25s pause before the delta and another before the final —
+        # multiples of the 0.05s heartbeat, so pings MUST appear on the wire.
+        return ScriptedProvider(
+            [{"deltas": ["slow"], "delay": 0.25, "final": final_message(TEXT_BLOCK)}]
+        )
+
+    def test_keyproxy_stream_not_compressed(self):
+        scope = chat_scope()
+        envelope = self.mint_envelope(scope, sub="alice")
+        redeemed = self.redeem(envelope, scope)
+        self.assertEqual(redeemed.status_code, 200)
+        session_id = redeemed.json()["session_id"]
+        provider = self.slow_provider()
+        with patch("keyproxy.providers.anthropic.stream_turn", provider):
+            response = self.client.post(
+                "/v1/providers/anthropic/messages/stream",
+                json={
+                    "session_id": session_id,
+                    "model": "claude-fable-5",
+                    "effort": "medium",
+                    "system": "s",
+                    "tools": [],
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+                headers={**bearer("alice"), "Accept-Encoding": "gzip"},
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            response.headers["content-type"].startswith("text/event-stream")
+        )
+        self.assertNotIn("content-encoding", response.headers)
+        # Plain chunks: the raw body parses as text and carries heartbeats
+        # emitted during the provider pauses, plus the real frames.
+        self.assertIn(": ping", response.text)
+        self.assertIn("event: delta", response.text)
+        self.assertIn("event: final", response.text)
+
+    def test_api_chat_stream_not_compressed(self):
+        scope = chat_scope()
+        envelope = self.mint_envelope(scope, sub="alice")
+        provider = self.slow_provider()
+        with patch("keyproxy.providers.anthropic.stream_turn", provider):
+            response = self.api.post(
+                "/api/chat",
+                json={
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "key_envelope": envelope,
+                    "scope": scope,
+                },
+                headers={**bearer("alice"), "Accept-Encoding": "gzip"},
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            response.headers["content-type"].startswith("text/event-stream")
+        )
+        self.assertNotIn("content-encoding", response.headers)
+        self.assertIn(": ping", response.text)
+        self.assertIn("event: text", response.text)
+        self.assertIn("event: done", response.text)
+        # The provider really was reached through the keyproxy (full path).
+        self.assertEqual(len(provider.calls), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_keyproxy_replay.py
+++ b/test_keyproxy_replay.py
@@ -1,0 +1,143 @@
+"""Packet 2a tests: replay protection + rate limiting (keyproxy/replay.py).
+
+Includes test_replay_race (external security review, 2026-07-16): concurrent
+redemptions of the same jti racing the replay set — exactly one must win.
+"""
+
+import threading
+import unittest
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import patch
+
+from keyproxy.replay import JtiReplaySet, ReplayCapacityError, SubRateLimiter
+
+
+class FakeClock:
+    def __init__(self, start=1_000.0):
+        self.now = start
+
+    def __call__(self):
+        return self.now
+
+    def advance(self, seconds):
+        self.now += seconds
+
+
+class TestJtiReplaySet(unittest.TestCase):
+    def test_first_burn_wins_second_is_replay(self):
+        replay = JtiReplaySet(ttl_seconds=120)
+        self.assertTrue(replay.burn("jti-1"))
+        self.assertFalse(replay.burn("jti-1"))
+        self.assertTrue(replay.burn("jti-2"))
+
+    def test_replay_race(self):
+        # Two-plus concurrent redemptions of the same jti: exactly one wins.
+        replay = JtiReplaySet(ttl_seconds=120)
+        threads = 8
+        for _ in range(50):
+            jti = str(uuid.uuid4())
+            barrier = threading.Barrier(threads)
+
+            def attempt():
+                barrier.wait()
+                return replay.burn(jti)
+
+            with ThreadPoolExecutor(max_workers=threads) as pool:
+                results = list(pool.map(lambda _: attempt(), range(threads)))
+            self.assertEqual(results.count(True), 1)
+            self.assertEqual(results.count(False), threads - 1)
+
+    def test_entries_expire_after_ttl(self):
+        # Forgetting a jti after the TTL is safe ONLY because the envelope's
+        # iat skew check (60 s) rejects it long before the 120 s retention
+        # ends — the set just needs to cover the redeemable window.
+        clock = FakeClock()
+        replay = JtiReplaySet(ttl_seconds=120, clock=clock)
+        self.assertTrue(replay.burn("jti-1"))
+        clock.advance(121)
+        self.assertTrue(replay.burn("jti-1"))
+
+    def test_capacity_fails_closed(self):
+        clock = FakeClock()
+        replay = JtiReplaySet(ttl_seconds=120, max_entries=2, clock=clock)
+        self.assertTrue(replay.burn("a"))
+        self.assertTrue(replay.burn("b"))
+        with self.assertRaises(ReplayCapacityError):
+            replay.burn("c")
+        # Already-burned jtis still answer False at capacity (replay beats
+        # capacity), and expiry frees space for new redemptions.
+        self.assertFalse(replay.burn("a"))
+        clock.advance(121)
+        self.assertTrue(replay.burn("c"))
+
+    def test_capacity_error_message_has_no_jti(self):
+        replay = JtiReplaySet(ttl_seconds=120, max_entries=1)
+        replay.burn("first-jti")
+        with self.assertRaises(ReplayCapacityError) as ctx:
+            replay.burn("second-secret-jti")
+        self.assertNotIn("jti", str(ctx.exception).replace("replay", ""))
+        self.assertNotIn("second-secret-jti", str(ctx.exception))
+
+    def test_default_ttl_tracks_max_skew_env(self):
+        clock = FakeClock()
+        with patch.dict("os.environ", {"KEYPROXY_MAX_SKEW": "5"}):
+            replay = JtiReplaySet(clock=clock)
+        self.assertTrue(replay.burn("jti-1"))
+        clock.advance(9)
+        self.assertFalse(replay.burn("jti-1"))
+        clock.advance(2)  # past 2 * skew
+        self.assertTrue(replay.burn("jti-1"))
+
+
+class TestSubRateLimiter(unittest.TestCase):
+    def test_allows_up_to_capacity_then_denies(self):
+        clock = FakeClock()
+        limiter = SubRateLimiter(per_minute=3, clock=clock)
+        self.assertTrue(limiter.allow("john"))
+        self.assertTrue(limiter.allow("john"))
+        self.assertTrue(limiter.allow("john"))
+        self.assertFalse(limiter.allow("john"))
+
+    def test_refills_over_time(self):
+        clock = FakeClock()
+        limiter = SubRateLimiter(per_minute=3, clock=clock)
+        for _ in range(3):
+            limiter.allow("john")
+        self.assertFalse(limiter.allow("john"))
+        clock.advance(20)  # 3/min -> one token per 20 s
+        self.assertTrue(limiter.allow("john"))
+        self.assertFalse(limiter.allow("john"))
+
+    def test_subs_are_isolated(self):
+        clock = FakeClock()
+        limiter = SubRateLimiter(per_minute=1, clock=clock)
+        self.assertTrue(limiter.allow("john"))
+        self.assertFalse(limiter.allow("john"))
+        self.assertTrue(limiter.allow("sager"))
+
+    def test_full_map_fails_closed_for_new_subs(self):
+        clock = FakeClock()
+        limiter = SubRateLimiter(per_minute=2, max_subs=1, clock=clock)
+        self.assertTrue(limiter.allow("john"))  # john's bucket is now drained by 1
+        self.assertFalse(limiter.allow("sager"))  # no room; john not prunable
+        self.assertTrue(limiter.allow("john"))  # existing subs keep working
+
+    def test_idle_buckets_are_pruned_to_admit_new_subs(self):
+        clock = FakeClock()
+        limiter = SubRateLimiter(per_minute=2, max_subs=1, clock=clock)
+        self.assertTrue(limiter.allow("john"))
+        clock.advance(60)  # john fully refilled -> idle, prunable
+        self.assertTrue(limiter.allow("sager"))
+
+    def test_default_capacity_from_env(self):
+        clock = FakeClock()
+        with patch.dict("os.environ", {"KEYPROXY_RATE_LIMIT_PER_MIN": "2"}):
+            limiter = SubRateLimiter(clock=clock)
+        self.assertTrue(limiter.allow("john"))
+        self.assertTrue(limiter.allow("john"))
+        self.assertFalse(limiter.allow("john"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_keyproxy_scopes.py
+++ b/test_keyproxy_scopes.py
@@ -1,0 +1,241 @@
+"""Packet 2a tests: scope v1 validation + budget counters (keyproxy/scopes.py).
+
+Hash agreement is proven against the Phase 1 cross-runtime vectors
+(tests/vectors/keyproxy_envelope_v1.json) — the same bytes the TypeScript
+side signs off on — so a scope hashed in the browser is the scope this
+module validates.
+"""
+
+import copy
+import json
+import os
+import unittest
+from unittest.mock import patch
+
+from keyproxy.scopes import (
+    TOKEN_BUDGET_MESSAGE,
+    BudgetExceededError,
+    BudgetTracker,
+    Scope,
+    ScopeError,
+    canonical_scope_json,
+    compute_scope_hash,
+    validate_scope,
+)
+
+VECTORS_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "tests",
+    "vectors",
+    "keyproxy_envelope_v1.json",
+)
+with open(VECTORS_PATH, encoding="utf-8") as fh:
+    VECTORS = json.load(fh)
+
+# The plan's worked chat-turn example ("Scope schema (v1)").
+CHAT_SCOPE = {
+    "v": 1,
+    "provider": "anthropic",
+    "action": "chat.turn",
+    "params": {},
+    "budget": {
+        "max_calls": 20,
+        "max_mutations": 0,
+        "max_tokens": 250_000,
+        "ttl": 300,
+    },
+}
+
+
+class TestVectorAgreement(unittest.TestCase):
+    def test_canonicalization_vectors(self):
+        for case in VECTORS["canonicalization"]:
+            with self.subTest(case=case["name"]):
+                self.assertEqual(
+                    canonical_scope_json(case["input"]).decode("utf-8"),
+                    case["canonical"],
+                )
+                self.assertEqual(
+                    compute_scope_hash(case["input"]), case["scope_hash"]
+                )
+
+    def test_envelope_scope_hashes_match_aad(self):
+        for case in VECTORS["envelopes"]:
+            with self.subTest(case=case["name"]):
+                scope = validate_scope(case["scope"], max_session_tokens=250_000)
+                self.assertEqual(scope.scope_hash, case["aad"]["scope_hash"])
+
+
+class TestValidateScope(unittest.TestCase):
+    def validate(self, scope_obj, ceiling=250_000):
+        return validate_scope(scope_obj, max_session_tokens=ceiling)
+
+    def test_plan_chat_scope_validates(self):
+        scope = self.validate(CHAT_SCOPE)
+        self.assertIsInstance(scope, Scope)
+        self.assertEqual(scope.provider, "anthropic")
+        self.assertEqual(scope.action, "chat.turn")
+        self.assertEqual(scope.max_calls, 20)
+        self.assertEqual(scope.max_mutations, 0)
+        self.assertEqual(scope.max_tokens, 250_000)
+        self.assertEqual(scope.ttl, 300)
+
+    def test_result_is_immutable(self):
+        scope = self.validate(CHAT_SCOPE)
+        with self.assertRaises(TypeError):
+            scope.raw["provider"] = "evil"
+        with self.assertRaises(TypeError):
+            scope.params["extra"] = 1
+
+    def test_absent_max_tokens_defaults_to_ceiling(self):
+        obj = copy.deepcopy(CHAT_SCOPE)
+        del obj["budget"]["max_tokens"]
+        self.assertEqual(self.validate(obj, ceiling=1_000).max_tokens, 1_000)
+
+    def test_max_tokens_above_ceiling_uses_system_threshold_copy(self):
+        obj = copy.deepcopy(CHAT_SCOPE)
+        obj["budget"]["max_tokens"] = 250_001
+        with self.assertRaises(ScopeError) as ctx:
+            self.validate(obj)
+        self.assertIn("system-imposed threshold", str(ctx.exception))
+        self.assertIn("development team", str(ctx.exception))
+
+    def test_ceiling_env_default(self):
+        obj = copy.deepcopy(CHAT_SCOPE)
+        obj["budget"]["max_tokens"] = 200
+        with patch.dict("os.environ", {"KEYPROXY_MAX_SESSION_TOKENS": "100"}):
+            with self.assertRaises(ScopeError):
+                validate_scope(obj)
+
+    def test_structural_rejections(self):
+        cases = {
+            "not a dict": ["v", 1],
+            "wrong version": {**CHAT_SCOPE, "v": 2},
+            "bool version": {**CHAT_SCOPE, "v": True},
+            "missing key": {k: v for k, v in CHAT_SCOPE.items() if k != "action"},
+            "extra key": {**CHAT_SCOPE, "note": "hi"},
+            "empty provider": {**CHAT_SCOPE, "provider": ""},
+            "non-string action": {**CHAT_SCOPE, "action": 7},
+            "non-dict params": {**CHAT_SCOPE, "params": []},
+            "non-dict budget": {**CHAT_SCOPE, "budget": 5},
+        }
+        for name, obj in cases.items():
+            with self.subTest(case=name):
+                with self.assertRaises(ScopeError):
+                    self.validate(obj)
+
+    def test_budget_rejections(self):
+        def with_budget(**overrides):
+            obj = copy.deepcopy(CHAT_SCOPE)
+            obj["budget"].update(overrides)
+            for key, value in list(overrides.items()):
+                if value is _ABSENT:
+                    del obj["budget"][key]
+            return obj
+
+        _ABSENT = object()
+        cases = {
+            "missing max_calls": with_budget(max_calls=_ABSENT),
+            "missing ttl": with_budget(ttl=_ABSENT),
+            "unknown budget key": with_budget(max_retries=3),
+            "zero max_calls": with_budget(max_calls=0),
+            "negative max_mutations": with_budget(max_mutations=-1),
+            "zero ttl": with_budget(ttl=0),
+            "float max_calls": with_budget(max_calls=1.0),
+            "bool max_mutations": with_budget(max_mutations=True),
+            "string max_tokens": with_budget(max_tokens="1000"),
+        }
+        for name, obj in cases.items():
+            with self.subTest(case=name):
+                with self.assertRaises(ScopeError):
+                    self.validate(obj)
+
+    def test_non_canonicalizable_params_rejected(self):
+        obj = copy.deepcopy(CHAT_SCOPE)
+        obj["params"] = {"nan": float("nan")}
+        with self.assertRaises(ScopeError) as ctx:
+            self.validate(obj)
+        self.assertEqual(str(ctx.exception), "scope is not canonicalizable")
+        self.assertIsNone(ctx.exception.__cause__)
+
+    def test_error_messages_never_echo_values(self):
+        obj = copy.deepcopy(CHAT_SCOPE)
+        obj["provider"] = "sk-ant-leaky-value"
+        obj["v"] = 99
+        with self.assertRaises(ScopeError) as ctx:
+            self.validate(obj)
+        self.assertNotIn("sk-ant-leaky-value", str(ctx.exception))
+        self.assertNotIn("99", str(ctx.exception))
+
+
+class TestBudgetTracker(unittest.TestCase):
+    def tracker(self, max_calls=2, max_mutations=1, max_tokens=100, ttl=300):
+        scope = validate_scope(
+            {
+                "v": 1,
+                "provider": "anthropic",
+                "action": "chat.turn",
+                "params": {},
+                "budget": {
+                    "max_calls": max_calls,
+                    "max_mutations": max_mutations,
+                    "max_tokens": max_tokens,
+                    "ttl": ttl,
+                },
+            },
+            max_session_tokens=250_000,
+        )
+        return BudgetTracker(scope)
+
+    def test_call_budget_exhausts(self):
+        tracker = self.tracker(max_calls=2)
+        tracker.charge_call()
+        tracker.charge_call()
+        with self.assertRaises(BudgetExceededError):
+            tracker.charge_call()
+        self.assertEqual(tracker.calls_used, 2)
+
+    def test_zero_mutation_budget_blocks_first_mutation(self):
+        scope = validate_scope(CHAT_SCOPE, max_session_tokens=250_000)
+        tracker = BudgetTracker(scope)  # max_mutations = 0
+        with self.assertRaises(BudgetExceededError):
+            tracker.charge_mutation()
+
+    def test_token_budget_is_posthoc_and_cumulative(self):
+        tracker = self.tracker(max_tokens=100)
+        tracker.charge_tokens(60)
+        tracker.charge_tokens(40)  # exactly at the line is allowed
+        self.assertEqual(tracker.tokens_used, 100)
+        with self.assertRaises(BudgetExceededError) as ctx:
+            tracker.charge_tokens(1)
+        self.assertEqual(str(ctx.exception), TOKEN_BUDGET_MESSAGE)
+
+    def test_exhaustion_latches_across_budget_lines(self):
+        tracker = self.tracker(max_calls=1)
+        tracker.charge_call()
+        with self.assertRaises(BudgetExceededError):
+            tracker.charge_call()
+        # The session is dead: every other charge now fails too.
+        with self.assertRaises(BudgetExceededError):
+            tracker.charge_tokens(1)
+        with self.assertRaises(BudgetExceededError):
+            tracker.charge_mutation()
+
+    def test_invalid_token_counts_rejected(self):
+        tracker = self.tracker()
+        for bad in (-1, 1.5, True, "10"):
+            with self.subTest(count=bad):
+                with self.assertRaises(ValueError):
+                    tracker.charge_tokens(bad)
+        self.assertEqual(tracker.tokens_used, 0)
+
+    def test_exhaustion_messages_never_carry_values(self):
+        tracker = self.tracker(max_calls=1)
+        tracker.charge_call()
+        with self.assertRaises(BudgetExceededError) as ctx:
+            tracker.charge_call()
+        self.assertNotIn("1", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_keyproxy_service.py
+++ b/test_keyproxy_service.py
@@ -1,0 +1,475 @@
+"""Packet 2b tests: the Key Proxy FastAPI service (keyproxy/main.py).
+
+TestClient tests over the assembled app with real envelope crypto round
+trips: redemption happy path, jti burning (second redemption 400), stale
+``iat``/sub-mismatch/scope-hash-mismatch rejections, wrong-sub session use,
+unclassifiable operations, the per-sub 429, and the never-log assertion —
+no envelope, key, or bearer material may reach any log record on either
+success or failure paths.
+"""
+
+import importlib.util
+import logging
+import time
+import unittest
+import uuid
+from pathlib import Path
+from unittest.mock import patch
+
+import jwt
+from cryptography.hazmat.primitives.serialization import load_der_public_key
+from fastapi.testclient import TestClient
+
+from keyproxy import crypto
+from keyproxy.main import DEV_KID, create_app
+from keyproxy.scopes import TOKEN_BUDGET_MESSAGE
+from keyproxy.sessions import SessionError
+
+SECRET = "unit-test-secret-0123456789abcdef"  # >=32 bytes: no HMAC key warning
+KID = "kp-test-1"
+API_KEY = "sk-ant-test-key-abcd"
+GENERIC = "invalid request"
+
+
+def chat_scope(**overrides):
+    scope = {
+        "v": 1,
+        "provider": "anthropic",
+        "action": "chat.turn",
+        "params": {},
+        "budget": {"max_calls": 20, "max_mutations": 0, "max_tokens": 250_000, "ttl": 300},
+    }
+    scope.update(overrides)
+    return scope
+
+
+def render_bundle(kid, private_key):
+    """The KEYPROXY_PRIVATE_KEYS format: kid line + PEMs (public PEM must be ignored)."""
+    return "\n".join(
+        [
+            f"kid: {kid}",
+            "",
+            crypto.public_key_to_pem(private_key.public_key()).rstrip(),
+            "",
+            crypto.private_key_to_pem(private_key).rstrip(),
+            "",
+        ]
+    )
+
+
+def bearer(sub):
+    return {"Authorization": f"Bearer {jwt.encode({'sub': sub}, SECRET, algorithm='HS256')}"}
+
+
+class _RecordingHandler(logging.Handler):
+    def __init__(self):
+        super().__init__(level=logging.DEBUG)
+        self.records = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+
+class KeyProxyServiceTestBase(unittest.TestCase):
+    extra_env = {}
+
+    def setUp(self):
+        self.private_key = crypto.generate_private_key()
+        env = {
+            "KEYPROXY_PRIVATE_KEYS": render_bundle(KID, self.private_key),
+            "QUANTCORE_JWT_SECRET": SECRET,
+            **self.extra_env,
+        }
+        env_patcher = patch.dict("os.environ", env, clear=True)
+        env_patcher.start()
+        self.addCleanup(env_patcher.stop)
+
+        self.app = create_app()
+        self.state = self.app.state.keyproxy
+        self.client = TestClient(self.app, raise_server_exceptions=True)
+
+        # Capture every log record the process emits during the test.
+        self.log_handler = _RecordingHandler()
+        root = logging.getLogger()
+        self._old_root_level = root.level
+        root.setLevel(logging.DEBUG)
+        root.addHandler(self.log_handler)
+        self.addCleanup(root.removeHandler, self.log_handler)
+        self.addCleanup(root.setLevel, self._old_root_level)
+
+    def logged_messages(self):
+        return [record.getMessage() for record in self.log_handler.records]
+
+    def assert_never_logged(self, *needles):
+        for message in self.logged_messages():
+            for needle in needles:
+                self.assertNotIn(needle, message)
+
+    def fetch_public_key(self, expect_kid=KID):
+        response = self.client.get("/v1/publickey")
+        self.assertEqual(response.status_code, 200)
+        keys = response.json()["keys"]
+        entry = next(k for k in keys if k["kid"] == expect_kid)
+        self.assertEqual(entry["alg"], crypto.ENVELOPE_ALG)
+        return load_der_public_key(crypto.b64url_decode(entry["spki"]))
+
+    def mint_envelope(
+        self, scope, *, sub="alice", provider="anthropic", api_key=API_KEY,
+        iat=None, kid=KID, public_key=None,
+    ):
+        aad = {
+            "sub": sub,
+            "provider": provider,
+            "iat": int(time.time()) if iat is None else iat,
+            "jti": str(uuid.uuid4()),
+            "scope_hash": crypto.compute_scope_hash(scope),
+        }
+        return crypto.encrypt_envelope(
+            api_key, public_key or self.fetch_public_key(), kid=kid, aad=aad
+        )
+
+    def redeem(self, envelope, scope, *, sub="alice", provider="anthropic"):
+        return self.client.post(
+            "/v1/sessions",
+            json={"provider": provider, "envelope": envelope, "scope": scope},
+            headers=bearer(sub),
+        )
+
+
+class TestHealthAndKeys(KeyProxyServiceTestBase):
+    def test_healthz_open(self):
+        response = self.client.get("/healthz")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"status": "ok"})
+
+    def test_publickey_open_and_importable(self):
+        public_key = self.fetch_public_key()
+        self.assertEqual(
+            crypto.spki_fingerprint(public_key),
+            crypto.spki_fingerprint(self.private_key.public_key()),
+        )
+
+    def test_keypair_script_output_is_a_valid_bundle(self):
+        # The runbook pipes the generate script's stdout straight into the
+        # secret — pin that the parser accepts the script's exact format.
+        script = Path(__file__).parent / "scripts" / "generate_keyproxy_keypair.py"
+        spec = importlib.util.spec_from_file_location("gen_keypair", script)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        with patch.dict(
+            "os.environ",
+            {"KEYPROXY_PRIVATE_KEYS": module.render(kid="kp-script-1")},
+        ):
+            app = create_app()
+        keys = app.state.keyproxy.public_keys_newest_first()
+        self.assertEqual([k["kid"] for k in keys], ["kp-script-1"])
+
+
+class TestSessionRedemption(KeyProxyServiceTestBase):
+    def test_happy_path_real_crypto_round_trip(self):
+        scope = chat_scope()
+        response = self.redeem(self.mint_envelope(scope), scope)
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(len(body["session_id"]), 32)
+        self.assertGreater(body["expires_at"], time.time())
+        session = self.state.sessions.get(body["session_id"], sub="alice")
+        self.assertEqual(session.api_key, API_KEY)
+        self.assertEqual(session.provider, "anthropic")
+
+    def test_second_redemption_is_a_replay(self):
+        scope = chat_scope()
+        envelope = self.mint_envelope(scope)
+        self.assertEqual(self.redeem(envelope, scope).status_code, 200)
+        replay = self.redeem(envelope, scope)
+        self.assertEqual(replay.status_code, 400)
+        self.assertEqual(replay.json()["detail"], GENERIC)
+
+    def test_missing_bearer_is_401(self):
+        scope = chat_scope()
+        response = self.client.post(
+            "/v1/sessions",
+            json={"provider": "anthropic", "envelope": self.mint_envelope(scope), "scope": scope},
+        )
+        self.assertEqual(response.status_code, 401)
+
+    def test_stale_iat_rejected(self):
+        scope = chat_scope()
+        envelope = self.mint_envelope(scope, iat=int(time.time()) - 3_600)
+        response = self.redeem(envelope, scope)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["detail"], GENERIC)
+
+    def test_sub_mismatch_rejected(self):
+        scope = chat_scope()
+        envelope = self.mint_envelope(scope, sub="bob")  # redeemed by alice
+        self.assertEqual(self.redeem(envelope, scope).status_code, 400)
+
+    def test_scope_hash_mismatch_rejected(self):
+        minted_scope = chat_scope()
+        envelope = self.mint_envelope(minted_scope)
+        widened = chat_scope(
+            budget={"max_calls": 999, "max_mutations": 0, "max_tokens": 250_000, "ttl": 300}
+        )
+        response = self.redeem(envelope, widened)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["detail"], GENERIC)
+
+    def test_unknown_provider_rejected(self):
+        scope = chat_scope(provider="openai")
+        envelope = {"anything": "at all"}
+        response = self.redeem(envelope, scope, provider="openai")
+        self.assertEqual(response.status_code, 400)
+
+    def test_unclassifiable_action_rejected(self):
+        scope = chat_scope(action="orders.place")
+        response = self.redeem(self.mint_envelope(scope), scope)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["detail"], GENERIC)
+
+    def test_mutation_budget_rejected_for_anthropic(self):
+        scope = chat_scope(
+            budget={"max_calls": 20, "max_mutations": 1, "max_tokens": 250_000, "ttl": 300}
+        )
+        response = self.redeem(self.mint_envelope(scope), scope)
+        self.assertEqual(response.status_code, 400)
+
+    def test_token_budget_over_ceiling_names_system_threshold(self):
+        scope = chat_scope(
+            budget={"max_calls": 20, "max_mutations": 0, "max_tokens": 250_001, "ttl": 300}
+        )
+        response = self.redeem({}, scope)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["detail"], TOKEN_BUDGET_MESSAGE)
+
+    def test_malformed_body_is_generic_400_not_echoing_422(self):
+        response = self.client.post(
+            "/v1/sessions", json={"provider": "anthropic"}, headers=bearer("alice")
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"detail": GENERIC})
+
+
+class TestSessionTeardown(KeyProxyServiceTestBase):
+    def create_session(self):
+        scope = chat_scope()
+        response = self.redeem(self.mint_envelope(scope), scope)
+        self.assertEqual(response.status_code, 200)
+        return response.json()["session_id"]
+
+    def test_wrong_sub_delete_is_204_but_tears_nothing_down(self):
+        session_id = self.create_session()
+        response = self.client.delete(
+            f"/v1/sessions/{session_id}", headers=bearer("bob")
+        )
+        self.assertEqual(response.status_code, 204)
+        # Alice's session survives an interloper's delete.
+        self.state.sessions.get(session_id, sub="alice")
+
+    def test_owner_delete_tears_down(self):
+        session_id = self.create_session()
+        response = self.client.delete(
+            f"/v1/sessions/{session_id}", headers=bearer("alice")
+        )
+        self.assertEqual(response.status_code, 204)
+        with self.assertRaises(SessionError):
+            self.state.sessions.get(session_id, sub="alice")
+
+    def test_unknown_session_delete_is_still_204(self):
+        response = self.client.delete(
+            "/v1/sessions/deadbeefdeadbeefdeadbeefdeadbeef", headers=bearer("alice")
+        )
+        self.assertEqual(response.status_code, 204)
+
+
+class TestRateLimit(KeyProxyServiceTestBase):
+    extra_env = {"KEYPROXY_RATE_LIMIT_PER_MIN": "2"}
+
+    def test_third_redemption_in_a_minute_is_429(self):
+        public_key = self.fetch_public_key()
+        for _ in range(2):
+            scope = chat_scope()
+            envelope = self.mint_envelope(scope, public_key=public_key)
+            self.assertEqual(self.redeem(envelope, scope).status_code, 200)
+        scope = chat_scope()
+        envelope = self.mint_envelope(scope, public_key=public_key)
+        response = self.redeem(envelope, scope)
+        self.assertEqual(response.status_code, 429)
+        self.assertEqual(response.json()["detail"], "rate limit exceeded")
+
+    def test_other_subs_have_their_own_bucket(self):
+        public_key = self.fetch_public_key()
+        for _ in range(2):
+            scope = chat_scope()
+            envelope = self.mint_envelope(scope, public_key=public_key)
+            self.redeem(envelope, scope)
+        scope = chat_scope()
+        envelope = self.mint_envelope(scope, sub="bob", public_key=public_key)
+        self.assertEqual(self.redeem(envelope, scope, sub="bob").status_code, 200)
+
+
+class TestKeyValidation(KeyProxyServiceTestBase):
+    def validate(self, scope, envelope):
+        return self.client.post(
+            "/v1/keys/validate",
+            json={"provider": "anthropic", "envelope": envelope, "scope": scope},
+            headers=bearer("alice"),
+        )
+
+    def test_validate_probes_and_tears_down_immediately(self):
+        scope = chat_scope(action="key.validate")
+        envelope = self.mint_envelope(scope)
+        with patch(
+            "keyproxy.providers.anthropic.validate_key", return_value=True
+        ) as probe:
+            response = self.validate(scope, envelope)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {"valid": True, "provider": "anthropic", "key_hint": "…abcd"},
+        )
+        probe.assert_called_once_with(API_KEY)
+        # Immediate teardown: no session persists, and the jti is burned.
+        self.assertEqual(self.state.sessions._sessions, {})
+        self.assertEqual(self.validate(scope, envelope).status_code, 400)
+
+    def test_invalid_key_reports_valid_false(self):
+        scope = chat_scope(action="key.validate")
+        envelope = self.mint_envelope(scope)
+        with patch("keyproxy.providers.anthropic.validate_key", return_value=False):
+            response = self.validate(scope, envelope)
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.json()["valid"])
+
+    def test_validate_requires_the_validate_action(self):
+        scope = chat_scope()  # chat.turn
+        response = self.validate(scope, self.mint_envelope(scope))
+        self.assertEqual(response.status_code, 400)
+
+
+class TestNeverLogs(KeyProxyServiceTestBase):
+    """The plan's logging policy, enforced: no envelope/key/bearer material
+    in any log record, on success or on any failure path."""
+
+    def sensitive(self, envelope):
+        token = bearer("alice")["Authorization"]
+        return [API_KEY, envelope["ct"], envelope["epk"], token.split(" ", 1)[1]]
+
+    def test_success_and_failure_paths_log_no_material(self):
+        scope = chat_scope()
+        envelope = self.mint_envelope(scope)
+
+        # Success path (logs the allowlist line only).
+        self.assertEqual(self.redeem(envelope, scope).status_code, 200)
+        # Replay failure.
+        self.assertEqual(self.redeem(envelope, scope).status_code, 400)
+        # GCM tamper failure.
+        tampered = dict(envelope)
+        tampered["ct"] = crypto.b64url_encode(
+            bytes(reversed(crypto.b64url_decode(envelope["ct"])))
+        )
+        self.assertEqual(self.redeem(tampered, scope).status_code, 400)
+        # Sub mismatch failure.
+        wrong_sub = self.mint_envelope(scope, sub="bob")
+        self.assertEqual(self.redeem(wrong_sub, scope).status_code, 400)
+        # Malformed body failure.
+        self.client.post(
+            "/v1/sessions", json={"provider": "anthropic"}, headers=bearer("alice")
+        )
+
+        self.assert_never_logged(*self.sensitive(envelope))
+        self.assert_never_logged(*self.sensitive(wrong_sub))
+
+    def test_allowlist_line_carries_correlation_id_only(self):
+        scope = chat_scope()
+        response = self.redeem(self.mint_envelope(scope), scope)
+        session = self.state.sessions.get(response.json()["session_id"], sub="alice")
+        allowlist = [
+            m for m in self.logged_messages() if "session redeemed" in m
+        ]
+        self.assertEqual(len(allowlist), 1)
+        self.assertIn(f"correlation_id={session.correlation_id}", allowlist[0])
+        self.assertIn("sub=alice", allowlist[0])
+        self.assertIn("provider=anthropic", allowlist[0])
+        self.assertNotIn(API_KEY, allowlist[0])
+
+    def test_decrypt_failure_logs_nothing_at_all(self):
+        scope = chat_scope()
+        envelope = self.mint_envelope(scope, iat=int(time.time()) - 3_600)
+        before = len(self.log_handler.records)
+        self.assertEqual(self.redeem(envelope, scope).status_code, 400)
+        new = self.log_handler.records[before:]
+        for record in new:
+            for needle in self.sensitive(envelope):
+                self.assertNotIn(needle, record.getMessage())
+        keyproxy_lines = [
+            r.getMessage() for r in new if r.name.startswith("keyproxy")
+        ]
+        self.assertEqual(
+            keyproxy_lines, [],
+            "decrypt failure emitted keyproxy log lines",
+        )
+
+
+class TestRotationAndDevMode(unittest.TestCase):
+    def test_publickey_advertises_newest_first_and_old_kid_still_decrypts(self):
+        old_key = crypto.generate_private_key()
+        new_key = crypto.generate_private_key()
+        bundle = render_bundle("kp-old", old_key) + "\n" + render_bundle("kp-new", new_key)
+        env = {
+            "KEYPROXY_PRIVATE_KEYS": bundle,
+            "QUANTCORE_JWT_SECRET": SECRET,
+        }
+        with patch.dict("os.environ", env, clear=True):
+            app = create_app()
+            client = TestClient(app)
+            keys = client.get("/v1/publickey").json()["keys"]
+            self.assertEqual([k["kid"] for k in keys], ["kp-new", "kp-old"])
+
+            scope = chat_scope()
+            aad = {
+                "sub": "alice",
+                "provider": "anthropic",
+                "iat": int(time.time()),
+                "jti": str(uuid.uuid4()),
+                "scope_hash": crypto.compute_scope_hash(scope),
+            }
+            envelope = crypto.encrypt_envelope(
+                API_KEY, old_key.public_key(), kid="kp-old", aad=aad
+            )
+            response = client.post(
+                "/v1/sessions",
+                json={"provider": "anthropic", "envelope": envelope, "scope": scope},
+                headers=bearer("alice"),
+            )
+            self.assertEqual(response.status_code, 200)
+
+    def test_dev_mode_ephemeral_key_and_disabled_auth(self):
+        env = {"KEYPROXY_AUTH_DISABLED": "1"}
+        with patch.dict("os.environ", env, clear=True):
+            app = create_app()
+            client = TestClient(app)
+            keys = client.get("/v1/publickey").json()["keys"]
+            self.assertEqual([k["kid"] for k in keys], [DEV_KID])
+            public_key = load_der_public_key(crypto.b64url_decode(keys[0]["spki"]))
+
+            scope = chat_scope()
+            aad = {
+                "sub": "local",  # the synthetic caller when auth is off
+                "provider": "anthropic",
+                "iat": int(time.time()),
+                "jti": str(uuid.uuid4()),
+                "scope_hash": crypto.compute_scope_hash(scope),
+            }
+            envelope = crypto.encrypt_envelope(
+                API_KEY, public_key, kid=DEV_KID, aad=aad
+            )
+            response = client.post(
+                "/v1/sessions",
+                json={"provider": "anthropic", "envelope": envelope, "scope": scope},
+            )
+            self.assertEqual(response.status_code, 200)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_keyproxy_service.py
+++ b/test_keyproxy_service.py
@@ -8,6 +8,7 @@ no envelope, key, or bearer material may reach any log record on either
 success or failure paths.
 """
 
+import functools
 import importlib.util
 import logging
 import time
@@ -25,7 +26,12 @@ from keyproxy.main import DEV_KID, create_app
 from keyproxy.scopes import TOKEN_BUDGET_MESSAGE
 from keyproxy.sessions import SessionError
 
-SECRET = "unit-test-secret-0123456789abcdef"  # >=32 bytes: no HMAC key warning
+# Packet 7a: the keyproxy verifies ES256 only — the harness mints user tokens
+# with a module-level EC keypair and patches the public half into the env.
+_JWT_SIGNING_KEY = crypto.generate_private_key()
+JWT_SIGNING_PEM = crypto.private_key_to_pem(_JWT_SIGNING_KEY)
+JWT_PUBLIC_PEM = crypto.public_key_to_pem(_JWT_SIGNING_KEY.public_key())
+JWT_AUDIENCE = ["quantcore-api", "quantcore-keyproxy"]
 KID = "kp-test-1"
 API_KEY = "sk-ant-test-key-abcd"
 GENERIC = "invalid request"
@@ -57,8 +63,16 @@ def render_bundle(kid, private_key):
     )
 
 
+@functools.lru_cache(maxsize=None)
+def mint_user_token(sub):
+    # Memoized: ECDSA signatures are randomized per signing, but the
+    # never-log assertions grep logs for the exact token a request carried,
+    # so the same sub must yield the same token within a run.
+    return jwt.encode({"sub": sub, "aud": JWT_AUDIENCE}, JWT_SIGNING_PEM, algorithm="ES256")
+
+
 def bearer(sub):
-    return {"Authorization": f"Bearer {jwt.encode({'sub': sub}, SECRET, algorithm='HS256')}"}
+    return {"Authorization": f"Bearer {mint_user_token(sub)}"}
 
 
 class _RecordingHandler(logging.Handler):
@@ -77,7 +91,7 @@ class KeyProxyServiceTestBase(unittest.TestCase):
         self.private_key = crypto.generate_private_key()
         env = {
             "KEYPROXY_PRIVATE_KEYS": render_bundle(KID, self.private_key),
-            "QUANTCORE_JWT_SECRET": SECRET,
+            "QUANTCORE_JWT_PUBLIC_KEY": JWT_PUBLIC_PEM,
             **self.extra_env,
         }
         env_patcher = patch.dict("os.environ", env, clear=True)
@@ -418,7 +432,7 @@ class TestRotationAndDevMode(unittest.TestCase):
         bundle = render_bundle("kp-old", old_key) + "\n" + render_bundle("kp-new", new_key)
         env = {
             "KEYPROXY_PRIVATE_KEYS": bundle,
-            "QUANTCORE_JWT_SECRET": SECRET,
+            "QUANTCORE_JWT_PUBLIC_KEY": JWT_PUBLIC_PEM,
         }
         with patch.dict("os.environ", env, clear=True):
             app = create_app()

--- a/test_keyproxy_sessions.py
+++ b/test_keyproxy_sessions.py
@@ -1,0 +1,164 @@
+"""Packet 2a tests: in-memory scoped session store (keyproxy/sessions.py).
+
+Covers the plan's session lifecycle: sliding TTL, the ~900 s hard lifetime
+cap, teardown discarding the plaintext key, and the generic "invalid
+session" rejection that makes missing / expired / wrong-sub lookups
+indistinguishable.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from keyproxy.scopes import validate_scope
+from keyproxy.sessions import (
+    DEFAULT_SESSION_TTL_SECONDS,
+    HARD_LIFETIME_CAP_SECONDS,
+    SessionError,
+    SessionStore,
+)
+
+
+class FakeClock:
+    def __init__(self, start=1_000.0):
+        self.now = start
+
+    def __call__(self):
+        return self.now
+
+    def advance(self, seconds):
+        self.now += seconds
+
+
+def make_scope(ttl=300, max_calls=20):
+    return validate_scope(
+        {
+            "v": 1,
+            "provider": "anthropic",
+            "action": "chat.turn",
+            "params": {},
+            "budget": {"max_calls": max_calls, "max_mutations": 0, "ttl": ttl},
+        },
+        max_session_tokens=250_000,
+    )
+
+
+class TestSessionStore(unittest.TestCase):
+    def setUp(self):
+        self.clock = FakeClock()
+        self.store = SessionStore(ttl_seconds=300, clock=self.clock)
+
+    def create(self, sub="john", ttl=300):
+        return self.store.create(
+            sub=sub,
+            provider="anthropic",
+            api_key="sk-ant-test-key",
+            scope=make_scope(ttl=ttl),
+        )
+
+    def test_create_issues_random_ids_and_holds_key(self):
+        a = self.create()
+        b = self.create()
+        self.assertRegex(a.session_id, r"^[0-9a-f]{32}$")  # 128-bit random
+        self.assertNotEqual(a.session_id, b.session_id)
+        self.assertNotEqual(a.correlation_id, b.correlation_id)
+        self.assertEqual(a.api_key, "sk-ant-test-key")
+        self.assertEqual(a.sub, "john")
+
+    def test_get_returns_live_session(self):
+        session = self.create()
+        self.assertIs(self.store.get(session.session_id, sub="john"), session)
+
+    def test_unknown_id_rejected_generically(self):
+        with self.assertRaises(SessionError) as ctx:
+            self.store.get("f" * 32, sub="john")
+        self.assertEqual(str(ctx.exception), "invalid session")
+
+    def test_sub_mismatch_is_indistinguishable_from_missing(self):
+        session = self.create(sub="john")
+        with self.assertRaises(SessionError) as wrong_sub:
+            self.store.get(session.session_id, sub="sager")
+        with self.assertRaises(SessionError) as missing:
+            self.store.get("f" * 32, sub="john")
+        self.assertEqual(str(wrong_sub.exception), str(missing.exception))
+        # The session itself is unharmed — the right sub still gets it.
+        self.store.get(session.session_id, sub="john")
+
+    def test_ttl_slides_on_activity(self):
+        session = self.create()
+        for _ in range(3):
+            self.clock.advance(250)  # inside the 300 s window each time
+            self.store.get(session.session_id, sub="john")
+        # 750 s elapsed — far past the original expiry, alive via sliding.
+
+    def test_expires_without_activity(self):
+        session = self.create()
+        self.clock.advance(301)
+        with self.assertRaises(SessionError):
+            self.store.get(session.session_id, sub="john")
+
+    def test_hard_lifetime_cap_beats_sliding_ttl(self):
+        session = self.create()
+        for _ in range(4):
+            self.clock.advance(200)
+            self.store.get(session.session_id, sub="john")  # alive through 800 s
+        self.clock.advance(200)  # t = 1000 s > 900 s cap despite recent touch
+        with self.assertRaises(SessionError):
+            self.store.get(session.session_id, sub="john")
+        self.assertEqual(HARD_LIFETIME_CAP_SECONDS, 900.0)
+
+    def test_scope_ttl_narrows_server_ttl(self):
+        session = self.create(ttl=60)
+        self.clock.advance(61)
+        with self.assertRaises(SessionError):
+            self.store.get(session.session_id, sub="john")
+
+    def test_scope_ttl_cannot_widen_server_ttl(self):
+        session = self.create(ttl=86_400)
+        self.clock.advance(301)  # server default 300 s still governs
+        with self.assertRaises(SessionError):
+            self.store.get(session.session_id, sub="john")
+
+    def test_expiry_tears_down_key(self):
+        session = self.create()
+        self.clock.advance(301)
+        with self.assertRaises(SessionError):
+            self.store.get(session.session_id, sub="john")
+        with self.assertRaises(SessionError):
+            session.api_key
+
+    def test_delete_is_idempotent_and_discards_key(self):
+        session = self.create()
+        self.store.delete(session.session_id)
+        self.store.delete(session.session_id)  # no raise on repeat
+        self.store.delete("f" * 32)  # nor on unknown ids
+        with self.assertRaises(SessionError):
+            session.api_key
+        with self.assertRaises(SessionError):
+            self.store.get(session.session_id, sub="john")
+
+    def test_capacity_fails_closed_and_sweep_frees_space(self):
+        store = SessionStore(ttl_seconds=300, max_sessions=2, clock=self.clock)
+        scope = make_scope()
+        for _ in range(2):
+            store.create(
+                sub="john", provider="anthropic", api_key="k", scope=scope
+            )
+        with self.assertRaises(SessionError):
+            store.create(sub="john", provider="anthropic", api_key="k", scope=scope)
+        self.clock.advance(301)  # both expire; create sweeps them out
+        store.create(sub="john", provider="anthropic", api_key="k", scope=scope)
+
+    def test_default_ttl_from_env(self):
+        with patch.dict("os.environ", {"KEYPROXY_SESSION_TTL": "10"}):
+            store = SessionStore(clock=self.clock)
+        session = store.create(
+            sub="john", provider="anthropic", api_key="k", scope=make_scope()
+        )
+        self.clock.advance(11)
+        with self.assertRaises(SessionError):
+            store.get(session.session_id, sub="john")
+        self.assertEqual(DEFAULT_SESSION_TTL_SECONDS, 300.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_keyproxy_streaming.py
+++ b/test_keyproxy_streaming.py
@@ -1,0 +1,266 @@
+"""Packet 3a tests: the keyproxy streaming turn endpoint.
+
+``POST /v1/providers/anthropic/messages/stream`` against a stub provider:
+delta/final/error SSE framing, per-call scope check + budget count before the
+key is attached, token-ceiling session kill, expired/unknown/wrong-sub
+rejections, the ``: ping`` heartbeat during provider silence, the
+no-compression guarantee, and the never-log assertions for the new paths.
+"""
+
+import json
+import time
+import unittest
+
+from unittest.mock import patch
+
+from test_keyproxy_service import (
+    API_KEY,
+    GENERIC,
+    KeyProxyServiceTestBase,
+    bearer,
+    chat_scope,
+)
+
+STREAM_URL = "/v1/providers/anthropic/messages/stream"
+
+FINAL_MESSAGE = {
+    "id": "msg_stub",
+    "role": "assistant",
+    "content": [{"type": "text", "text": "hello world"}],
+    "stop_reason": "end_turn",
+    "usage": {"input_tokens": 100, "output_tokens": 50},
+}
+
+
+def stub_stream(*deltas, final=None, delay=0.0, error=False):
+    """A stand-in for keyproxy.providers.anthropic.stream_turn."""
+
+    def stream_turn(api_key, **params):
+        stream_turn.calls.append((api_key, params))
+        for text in deltas:
+            if delay:
+                time.sleep(delay)
+            yield ("delta", text)
+        if error:
+            raise RuntimeError("provider blew up: " + api_key)
+        if delay:
+            time.sleep(delay)
+        yield ("final", final if final is not None else dict(FINAL_MESSAGE))
+
+    stream_turn.calls = []
+    return stream_turn
+
+
+def parse_sse(raw_text):
+    """Split an SSE body into (comment_lines, [(event, data_dict), ...])."""
+    comments, events = [], []
+    for block in raw_text.split("\n\n"):
+        event = data = None
+        for line in block.split("\n"):
+            if line.startswith(":"):
+                comments.append(line)
+            elif line.startswith("event:"):
+                event = line.split(":", 1)[1].strip()
+            elif line.startswith("data:"):
+                data = json.loads(line.split(":", 1)[1])
+        if event is not None:
+            events.append((event, data))
+    return comments, events
+
+
+class StreamingTestBase(KeyProxyServiceTestBase):
+    def open_session(self, scope=None, sub="alice"):
+        scope = scope or chat_scope()
+        response = self.redeem(self.mint_envelope(scope, sub=sub), scope, sub=sub)
+        self.assertEqual(response.status_code, 200)
+        return response.json()["session_id"]
+
+    def stream(self, session_id, sub="alice", headers=None, **overrides):
+        body = {
+            "session_id": session_id,
+            "model": "claude-fable-5",
+            "effort": "high",
+            "system": "you are a test",
+            "tools": [],
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+        body.update(overrides)
+        return self.client.post(
+            STREAM_URL, json=body, headers={**bearer(sub), **(headers or {})}
+        )
+
+
+class TestStreamingTurn(StreamingTestBase):
+    def test_delta_final_framing_and_key_attachment(self):
+        stub = stub_stream("Hello", " world")
+        with patch("keyproxy.providers.anthropic.stream_turn", stub):
+            response = self.stream(self.open_session())
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            response.headers["content-type"].startswith("text/event-stream")
+        )
+        _, events = parse_sse(response.text)
+        self.assertEqual(
+            events,
+            [
+                ("delta", {"text": "Hello"}),
+                ("delta", {"text": " world"}),
+                ("final", FINAL_MESSAGE),
+            ],
+        )
+        # The plaintext key and the mirrored turn params reached the provider.
+        (key, params), = stub.calls
+        self.assertEqual(key, API_KEY)
+        self.assertEqual(params["model"], "claude-fable-5")
+        self.assertEqual(params["effort"], "high")
+        self.assertEqual(params["max_tokens"], 8192)
+        self.assertEqual(params["system"], "you are a test")
+        self.assertEqual(params["messages"], [{"role": "user", "content": "hi"}])
+
+    def test_provider_error_is_a_generic_error_frame(self):
+        stub = stub_stream("partial", error=True)
+        with patch("keyproxy.providers.anthropic.stream_turn", stub):
+            response = self.stream(self.open_session())
+        self.assertEqual(response.status_code, 200)
+        _, events = parse_sse(response.text)
+        self.assertEqual(events[-1], ("error", {"detail": "provider error"}))
+        # The exception message carried the key — it must never surface.
+        self.assertNotIn(API_KEY, response.text)
+        self.assertNotIn("blew up", response.text)
+        self.assert_never_logged(API_KEY, "blew up")
+
+    def test_call_budget_counted_then_exhausted_then_killed(self):
+        scope = chat_scope(
+            budget={"max_calls": 2, "max_mutations": 0, "max_tokens": 250_000, "ttl": 300}
+        )
+        session_id = self.open_session(scope)
+        with patch("keyproxy.providers.anthropic.stream_turn", stub_stream("x")):
+            self.assertEqual(self.stream(session_id).status_code, 200)
+            session = self.state.sessions.get(session_id, sub="alice")
+            self.assertEqual(session.budget.calls_used, 1)
+            self.assertEqual(session.budget.tokens_used, 150)
+            self.assertEqual(self.stream(session_id).status_code, 200)
+            third = self.stream(session_id)
+        self.assertEqual(third.status_code, 400)
+        self.assertEqual(third.json()["detail"], "session call budget exhausted")
+        # Exhaustion kills the session: later calls can't even name it.
+        self.assertEqual(self.state.sessions._sessions, {})
+        fourth = self.stream(session_id)
+        self.assertEqual(fourth.status_code, 400)
+        self.assertEqual(fourth.json()["detail"], GENERIC)
+
+    def test_token_ceiling_kills_session_after_final(self):
+        scope = chat_scope(
+            budget={"max_calls": 20, "max_mutations": 0, "max_tokens": 120, "ttl": 300}
+        )
+        session_id = self.open_session(scope)
+        with patch("keyproxy.providers.anthropic.stream_turn", stub_stream("x")):
+            response = self.stream(session_id)
+        # The response that crossed the line still streams to completion...
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(parse_sse(response.text)[1][-1][0], "final")
+        # ...but the cumulative usage (150 > 120) killed the session.
+        self.assertEqual(self.state.sessions._sessions, {})
+        replayed = self.stream(session_id)
+        self.assertEqual(replayed.status_code, 400)
+        self.assertEqual(replayed.json()["detail"], GENERIC)
+
+    def test_unknown_session_rejected(self):
+        response = self.stream("deadbeef" * 4)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["detail"], GENERIC)
+
+    def test_wrong_sub_rejected(self):
+        session_id = self.open_session(sub="alice")
+        response = self.stream(session_id, sub="bob")
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["detail"], GENERIC)
+        # And the session survives for its real owner.
+        self.state.sessions.get(session_id, sub="alice")
+
+    def test_expired_session_rejected(self):
+        session_id = self.open_session()
+        session = self.state.sessions.get(session_id, sub="alice")
+        session._last_activity -= session.ttl + 1
+        response = self.stream(session_id)
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["detail"], GENERIC)
+        self.assertEqual(self.state.sessions._sessions, {})
+
+    def test_missing_bearer_is_401(self):
+        response = self.client.post(
+            STREAM_URL,
+            json={
+                "session_id": "deadbeef" * 4,
+                "model": "m",
+                "effort": "high",
+                "messages": [],
+            },
+        )
+        self.assertEqual(response.status_code, 401)
+
+    def test_malformed_body_is_generic_400(self):
+        response = self.client.post(
+            STREAM_URL, json={"session_id": "x"}, headers=bearer("alice")
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {"detail": GENERIC})
+
+    def test_no_compression_of_event_stream(self):
+        # The keyproxy half of test_keyproxy_stream_not_compressed: even when
+        # the client advertises gzip, the SSE body must come back identity —
+        # a compressor buffers until its window fills, which looks exactly
+        # like broken streaming.
+        with patch("keyproxy.providers.anthropic.stream_turn", stub_stream("x")):
+            response = self.stream(
+                self.open_session(), headers={"Accept-Encoding": "gzip"}
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("content-encoding", response.headers)
+
+    def test_streaming_paths_never_log_key_material(self):
+        token = bearer("alice")["Authorization"].split()[1]
+        session_id = self.open_session()
+        with patch("keyproxy.providers.anthropic.stream_turn", stub_stream("x")):
+            self.assertEqual(self.stream(session_id).status_code, 200)
+        self.stream("deadbeef" * 4)  # rejection path
+        self.assert_never_logged(API_KEY, token)
+        allowlist = [m for m in self.logged_messages() if "turn streamed" in m]
+        self.assertEqual(len(allowlist), 1)
+        self.assertIn("correlation_id=", allowlist[0])
+        self.assertIn("sub=alice", allowlist[0])
+        self.assertIn("provider=anthropic", allowlist[0])
+        self.assertIn("tokens=150", allowlist[0])
+        # Beyond the allowlisted summary lines ("session redeemed" from the
+        # 2b redemption, "turn streamed" from this packet), the streaming
+        # paths — including the rejection — emit no keyproxy records at all.
+        unexpected = [
+            r.getMessage()
+            for r in self.log_handler.records
+            if r.name.startswith("keyproxy")
+            and "turn streamed" not in r.getMessage()
+            and "session redeemed" not in r.getMessage()
+        ]
+        self.assertEqual(unexpected, [])
+
+
+class TestStreamingHeartbeat(StreamingTestBase):
+    extra_env = {"KEYPROXY_HEARTBEAT_SECS": "0.05"}
+
+    def test_heartbeat_comments_during_provider_silence(self):
+        stub = stub_stream("late delta", delay=0.25)
+        with patch("keyproxy.providers.anthropic.stream_turn", stub):
+            response = self.stream(self.open_session())
+        self.assertEqual(response.status_code, 200)
+        comments, events = parse_sse(response.text)
+        self.assertTrue(
+            any(c.startswith(": ping") for c in comments),
+            f"expected ': ping' heartbeats on the wire, got {comments!r}",
+        )
+        # Heartbeats are comments — the event framing is untouched by them.
+        self.assertEqual(events[0], ("delta", {"text": "late delta"}))
+        self.assertEqual(events[-1][0], "final")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements the BYOK (Bring Your Own LLM API Key) plan — [`docs/proposals/byok-key-proxy-plan.md`](docs/proposals/byok-key-proxy-plan.md), issue #100 — phases 2 through 8a, one commit per phase (phases 1a/1b landed earlier in #102/#103). Per-phase detail is logged as checkpoint comments on #100.

## What this adds

- **Keyproxy service (`keyproxy/`)** — a lean, isolated FastAPI service that is the *only* place user API keys are ever decrypted: ECDH-ES envelope decryption, per-turn replay protection, in-memory redemption sessions, scope enforcement, token budgets, and an Anthropic streaming provider. A strict **never-log policy** (no keys, envelopes, auth headers, or credential-bearing exception dumps in any log) is enforced by tests on every failure path.
- **Streaming pass-through** — `/api/chat` accepts a `key_envelope` + `scope`, exchanges it with the keyproxy for a redemption session, and streams SSE back with no buffering/compression (heartbeats included); `KeyProxyChatClient` slots into the existing chat-tier via the services registry.
- **Browser key vault (`frontend/src/vault/`)** — keys live client-side in IndexedDB, PBKDF2-passphrase-wrapped, envelope-encrypted to the keyproxy's pinned public key before ever leaving the browser. Settings UI for add/rotate/unlock/remove.
- **Page hardening** — CSP + Trusted Types in the Express server (landed before any real key could be pasted).
- **Per-user ES256 identity** — quantui's Express verifies the IAP assertion against Google's JWKS and mints short-lived ES256 user JWTs; `api/auth.py` (dual-mode) and the keyproxy (ES256-only) verify with the public key and can't mint. Algorithm-confusion probes in tests. Note: `cryptography` moved into `requirements-base.txt` (PyJWT needs it for ES256).
- **CI/CD (packet 8a)** — `build-keyproxy` in cloudbuild, guarded image-only deploys in `deploy.yml`/`prod-rollout.yml` (first deploy stays the manual 8b runbook), the Express auth tests wired into `frontend-gate`, and a **gitleaks secret-scan job** gating deploys with a deliberately narrow `.gitleaks.toml` allowlist (full 256-commit history scans clean locally; planted anthropic/AWS/PEM fakes all caught).

## Verification

- Backend: 587 tests green; frontend: 167 vitest + coverage thresholds; Express server: 14 `node --test`; compose E2E exercised via `runUI-CONTAINERS.sh`.
- This PR's CI run is itself part of the 8a Verify block; the throwaway-branch planted-secret proof of the gitleaks job remains a follow-up.

## Not in this PR

- Packet 8b (manual first-deploy runbook: dedicated runtime SA, `keyproxy-private-key` secrets, IAM-locked invoker) — interactive, per plan.
- Phase 7 deploy-time steps (`quantui-signing-key`/`-pub` secrets, `QUANTUI_IAP_AUDIENCE`, public-key mounts, two-IAP-user cloud E2E).

Closes #100? **No** — leave #100 open until 8b lands; it tracks the deploy runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)