### PR TITLE
fix: sanitize exception text and add degraded-result diagnostics for chat tool turns

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -10,11 +10,23 @@ Run with:  uvicorn api.main:app --host 127.0.0.1 --port 5001
 
 from __future__ import annotations
 
+import logging
 import sys
 from pathlib import Path
 
 from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+
+# Cloud Run's `uvicorn api.main:app` entrypoint never hits `if __name__ ==
+# "__main__"`, and uvicorn's own logging config only touches the "uvicorn*"
+# loggers, leaving the root logger at its WARNING default — every
+# `logger.info(...)`/`logger.warning(...)` call in quantcore/* was silently
+# dropped before reaching Cloud Logging. basicConfig() is a no-op if a handler
+# is already attached to root, so this is safe regardless of import order.
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
 
 # Ensure project root and fastMCPTest are importable (mirrors api/app.py).
 PROJECT_ROOT = Path(__file__).resolve().parent.parent

--- a/keyproxy/main.py
+++ b/keyproxy/main.py
@@ -55,6 +55,17 @@ from keyproxy.sessions import (
     SessionStore,
 )
 
+# Cloud Run's `uvicorn keyproxy.main:app` entrypoint never hits
+# `if __name__ == "__main__"`, and uvicorn's own logging config only touches
+# the "uvicorn*" loggers, leaving the root logger at its WARNING default —
+# every logger.info(...) call below (session redeemed/deleted, turn streamed,
+# key validated) was silently dropped before reaching Cloud Logging.
+# basicConfig() is a no-op if a handler is already attached to root.
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
+
 logger = logging.getLogger("keyproxy")
 
 _INVALID = "invalid request"

--- a/quantcore/error_text.py
+++ b/quantcore/error_text.py
@@ -1,0 +1,20 @@
+"""Shared helper for turning exceptions into model/API-safe text.
+
+Raw ``str(exc)`` on library exceptions (requests/urllib3 connection errors,
+yfinance/Polygon HTTP errors, etc.) can carry invalid-UTF-8 byte sequences,
+lone surrogates, or unbounded length (embedded response bodies, tracebacks).
+Any of those can reach a downstream JSON-consuming API — e.g. as Anthropic
+tool_result content in quantcore/services/chat.py — and trip its request
+validation. Route exception text through this before it leaves the service
+layer.
+"""
+
+MAX_ERROR_TEXT_LEN = 500
+
+
+def safe_error_text(exc: BaseException | str, max_len: int = MAX_ERROR_TEXT_LEN) -> str:
+    text = exc if isinstance(exc, str) else str(exc)
+    text = text.encode("utf-8", "replace").decode("utf-8")
+    if len(text) > max_len:
+        text = text[:max_len] + "...(truncated)"
+    return text

--- a/quantcore/services/chat.py
+++ b/quantcore/services/chat.py
@@ -25,6 +25,7 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Callable, Iterator, Protocol
 
