### PR TITLE
BYOK packet 8b prep: Google ID-token IAM hop + cloud UI SPKI pin wiring

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -23,6 +23,15 @@ substitutions:
   _PROJECT: quantcore-test-20260606
   _REPO: quantcore
   _TAG: latest
+  # BYOK packet 8b — SPKI pins for the browser envelope layer, baked into the
+  # UI bundle at build time (frontend/src/vault/envelope.ts refuses to encrypt
+  # against any key not on this list). BOTH projects' pins ride in the one
+  # image because prod promotion copies it by digest (never rebuilds): the
+  # test keyproxy's kp-2026-07-test pin first, prod's kp-2026-07-prod second.
+  # Pins are public values (SHA-256 of a public key). On rotation, ship
+  # old+new here, add the new PEM to the keyproxy-private-key secret bundle,
+  # then drop the old pin in the next release.
+  _VITE_KEYPROXY_SPKI_PINS: "pzWt6lfgPH4Ef8CVZUzW3GXo88v5MRKKPQq9IQe4VqE,3YQ7LqMEiKf_-FBcoui-kfDjHJQgV-QzyrmDOcDNxGY"
 
 options:
   machineType: E2_HIGHCPU_8         # faster torch image build
@@ -78,6 +87,8 @@ steps:
       - build
       - -f
       - Dockerfile.ui
+      - --build-arg
+      - VITE_KEYPROXY_SPKI_PINS=${_VITE_KEYPROXY_SPKI_PINS}
       - -t
       - ${_REGION}-docker.pkg.dev/${_PROJECT}/${_REPO}/quantcore-ui:${_TAG}
       - -t

--- a/quantcore/gateways/keyproxy_gateway.py
+++ b/quantcore/gateways/keyproxy_gateway.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 import json
 import os
 import threading
+import time
 from typing import Iterator, Optional
 
 import httpx
@@ -92,13 +93,61 @@ def _shared_client() -> httpx.Client:
         return _client
 
 
+# --- Google IAM layer (packet 8b) -----------------------------------------
+#
+# On Cloud Run the keyproxy is deployed --no-allow-unauthenticated, so every
+# hop must ALSO carry a Google-signed ID token (defense-in-depth layer 1).
+# It rides in X-Serverless-Authorization — Cloud Run's front end verifies and
+# strips that header, which leaves Authorization free for the user's ES256
+# JWT that the keyproxy app itself verifies (layer 2). Activation is explicit
+# via KEYPROXY_ID_TOKEN_AUDIENCE (set to the keyproxy service URL on the
+# quantcore-api service); local/compose stacks leave it unset and skip the
+# IAM layer entirely. Google ID tokens live 1 h — cache and refresh early so
+# the metadata-server round-trip is off the per-request path.
+
+_ID_TOKEN_AUDIENCE_ENV = "KEYPROXY_ID_TOKEN_AUDIENCE"
+_ID_TOKEN_TTL_SECONDS = 50 * 60
+
+_id_token_lock = threading.Lock()
+_id_token_cache: Optional[tuple[str, float]] = None  # (token, monotonic fetch time)
+
+
+def _google_id_token() -> Optional[str]:
+    audience = os.environ.get(_ID_TOKEN_AUDIENCE_ENV)
+    if not audience:
+        return None
+    global _id_token_cache
+    with _id_token_lock:
+        now = time.monotonic()
+        if _id_token_cache is not None and now - _id_token_cache[1] < _ID_TOKEN_TTL_SECONDS:
+            return _id_token_cache[0]
+        try:
+            from google.auth.transport import requests as google_auth_requests
+            from google.oauth2 import id_token as google_id_token
+
+            token = google_id_token.fetch_id_token(
+                google_auth_requests.Request(), audience
+            )
+        except Exception:
+            # Never-log policy: google-auth exceptions can embed request and
+            # response material, so the cause is dropped — the constant
+            # user-facing message is all that propagates.
+            raise KeyProxyError(UNAVAILABLE_MESSAGE) from None
+        _id_token_cache = (token, now)
+        return token
+
+
 def _headers(auth_token: str) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    id_token = _google_id_token()
+    if id_token:
+        headers["X-Serverless-Authorization"] = f"Bearer {id_token}"
     # An empty token (AUTH_DISABLED dev stacks) must omit the header entirely:
     # "Bearer " with no token is an illegal header value that h11 rejects
     # client-side before the request is ever sent.
