### PR TITLE
fix: QuantUI Securities prices are one session stale (exclusive yf.download end bound)

### DIFF
--- a/quantcore/gateways/yfinance_gateway.py
+++ b/quantcore/gateways/yfinance_gateway.py
@@ -20,6 +20,8 @@ import threading
 import pandas as pd
 import yfinance as yf
 
+from quantcore.analytics.market_time import ET
+
 logger = logging.getLogger(__name__)
 
 _YF_DOWNLOAD_LOCK = threading.Lock()
@@ -59,7 +61,13 @@ class YFinanceGateway:
         frame when Yahoo returns nothing. Window capped at _MAX_FETCH_DAYS.
         """
         fetch_days = min(days, _MAX_FETCH_DAYS)
-        end = datetime.datetime.utcnow()
+        # yf.download's `end` bound is EXCLUSIVE, so it must sit one day past the
+        # session we want; passing today silently drops today's bar and the cache
+        # can then only ever serve the previous close. Anchor to the ET market
+        # date, not UTC — utcnow() rolls over at 20:00 ET and would otherwise
+        # shift the window mid-evening.
+        today_et = datetime.datetime.now(tz=ET).date()
+        end = today_et + datetime.timedelta(days=1)
         start = end - datetime.timedelta(days=fetch_days)
         with _YF_DOWNLOAD_LOCK:
             df = yf.download(

--- a/test_price_freshness.py
+++ b/test_price_freshness.py
@@ -1,0 +1,119 @@
+"""Regression tests for daily-bar freshness — the current session must be fetchable.
+
+The QuantUI Securities page showed prices that lagged Yahoo Finance. Root cause:
+``YFinanceGateway.fetch_history`` passed ``end=utcnow().date()`` to ``yf.download``,
+whose ``end`` bound is **exclusive**. Today's daily bar therefore fell outside every
+request window and could never enter the OHLCV cache, so every cache-backed surface
+(``/ohlcv``, ``/technicals`` and the Securities grid's ``last_close``) served the
+previous session's close.
+
+Two independent defects are pinned here:
+
+1. **Exclusive end bound** — the window must extend *past* the current session.
+2. **UTC vs ET session date** — ``utcnow()`` rolls to the next calendar date at
+   20:00 ET, so the bug self-healed for the last four hours of each evening and
+   reappeared every morning. The window must be anchored to the ET market date.
+
+Both are provider-API translation concerns, so they live in the gateway (standard
+§5.3 / Rule 3) — no business logic is added there. Everything is mocked: no
+network, no DB. The live cross-surface oracle is ``test_price_freshness_live.py``.
+"""
+import datetime
+import unittest
+from unittest.mock import patch
+
+import pandas as pd
+
+from quantcore.analytics.market_time import ET
+from quantcore.gateways.yfinance_gateway import YFinanceGateway
+
+# A well-formed two-bar frame; these tests only assert on the request window.
+_FRAME = pd.DataFrame(
+    {"Open": [1.0, 2.0], "High": [1.0, 2.0], "Low": [1.0, 2.0],
+     "Close": [1.0, 2.0], "Volume": [10, 20]},
+    index=pd.to_datetime(["2026-07-17", "2026-07-20"]),
+)
+
+
+class FetchWindowTest(unittest.TestCase):
+    """The request window handed to yf.download must cover the current session."""
+
+    def _captured_window(self, now_utc: datetime.datetime) -> tuple[datetime.date, datetime.date]:
+        """Run fetch_history with a frozen clock; return the (start, end) it requested."""
+        captured: dict[str, str] = {}
+
+        def fake_download(symbol, **kwargs):
+            captured.update(kwargs)
+            return _FRAME
+
+        class FrozenDateTime(datetime.datetime):
+            @classmethod
+            def utcnow(cls):
+                return now_utc
+
+            @classmethod
+            def now(cls, tz=None):
+                aware = now_utc.replace(tzinfo=datetime.timezone.utc)
+                return aware.astimezone(tz) if tz else aware
+
+        with patch("quantcore.gateways.yfinance_gateway.yf.download", fake_download), \
+             patch("quantcore.gateways.yfinance_gateway.datetime.datetime", FrozenDateTime):
+            YFinanceGateway().fetch_history("AAPL", "1d", 30)
+
+        return (
+            datetime.date.fromisoformat(captured["start"]),
+            datetime.date.fromisoformat(captured["end"]),
+        )
+
+    def test_window_end_is_exclusive_so_must_pass_current_session(self):
+        """Mid-session: yf.download's end bound is exclusive, so end must be > today."""
+        # Monday 2026-07-20, 14:00 UTC == 10:00 ET — market open, today's bar exists.
+        _, end = self._captured_window(datetime.datetime(2026, 7, 20, 14, 0))
+        self.assertGreater(
+            end, datetime.date(2026, 7, 20),
+            "yf.download's `end` is exclusive — an end of today silently drops "
+            "today's bar, which is exactly the stale-price bug",
+        )
+
+    def test_window_anchored_to_et_date_not_utc_date(self):
+        """After 20:00 ET the UTC date is already tomorrow; the window must not shift."""
+        # Monday 2026-07-20, 23:30 UTC == 19:30 ET. utcnow() still reads 07-20 here,
+        # but at 00:30 UTC (20:30 ET) it reads 07-21 — the same ET session, a
+        # different UTC date. Both must produce a window covering the 07-20 session.
+        _, end_evening = self._captured_window(datetime.datetime(2026, 7, 20, 23, 30))
+        _, end_after_rollover = self._captured_window(datetime.datetime(2026, 7, 21, 0, 30))
+
+        self.assertGreater(end_evening, datetime.date(2026, 7, 20))
+        self.assertGreater(
+            end_after_rollover, datetime.date(2026, 7, 20),
+            "the UTC-date rollover at 20:00 ET must not change which session is fetched",
+        )
+
+    def test_window_covers_requested_lookback(self):
+        """The start bound must still honour the caller's `days` argument."""
+        start, end = self._captured_window(datetime.datetime(2026, 7, 20, 14, 0))
+        self.assertGreaterEqual(
+            (end - start).days, 30,
+            "the fetch window must span at least the requested lookback",
+        )
+
+
+class CurrentSessionBarSurvivesTest(unittest.TestCase):
+    """A returned current-session bar must not be filtered out downstream."""
+
+    def test_todays_bar_is_returned_to_the_caller(self):
+        today_et = datetime.datetime.now(tz=ET).date()
+        frame = pd.DataFrame(
+            {"Open": [1.0], "High": [2.0], "Low": [0.5], "Close": [1.5], "Volume": [99]},
+            index=pd.to_datetime([today_et.isoformat()]),
+        )
+        with patch("quantcore.gateways.yfinance_gateway.yf.download", return_value=frame):
+            out = YFinanceGateway().fetch_history("AAPL", "1d", 30)
+
+        self.assertFalse(out.empty, "today's bar was dropped by the gateway")
+        self.assertEqual(pd.Timestamp(out.index[-1]).date(), today_et)
+        self.assertAlmostEqual(float(out["Close"].iloc[-1]), 1.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_price_freshness_live.py
+++ b/test_price_freshness_live.py
@@ -1,0 +1,198 @@
+"""Live cross-surface price-parity oracle: yfinance vs the REST tier vs the MCP tools.
+
+This is the test that would have caught the stale Securities-page price directly.
+It establishes an independent ground truth by calling yfinance itself, then asserts
+that both remote surfaces agree with it for a handful of reference symbols:
+
+    ground truth (yfinance)  ==  REST tier  ==  MCP wrapper
+
+Surfaces exercised, per the layering in architectural-standard-v2 §5.4/§5.5 and
+Rule 6 (``AI Agent → MCP wrapper → REST tier → Service``):
+
+* ``GET /api/securities/{t}/ohlcv``      — cache-backed daily bars
+* ``GET /api/securities/{t}/technicals`` — cache-backed ``last_close`` (the Securities grid)
+* ``GET /api/securities/{t}/price-summary`` — live quote path
+* MCP ``get_stock_price`` — driven through ``rest_client`` against the same app,
+  so the wrapper's real tool body and path construction are covered rather than bypassed
+
+The primary assertion is **bar-date equality**, not price tolerance: a stale cache
+reports an older session, which is deterministic to detect, whereas a price
+tolerance alone can pass on a flat day. Close values are then compared within a
+small tolerance to catch symbol misalignment (the 2026-06-30 corruption class).
+
+This test performs real network I/O and needs a database, so it is **opt-in** and
+skipped by default — CI stays hermetic and free of Yahoo rate-limit flake:
+
+    QUANTCORE_LIVE_PRICE_TESTS=1 .venv/bin/python -m unittest test_price_freshness_live
+
+Importing yfinance here is deliberate and allowed: root-level test modules sit
+outside the ``test_architecture_guards.py`` fence, and the whole point of this
+module is to hold an oracle that is *independent* of YFinanceGateway.
+"""
+import datetime
+import os
+import unittest
+from pathlib import Path
+
+LIVE = os.environ.get("QUANTCORE_LIVE_PRICE_TESTS") == "1"
+
+# Point at the test DB before quantcore.db freezes DB_DSN at import time, matching
+# the convention in test_api_smoke.py / test_support_tools_adapters.py.
+_env_file = Path(__file__).parent / ".env"
+if _env_file.exists():
+    for _line in _env_file.read_text().splitlines():
+        if _line.strip().startswith("QUANTCORE_TEST_DB_DSN="):
+            os.environ["QUANTCORE_DB_DSN"] = _line.split("=", 1)[1].strip()
+            break
+
+# Reference symbols: highly liquid, never halted, no thin-volume gaps.
+REFERENCE_SYMBOLS = ["AAPL", "MSFT", "SPY"]
+
+# Daily closes must agree to within this fraction of the ground-truth close.
+CLOSE_TOLERANCE = 0.005  # 0.5%
+# The live quote may legitimately drift from the last daily close intraday.
+QUOTE_TOLERANCE = 0.05  # 5%
+
+
+def _truth_last_bar(symbol: str) -> tuple[datetime.date, float]:
+    """Ground truth: the most recent daily bar yfinance will return, fetched with an
+    explicitly inclusive end bound so the current session is never excluded."""
+    import yfinance as yf  # noqa: PLC0415 — intentionally independent of the gateway
+
+    end = datetime.date.today() + datetime.timedelta(days=2)
+    start = end - datetime.timedelta(days=30)
+    df = yf.download(
+        symbol,
+        start=start.isoformat(),
+        end=end.isoformat(),
+        interval="1d",
+        auto_adjust=True,
+        progress=False,
+    )
+    if df is None or df.empty:
+        raise unittest.SkipTest(f"yfinance returned no data for {symbol}")
+    if hasattr(df.columns, "levels"):  # flatten MultiIndex from newer yfinance
+        df.columns = df.columns.get_level_values(0)
+    return df.index[-1].date(), float(df["Close"].iloc[-1])
+
+
+@unittest.skipUnless(LIVE, "set QUANTCORE_LIVE_PRICE_TESTS=1 to run live price-parity checks")
+class LivePriceParityTest(unittest.TestCase):
+    """Every remote surface must report the same session as yfinance itself."""
+
+    @classmethod
+    def setUpClass(cls):
+        from fastapi.testclient import TestClient
+
+        from api.main import create_app
+
+        cls.client = TestClient(create_app())
+        cls.truth = {s: _truth_last_bar(s) for s in REFERENCE_SYMBOLS}
+
+    # -- REST tier -----------------------------------------------------------
+
+    def test_rest_ohlcv_returns_the_current_session(self):
+        for symbol in REFERENCE_SYMBOLS:
+            with self.subTest(symbol=symbol):
+                truth_date, truth_close = self.truth[symbol]
+
+                resp = self.client.get(f"/api/securities/{symbol}/ohlcv", params={"days": 30})
+                self.assertEqual(resp.status_code, 200, resp.text)
+                bars = resp.json()["bars"]
+                self.assertTrue(bars, f"no bars returned for {symbol}")
+
+                last = bars[-1]
+                self.assertEqual(
+                    datetime.date.fromisoformat(last["date"]), truth_date,
+                    f"{symbol}: REST /ohlcv is a stale session — served {last['date']}, "
+                    f"yfinance has {truth_date}",
+                )
+                self.assertLessEqual(
+                    abs(last["close"] - truth_close) / truth_close, CLOSE_TOLERANCE,
+                    f"{symbol}: close {last['close']} disagrees with yfinance {truth_close}",
+                )
+
+    def test_rest_technicals_last_close_matches_yfinance(self):
+        """This is the value behind the Securities grid's price."""
+        for symbol in REFERENCE_SYMBOLS:
+            with self.subTest(symbol=symbol):
+                _, truth_close = self.truth[symbol]
+
+                resp = self.client.get(f"/api/securities/{symbol}/technicals")
+                self.assertEqual(resp.status_code, 200, resp.text)
+                indicators = resp.json().get("indicators") or []
+                self.assertTrue(indicators, f"no indicators returned for {symbol}")
+
+                last_close = indicators[-1].get("last_close", indicators[-1].get("close"))
+                self.assertIsNotNone(last_close, f"{symbol}: no close in technicals row")
+                self.assertLessEqual(
+                    abs(last_close - truth_close) / truth_close, CLOSE_TOLERANCE,
+                    f"{symbol}: Securities-grid close {last_close} disagrees with "
+                    f"yfinance {truth_close} — the stale-price symptom",
+                )
+
+    def test_rest_price_summary_tracks_the_live_quote(self):
+        for symbol in REFERENCE_SYMBOLS:
+            with self.subTest(symbol=symbol):
+                _, truth_close = self.truth[symbol]
+
+                resp = self.client.get(f"/api/securities/{symbol}/price-summary")
+                self.assertEqual(resp.status_code, 200, resp.text)
+                price = resp.json()["price"]
+                self.assertLessEqual(
+                    abs(price - truth_close) / truth_close, QUOTE_TOLERANCE,
+                    f"{symbol}: quote {price} is far from the last close {truth_close}",
+                )
+
+    # -- MCP wrapper (Rule 6: wrapper → REST tier) ---------------------------
+
+    def test_mcp_get_stock_price_agrees_with_rest_and_yfinance(self):
+        """Drive the real MCP tool body, with its HTTP seam pointed at this app."""
+        from unittest.mock import patch
+
+        from fastMCPTest import stock_price_server
+
+        def routed_get(path, params=None, **_kwargs):
+            resp = self.client.get(path, params=params or {})
+            resp.raise_for_status()
+            return resp.json()
+
+        for symbol in REFERENCE_SYMBOLS:
+            with self.subTest(symbol=symbol):
+                _, truth_close = self.truth[symbol]
+
+                with patch.object(stock_price_server.rest_client, "get", routed_get):
+                    result = stock_price_server.get_stock_price(symbol)
+
+                self.assertEqual(result["symbol"], symbol)
+                self.assertLessEqual(
+                    abs(result["price"] - truth_close) / truth_close, QUOTE_TOLERANCE,
+                    f"{symbol}: MCP price {result['price']} disagrees with yfinance "
+                    f"{truth_close}",
+                )
+
+    def test_surfaces_do_not_disagree_with_each_other(self):
+        """REST and MCP must not drift apart — they are the same service call."""
+        from unittest.mock import patch
+
+        from fastMCPTest import stock_price_server
+
+        def routed_get(path, params=None, **_kwargs):
+            resp = self.client.get(path, params=params or {})
+            resp.raise_for_status()
+            return resp.json()
+
+        for symbol in REFERENCE_SYMBOLS:
+            with self.subTest(symbol=symbol):
+                rest = self.client.get(f"/api/securities/{symbol}/price-summary").json()
+                with patch.object(stock_price_server.rest_client, "get", routed_get):
+                    mcp = stock_price_server.get_stock_price(symbol)
+
+                self.assertLessEqual(
+                    abs(rest["price"] - mcp["price"]) / rest["price"], QUOTE_TOLERANCE,
+                    f"{symbol}: REST and MCP surfaces disagree",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Symptom

The price on the QuantUI Securities page disagrees with Yahoo Finance. Measured on 2026-07-20 for AAPL: **333.74 (bar dated 2026-07-17) vs Yahoo live 326.59 — 2.2% stale.**

## Root cause

The instinct that it was the OHLCV caching mechanism was right, but the defect is one layer below the cache — in the fetch window, so the cache was never *offered* today's bar in the first place.

`yf.download`'s `end` parameter is **exclusive**. `YFinanceGateway.fetch_history` passed:

```python
end = datetime.datetime.utcnow()
... yf.download(symbol, start=..., end=end.strftime("%Y-%m-%d"), ...)
```

Passing today as an exclusive bound silently drops today's bar. Every cache-backed surface — `/api/securities/{t}/ohlcv`, `/technicals`, and the `last_close` behind the Securities grid — could therefore only ever serve the previous session's close.

**Second, compounding defect:** the window was anchored to UTC. `utcnow()` rolls to the next calendar date at 20:00 ET, so the window was *accidentally correct* between 20:00 ET and midnight. The bug self-healed every evening and reappeared every morning — which is why it reads as intermittent.

**Side effect:** `PricesService.get_history`'s staleness check (`latest_closed_ts` date < `latest_completed_session()`) fired a fetch on *every* call that then returned nothing new — a permanent wasted-network loop that could never converge.

## Fix

One file, in `quantcore/gateways/yfinance_gateway.py`:

```python
today_et = datetime.datetime.now(tz=ET).date()
end = today_et + datetime.timedelta(days=1)
start = end - datetime.timedelta(days=fetch_days)
```

`start` is derived from `end` rather than from today, so the covered span stays exactly `fetch_days` and the existing `_MAX_FETCH_DAYS = 730` cap contract holds (`test_yfinance_gateway.test_window_capped_at_max_fetch_days` catches this if it ever drifts).

### Placement rationale (architectural-standard-v2)

- **Rule 3** — the gateway is the right home: this is provider-API *semantics translation* (Yahoo's exclusive bound), not a business rule.
- **Rule 5** — caching policy stays in `PricesService.get_history`, untouched.
- **Rule 6** — the MCP surface is tested through the real tool body with its `rest_client` seam routed at the TestClient, so the `AI Agent → MCP wrapper → REST tier → Service` path is exercised rather than bypassed.

### Remediation of existing bad data

None needed — this is self-healing. `get_history`'s staleness check already fires a fetch on stale symbols; the corrected window now actually returns today's bar and upserts it.

## Tests

**`test_price_freshness.py`** — hermetic (no network, no DB), safe for CI. Pins both defects: the exclusive end bound, and ET-vs-UTC anchoring (asserts a 23:30 UTC and a 00:30 UTC call on the same ET session produce the same window). **Verified to fail against the unfixed gateway before the fix was applied** (2 failures / 2 passes).

**`test_price_freshness_live.py`** — the cross-surface parity oracle requested in the issue: REST, MCP, and a direct `yfinance` call must agree for AAPL / MSFT / SPY. Primary assertion is **bar-date equality** (deterministic) plus close-within-tolerance, which also catches symbol misalignment. Gated behind `QUANTCORE_LIVE_PRICE_TESTS=1` so CI stays hermetic and free of Yahoo rate-limit flake — there was no prior convention for live-network tests, so this establishes one.

Note this file imports `yfinance` directly, as an independent oracle. That is legitimate: `test_architecture_guards.py`'s yfinance fence scans `quantcore/`, `api/`, `fastMCPTest/`, `scripts/`, `mcp_gateway/`, `main.py`, and `notifier.py` — root-level `test_*.py` are outside it by design.

### Results

Live parity, post-fix, all three symbols at 0.000% delta vs Yahoo:

```
AAPL: gateway last bar 2026-07-20 close=326.59 | yahoo live=326.59 | delta=0.000%
MSFT: gateway last bar 2026-07-20 close=402.29 | yahoo live=402.29 | delta=0.000%
SPY:  gateway last bar 2026-07-20 close=742.09 | yahoo live=742.09 | delta=0.000%
```

- `QUANTCORE_LIVE_PRICE_TESTS=1 python -m unittest test_price_freshness_live` → **5 tests, OK** (against live Yahoo + prod DB)
- `python -m unittest test_yfinance_gateway test_price_freshness test_prices_history_policy test_market_time` → **31 tests, OK**
- Full suite: failure set is **byte-identical before and after** the change (58 pre-existing environmental failures — no local Postgres, uvicorn cannot bind; concentrated in `test_keyproxy_gateway`, `test_options_contract_tools`, `test_portfolio_service`, `test_harvester_service`, `test_options_repository`, `test_oi_change_tools`). No regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)