+from quantcore.error_text import safe_error_text
 from quantcore.services.chat_tools import (
     TOOL_SCHEMAS,
     validate_directive,
@@ -296,6 +297,7 @@ class ChatService:
                 # Echo assistant content back unchanged (thinking blocks included).
                 convo.append({"role": "assistant", "content": final.content})
                 results = []
+                degraded: list[str] = []
                 for tu in tool_uses:
                     args = dict(tu.input or {})
                     if tu.name == "show_component":
@@ -311,6 +313,7 @@ class ChatService:
                             results.append(_tool_result(tu.id, {"rendered": True}))
                         else:
                             results.append(_tool_result(tu.id, reason, is_error=True))
+                            degraded.append(tu.name)
                         continue
 
                     yield ToolStatus(tool=tu.name, args=args, state="running")
@@ -320,18 +323,26 @@ class ChatService:
                         results.append(
                             _tool_result(tu.id, f"Unknown tool: {tu.name}", is_error=True)
                         )
+                        degraded.append(tu.name)
                         continue
                     try:
                         out = handler(**args)
                     except Exception as exc:  # noqa: BLE001 — model gets to recover
-                        logger.warning("chat tool %s failed: %s", tu.name, exc)
+                        safe_exc = safe_error_text(exc)
+                        logger.warning("chat tool %s failed: %s", tu.name, safe_exc)
                         yield ToolStatus(tool=tu.name, args=args, state="error")
                         results.append(
-                            _tool_result(tu.id, f"Error: {exc}", is_error=True)
+                            _tool_result(tu.id, f"Error: {safe_exc}", is_error=True)
                         )
+                        degraded.append(tu.name)
                         continue
                     yield ToolStatus(tool=tu.name, args=args, state="done")
                     results.append(_tool_result(tu.id, out))
+                    # Some handlers (e.g. get_technical_signals, get_options_flow_signals)
+                    # fan out internally and degrade individual sub-results rather than
+                    # raising — surface those partial failures here too.
+                    if isinstance(out, dict) and out.get("_errors"):
+                        degraded.append(tu.name)
 
                 convo.append({"role": "user", "content": results})
                 # Diagnostic only: tool names are a fixed, non-sensitive enum
@@ -343,6 +354,11 @@ class ChatService:
                     results_bytes = len(json.dumps(results))
                 except (TypeError, ValueError):
                     results_bytes = -1
+                if degraded:
+                    logger.warning(
+                        "tool turn had degraded results tool_count=%d degraded=%s results_bytes=%d",
+                        len(tool_uses), degraded, results_bytes,
+                    )
                 logger.info(
                     "tool turn built tool_count=%d tools=%s results_bytes=%d",
                     len(tool_uses),

--- a/quantcore/services/fundamentals.py
+++ b/quantcore/services/fundamentals.py
@@ -21,6 +21,7 @@ from typing import Any, Optional, Tuple
 import numpy as np
 import pandas as pd
 
+from quantcore.error_text import safe_error_text
 from quantcore.gateways.yfinance_gateway import YFinanceGateway
 from quantcore.repositories.fundamentals_repository import FundamentalsRepository
 
@@ -965,5 +966,5 @@ class FundamentalsService:
                 pass
             dates = sorted(set(d for d in dates if d and len(d) == 10))
         except Exception as exc:
-            return {"ticker": ticker, "earnings_dates": [], "error": str(exc)}
+            return {"ticker": ticker, "earnings_dates": [], "error": safe_error_text(exc)}
         return {"ticker": ticker, "earnings_dates": dates}

--- a/quantcore/services/microstructure.py
+++ b/quantcore/services/microstructure.py
@@ -16,6 +16,7 @@ import datetime
 import math
 
 from quantcore.analytics.market_time import period_to_days
+from quantcore.error_text import safe_error_text
 from quantcore.gateways.yfinance_gateway import YFinanceGateway
 from quantcore.repositories.ohlcv_repository import OhlcvRepository
 
@@ -55,7 +56,7 @@ class MicrostructureService:
         except TimeoutError as e:
             return {
                 "symbol":  symbol.upper(),
-                "error":   str(e),
+                "error":   safe_error_text(e),
                 "note":    "Retry the call — Yahoo Finance info endpoint was temporarily unresponsive.",
             }
 

--- a/quantcore/services/options.py
+++ b/quantcore/services/options.py
@@ -20,6 +20,7 @@ behavioural parity is the contract.
 from __future__ import annotations
 
 import datetime
+import logging
 import math
 import time as _time
 from collections import defaultdict
@@ -38,6 +39,7 @@ from quantcore.analytics.options_math import (
     compute_max_pain,
     safe_int as _safe_int,
 )
+from quantcore.error_text import safe_error_text
 from quantcore.gateways.polygon_gateway import PolygonGateway, PolygonPlanError
 from quantcore.gateways.yfinance_gateway import YFinanceGateway
 from quantcore.repositories.ohlcv_repository import OhlcvRepository
@@ -46,6 +48,8 @@ from quantcore.services.options_contracts import (
     get_option_contracts_data,
     price_vertical_spread_data,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class OptionsService:
@@ -1065,8 +1069,13 @@ class OptionsService:
                     results[key] = future.result()
                 except Exception as e:
                     results[key] = None
-                    errors[key] = str(e)
+                    errors[key] = safe_error_text(e)
 
+        if errors:
+            logger.warning(
+                "options flow sub-signal(s) failed ticker=%s signals=%s",
+                ticker, sorted(errors),
+            )
         return {"ticker": ticker, "_errors": errors if errors else None, **results}
 
     def get_portfolio_delta_exposure(self, portfolio: list[dict]) -> dict:
@@ -1203,11 +1212,11 @@ class OptionsService:
                 contracts_all = self._polygon.option_snapshots(ticker, date_str)
             except PolygonPlanError as exc:
                 return {
-                    "error": str(exc),
+                    "error": safe_error_text(exc),
                     "polygon_status": exc.status_code,
                 }, 402
             except requests.RequestException as exc:
-                results.append({"date": date_str, "status": "error", "error": str(exc)})
+                results.append({"date": date_str, "status": "error", "error": safe_error_text(exc)})
                 continue
 
             if contracts_all is None:

--- a/quantcore/services/prices.py
+++ b/quantcore/services/prices.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import bisect
 import datetime
+import logging
 import math
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -31,10 +32,13 @@ from quantcore.analytics.indicators import (
 )
 from quantcore.analytics.market_time import latest_completed_session, period_to_days
 from quantcore.analytics.volume_profile import build_volume_profile, find_volume_nodes
+from quantcore.error_text import safe_error_text
 from quantcore.gateways.yfinance_gateway import YFinanceGateway
 from quantcore.repositories.ohlcv_repository import OhlcvRepository
 from quantcore.repositories.options_repository import OptionsStore
 from quantcore.repositories.sentiment_repository import SentimentStore
+
+logger = logging.getLogger(__name__)
 
 VALID_INTERVALS = {"1d", "1wk", "1mo", "1h", "30m", "15m"}
 
@@ -1759,7 +1763,7 @@ class PricesService:
         try:
             dd = self.get_historical_drawdown(ticker)
         except Exception as exc:
-            return {"ticker": ticker, "drawdown": None, "error": str(exc)}
+            return {"ticker": ticker, "drawdown": None, "error": safe_error_text(exc)}
         # Derive a simple stop-loss recommendation from drawdown stats
         price_data: dict = {}
         try:
@@ -1843,8 +1847,13 @@ class PricesService:
                     results[key] = future.result()
                 except Exception as e:
                     results[key] = None
-                    errors[key] = str(e)
+                    errors[key] = safe_error_text(e)
 
+        if errors:
+            logger.warning(
+                "technical signal sub-indicator(s) failed ticker=%s indicators=%s",
+                ticker, sorted(errors),
+            )
         return {"ticker": ticker, "_errors": errors if errors else None, **results}
 
     def screen_securities(self, filters: dict, portfolio: list[dict], watchlist: list[dict]) -> dict:


### PR DESCRIPTION
## Summary
- Traces the intermittent Anthropic `invalid_request_error` on multi-tool Sidekick chat turns to raw `str(exc)` text (from `ThreadPoolExecutor` sub-task failures in `get_technical_signals`/`get_options_flow_signals` and other exception sites) escaping into `tool_result` content unsanitized. Adds `quantcore/error_text.py`'s `safe_error_text()` as a single choke point and applies it at every site where exception text reaches a `tool_result`.
- Adds a `"tool turn had degraded results"` warning in `chat.py` naming which tool calls errored, were unknown, or returned partial `_errors`, so a future incident is traceable from one log line.
- Fixes an app-wide gap where `logger.info`/`logger.warning` calls were silently dropped: neither `api/main.py` nor `keyproxy/main.py` configured the root logger, and Cloud Run's `uvicorn <module>:app` entrypoint never hits `__main__` (uvicorn's own logging config only touches the `uvicorn*` loggers).

## Test plan
- [x] `python -m unittest test_chat_protocol test_chat_service test_prices_service test_options_service test_fundamentals_service test_microstructure_service test_options_screening_service` — 219 tests pass, including the new degraded-result warning paths (`show_component`, `get_rsi`, `get_whatever`, `gap_analysis`, `delta_adjusted_oi`)
- [ ] Deploy to test, reproduce the original failing 22-tool-call query, confirm no `invalid_request_error` and that Cloud Logging now shows INFO/WARNING diagnostics if a sub-indicator degrades

🤖 Generated with [Claude Code](https://claude.com/claude-code)