-    if not auth_token:
-        return {}
-    return {"Authorization": f"Bearer {auth_token}"}
+    if auth_token:
+        headers["Authorization"] = f"Bearer {auth_token}"
+    return headers
 
 
 def _error_message(status_code: int, detail: object) -> str:
@@ -261,7 +310,8 @@ class KeyProxyChatClient:
                 f"{_base_url()}/v1/sessions/{session_id}",
                 headers=_headers(self._auth_token),
             )
-        except httpx.HTTPError:
+        except (httpx.HTTPError, KeyProxyError):
+            # Best-effort includes an ID-token fetch failure — TTL backstop.
             pass
 
     # -- the protocol method ------------------------------------------------
@@ -321,7 +371,11 @@ class KeyProxyChatClient:
 def get_public_keys() -> list[dict]:
     """``GET /v1/publickey`` — the envelope encryption keys, newest first."""
     try:
-        response = _shared_client().get(f"{_base_url()}/v1/publickey")
+        # No user token — the endpoint is public at the app layer — but the
+        # Cloud Run IAM layer still requires the Google ID token.
+        response = _shared_client().get(
+            f"{_base_url()}/v1/publickey", headers=_headers("")
+        )
     except httpx.HTTPError:
         raise KeyProxyError(UNAVAILABLE_MESSAGE) from None
     if response.status_code != 200:

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -27,3 +27,7 @@ PyJWT>=2.8.0
 # verification only — the envelope private-key material and the decryption
 # code path remain confined to the keyproxy service (invariant #1).
 cryptography>=42.0.0
+# BYOK packet 8b: the keyproxy gateway fetches a Google-signed ID token from
+# the metadata server (X-Serverless-Authorization) to pass the IAM-locked
+# keyproxy's Cloud Run front end. Inert unless KEYPROXY_ID_TOKEN_AUDIENCE is set.
+google-auth>=2.0.0

--- a/test_keyproxy_gateway.py
+++ b/test_keyproxy_gateway.py
@@ -343,6 +343,12 @@ class TestPubkeyAndValidate(GatewayTestBase):
 
 
 class TestAuthHeaders(unittest.TestCase):
+    def setUp(self):
+        os.environ.pop("KEYPROXY_ID_TOKEN_AUDIENCE", None)
+        keyproxy_gateway._id_token_cache = None
+        self.addCleanup(os.environ.pop, "KEYPROXY_ID_TOKEN_AUDIENCE", None)
+        self.addCleanup(setattr, keyproxy_gateway, "_id_token_cache", None)
+
     def test_empty_token_omits_the_header_entirely(self):
         # AUTH_DISABLED dev stacks pass auth_token="" — "Bearer " with no
         # token is an illegal header value that h11 rejects client-side, so
@@ -354,6 +360,81 @@ class TestAuthHeaders(unittest.TestCase):
             keyproxy_gateway._headers("tok-123"),
             {"Authorization": "Bearer tok-123"},
         )
