### PR TITLE
keyproxy: log safe diagnostic metadata on provider stream failure

### DIFF
--- a/keyproxy/main.py
+++ b/keyproxy/main.py
@@ -15,10 +15,13 @@ Run with:  uvicorn keyproxy.main:app --host 127.0.0.1 --port 5002
 
 Logging policy (enforced by tests): every rejection is a generic 400/401/429
 with a constant detail string; request bodies are never echoed (the default
-FastAPI 422, which reflects input back, is overridden). The only log lines
-this module emits are the allowlist lines — correlation id, sub, provider,
-status — on *successful* redemption/validation/teardown; failure paths log
-nothing at all.
+FastAPI 422, which reflects input back, is overridden). Log lines this module
+emits are the allowlist lines — correlation id, sub, provider, status — on
+*successful* redemption/validation/teardown, plus one diagnostic line when a
+provider call fails: exception class name and, for anthropic.APIStatusError
+(detected structurally, not by import), its status code and fixed error-type
+enum. Never the exception message/body text itself, which may echo request
+material.
 """
 
 from __future__ import annotations
@@ -372,9 +375,27 @@ def create_app() -> FastAPI:
                     if kind == "final":
                         return
                 out.put(("error", None))  # stream ended without a final
-            except Exception:
-                # Never let a provider exception (which may echo request
-                # material) reach the wire or a log — generic error frame.
+            except Exception as exc:
+                # Never let exception text (which may echo request material,
+                # e.g. an API key embedded in a message) reach a log — only
+                # duck-typed, content-free metadata: the exception's class
+                # name, and — for anthropic.APIStatusError specifically,
+                # detected by attribute shape so this module never needs to
+                # import the SDK — the HTTP status code and the provider's
+                # fixed error-type enum (never `.message`/`.body` text).
+                status_code = getattr(exc, "status_code", None)
+                error_type = None
+                error_body = getattr(exc, "body", None)
+                if isinstance(error_body, dict):
+                    err = error_body.get("error")
+                    if isinstance(err, dict):
+                        error_type = err.get("type")
+                logger.warning(
+                    "provider stream failed exception_type=%s status_code=%s error_type=%s",
+                    type(exc).__name__,
+                    status_code,
+                    error_type,
+                )
                 out.put(("error", None))
 
         def event_stream():

--- a/test_keyproxy_streaming.py
+++ b/test_keyproxy_streaming.py
@@ -243,6 +243,45 @@ class TestStreamingTurn(StreamingTestBase):
         ]
         self.assertEqual(unexpected, [])
 
+    def test_provider_error_logs_only_safe_metadata(self):
+        # A bare exception (no .status_code) — e.g. the RuntimeError above,
+        # which embeds the key in its message — must log only its class name.
+        stub = stub_stream("partial", error=True)
+        with patch("keyproxy.providers.anthropic.stream_turn", stub):
+            self.stream(self.open_session())
+        self.assert_never_logged(API_KEY, "blew up")
+        diag = [m for m in self.logged_messages() if "provider stream failed" in m]
+        self.assertEqual(len(diag), 1)
+        self.assertIn("exception_type=RuntimeError", diag[0])
+        self.assertIn("status_code=None", diag[0])
+
+    def test_provider_status_error_logs_code_and_type_not_message(self):
+        # Duck-typed anthropic.APIStatusError shape: status_code + a body
+        # whose error.message carries request-derived text that must never
+        # reach a log, while status_code/error.type (a fixed enum) may.
+        class FakeAPIStatusError(Exception):
+            status_code = 400
+            body = {
+                "type": "error",
+                "error": {
+                    "type": "invalid_request_error",
+                    "message": "tool_result for " + API_KEY + " is malformed",
+                },
+            }
+
+        def stream_turn(api_key, **params):
+            yield ("delta", "partial")
+            raise FakeAPIStatusError("unused")
+
+        with patch("keyproxy.providers.anthropic.stream_turn", stream_turn):
+            self.stream(self.open_session())
+        self.assert_never_logged(API_KEY, "is malformed")
+        diag = [m for m in self.logged_messages() if "provider stream failed" in m]
+        self.assertEqual(len(diag), 1)
+        self.assertIn("exception_type=FakeAPIStatusError", diag[0])
+        self.assertIn("status_code=400", diag[0])
+        self.assertIn("error_type=invalid_request_error", diag[0])
+
 
 class TestStreamingHeartbeat(StreamingTestBase):
     extra_env = {"KEYPROXY_HEARTBEAT_SECS": "0.05"}


### PR DESCRIPTION
## Summary
- The multi-tool-call Sidekick chat flow reliably fails on a session's **second** `messages.stream` call (the tool-results follow-up) — the current `worker()` except-clause swallows every provider exception with zero signal, so the real Anthropic-side error has never been observed.
- Adds a diagnostic log line on provider stream failure: exception class name, and for `anthropic.APIStatusError`-shaped exceptions (detected structurally via `getattr`, so this module never needs to import the SDK), the HTTP status code and the fixed `error.type` enum string.
- Never logs `.message`/`.body` text or any other exception content, since that can echo request material (including, in the worst case exercised by existing tests, an API key embedded in an exception message).

## Test plan
- [x] `python -m unittest test_keyproxy_streaming -v` — 14/14 pass, including two new tests: `test_provider_error_logs_only_safe_metadata` (bare exception, no `status_code`) and `test_provider_status_error_logs_code_and_type_not_message` (duck-typed `APIStatusError` shape).
- [x] Full non-DB keyproxy suite (`test_keyproxy_service`, `test_keyproxy_sessions`, `test_keyproxy_replay`, `test_keyproxy_scopes`, `test_keyproxy_crypto`, `test_keyproxy_gateway`) — 141/141 pass, unaffected by this change.
- [ ] Deploy to **test** Cloud Run and confirm the new log line appears with no sensitive content, then retrigger the multi-tool-call scenario against **prod** to capture the real Anthropic-side error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)