### PR TITLE
chat: log safe multi-tool-turn diagnostics for invalid_request_error probe

### DIFF
--- a/quantcore/services/chat.py
+++ b/quantcore/services/chat.py
@@ -334,6 +334,21 @@ class ChatService:
                     results.append(_tool_result(tu.id, out))
 
                 convo.append({"role": "user", "content": results})
+                # Diagnostic only: tool names are a fixed, non-sensitive enum
+                # (TOOL_SCHEMAS) and this is a byte count, not content — safe
+                # under the never-log policy. Narrows whether a provider
+                # invalid_request_error on the follow-up call correlates with
+                # multi-tool turns or with oversized tool_result payloads.
+                try:
+                    results_bytes = len(json.dumps(results))
+                except (TypeError, ValueError):
+                    results_bytes = -1
+                logger.info(
+                    "tool turn built tool_count=%d tools=%s results_bytes=%d",
+                    len(tool_uses),
+                    [tu.name for tu in tool_uses],
+                    results_bytes,
+                )
 
             yield ErrorEvent(
                 message=f"Tool iteration limit ({self._max_iterations}) reached."

--- a/test_chat_service.py
+++ b/test_chat_service.py
@@ -138,6 +138,36 @@ class TestToolTurn(ChatServiceTestBase):
         self.assertEqual(result_block["tool_use_id"], "tu_1")
         self.assertIn("55.1", result_block["content"])
 
+    def test_multi_tool_turn_logs_safe_diagnostic_metadata(self):
+        """Diagnostic-only line for the invalid_request_error investigation:
+        tool names (a fixed, non-sensitive enum) and a byte count (not
+        content) are safe to log and should reflect a multi-tool turn."""
+        self.prices.get_rsi.return_value = {"symbol": "AMD", "rsi": 55.1}
+        self.prices.get_macd.return_value = {"symbol": "AMD", "macd": 1.2}
+        client = ScriptedClient(
+            [
+                {
+                    "final": final(
+                        "tool_use",
+                        tool_use("tu_1", "get_rsi", {"symbol": "AMD"}),
+                        tool_use("tu_2", "get_macd", {"symbol": "AMD"}),
+                    )
+                },
+                {"final": final("end_turn", text_block("done"))},
+            ]
+        )
+        with self.assertLogs("quantcore.services.chat", level="INFO") as cm:
+            self.run_chat(client)
+        diag = [m for m in cm.output if "tool turn built" in m]
+        self.assertEqual(len(diag), 1)
+        self.assertIn("tool_count=2", diag[0])
+        self.assertIn("get_rsi", diag[0])
+        self.assertIn("get_macd", diag[0])
+        self.assertIn("results_bytes=", diag[0])
+        # No tool arguments or result content leaked into the log line.
+        self.assertNotIn("AMD", diag[0])
+        self.assertNotIn("55.1", diag[0])
+
     def test_unknown_tool_is_error_result_and_loop_continues(self):
         client = ScriptedClient(
             [


### PR DESCRIPTION
## Summary
- Continues the keyproxy diagnostic work from #111, which confirmed the Sidekick chat failure is `anthropic.BadRequestError` / HTTP 400 / `error.type=invalid_request_error` on the follow-up `messages.stream` call after tool execution.
- Adds one INFO-level log line in `ChatService.stream_chat` right before the next model call: tool count, tool names (fixed, non-sensitive enum from `TOOL_SCHEMAS`), and the serialized byte size of the outgoing `tool_result` content — no request content, args, or results are logged.
- Goal: correlate the `invalid_request_error` with multi-tool turns and/or oversized tool_result payloads (e.g. large options-chain data) without violating the never-log policy.

## Test plan
- [x] `python -m unittest test_chat_service test_chat_protocol` — 70/70 pass, including a new test asserting the log line's exact safe fields and that no tool args/results leak into it.
- [ ] Deploy to test, reproduce a multi-tool-call Sidekick failure, and inspect the new log line for tool_count/tools/results_bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)