+
+
+class TestGoogleIdTokenLayer(unittest.TestCase):
+    """Packet 8b: the Cloud Run IAM hop (X-Serverless-Authorization).
+
+    Only active when KEYPROXY_ID_TOKEN_AUDIENCE is set — every test above and
+    below this class runs with it unset, pinning that local/compose behavior
+    is completely unchanged.
+    """
+
+    AUDIENCE = "https://keyproxy.example.run.app"
+
+    def setUp(self):
+        os.environ["KEYPROXY_ID_TOKEN_AUDIENCE"] = self.AUDIENCE
+        keyproxy_gateway._id_token_cache = None
+        self.addCleanup(os.environ.pop, "KEYPROXY_ID_TOKEN_AUDIENCE", None)
+        self.addCleanup(setattr, keyproxy_gateway, "_id_token_cache", None)
+
+    def test_id_token_rides_serverless_header_user_jwt_keeps_authorization(self):
+        with patch("google.oauth2.id_token.fetch_id_token", return_value="idtok") as fetch:
+            self.assertEqual(
+                keyproxy_gateway._headers("user-jwt"),
+                {
+                    "X-Serverless-Authorization": "Bearer idtok",
+                    "Authorization": "Bearer user-jwt",
+                },
+            )
+        # Audience is the keyproxy service URL (what Cloud Run IAM checks).
+        self.assertEqual(fetch.call_args.args[1], self.AUDIENCE)
+
+    def test_publickey_style_calls_carry_only_the_id_token(self):
+        with patch("google.oauth2.id_token.fetch_id_token", return_value="idtok"):
+            self.assertEqual(
+                keyproxy_gateway._headers(""),
+                {"X-Serverless-Authorization": "Bearer idtok"},
+            )
+
+    def test_token_is_cached_across_requests(self):
+        with patch("google.oauth2.id_token.fetch_id_token", return_value="idtok") as fetch:
+            keyproxy_gateway._headers("a")
+            keyproxy_gateway._headers("b")
+        self.assertEqual(fetch.call_count, 1)
+
+    def test_token_is_refetched_after_ttl(self):
+        with patch("google.oauth2.id_token.fetch_id_token", return_value="idtok") as fetch:
+            keyproxy_gateway._headers("a")
+            token, fetched_at = keyproxy_gateway._id_token_cache
+            keyproxy_gateway._id_token_cache = (
+                token,
+                fetched_at - keyproxy_gateway._ID_TOKEN_TTL_SECONDS - 1,
+            )
+            keyproxy_gateway._headers("a")
+        self.assertEqual(fetch.call_count, 2)
+
+    def test_fetch_failure_is_a_clean_silent_error(self):
+        # Never-log policy: google-auth exceptions can embed request/response
+        # material — nothing may be logged, and the raised error must carry
+        # only the constant user-facing message, never the cause's text.
+        boom = RuntimeError("metadata response body with sensitive-material")
+        with patch("google.oauth2.id_token.fetch_id_token", side_effect=boom):
+            with self.assertNoLogs(level="DEBUG"):
+                with self.assertRaises(keyproxy_gateway.KeyProxyError) as ctx:
+                    keyproxy_gateway._headers("user-jwt")
+        self.assertEqual(str(ctx.exception), keyproxy_gateway.UNAVAILABLE_MESSAGE)
+        self.assertIsNone(ctx.exception.__cause__)
+        self.assertNotIn("sensitive-material", repr(ctx.exception))
+
+    def test_close_stays_best_effort_when_the_fetch_fails(self):
+        client = keyproxy_gateway.KeyProxyChatClient(
+            envelope={}, scope={}, auth_token="t", model="m", effort="low",
+        )
+        client._session_id = "sess-1"
+        with patch("google.oauth2.id_token.fetch_id_token", side_effect=RuntimeError):
+            client.close()  # must not raise
+        self.assertIsNone(client._session_id)
 
 
 class TestKeyProxyServiceThin(unittest.TestCase):


### PR DESCRIPTION
Closes the two gaps between main and an IAM-locked keyproxy deploy (BYOK plan #100, packet 8b pre-flight):

## 1. Google ID-token attach in the keyproxy gateway

The plan's defense-in-depth layer 1 has quantcore-api present a Google-signed ID token to the `--no-allow-unauthenticated` keyproxy — that code was never written, so the first IAM-locked deploy would have 401'd every call at the Cloud Run front end.

- `quantcore/gateways/keyproxy_gateway.py` now fetches an ID token from the metadata server (`google-auth`) when `KEYPROXY_ID_TOKEN_AUDIENCE` is set, cached ~50 min, sent in **`X-Serverless-Authorization`** — Cloud Run verifies + strips it, leaving `Authorization` free for the user's ES256 JWT (layer 2).
- `GET /v1/publickey` now carries the same headers (public at the app layer, IAM-locked at the platform layer).
- `close()` stays best-effort if the fetch fails (session TTL is the backstop).
- Local/compose stacks leave the env unset — unchanged behavior is pinned by the existing header tests.
- Never-log policy on the new failure path: the google-auth cause is dropped (`from None`), only the constant user-facing message propagates — asserted with `assertNoLogs` + `__cause__ is None`.
- `google-auth>=2.0.0` joins requirements-base.txt (inert unless the audience env is set).

## 2. SPKI pins baked into the cloud UI build

`Dockerfile.ui` has accepted `VITE_KEYPROXY_SPKI_PINS` since packet 6, but cloudbuild.yaml never passed it — the deployed SPA had an empty pin list and `envelope.ts` refuses to encrypt with no pins.

- `build-ui` now passes `--build-arg VITE_KEYPROXY_SPKI_PINS=${_VITE_KEYPROXY_SPKI_PINS}`, defaulting to **both** projects' pins (`kp-2026-07-test`, `kp-2026-07-prod`) since prod promotion copies the UI image by digest and never rebuilds. Pins are public values (SHA-256 of a public key); rotation is the documented dual-pin dance.

Both keypairs were generated and piped straight into each project's `keyproxy-private-key` Secret Manager secret (never on disk); the manual 8b runbook deploy follows once this lands.

612 backend tests pass locally (21 in the gateway suite, 6 new); gitleaks clean on the range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)