### PR TITLE
debug: temporarily log sanitized keyproxy provider-error detail

### DIFF
--- a/keyproxy/main.py
+++ b/keyproxy/main.py
@@ -22,6 +22,13 @@ provider call fails: exception class name and, for anthropic.APIStatusError
 (detected structurally, not by import), its status code and fixed error-type
 enum. Never the exception message/body text itself, which may echo request
 material.
+
+TEMPORARY (test-only): the provider-error diagnostic line also logs the
+provider's error message/body text, with the session's API key redacted, to
+chase an intermittent invalid_request_error on large tool_result follow-up
+turns. Revert this block (and the matching test changes in
+test_keyproxy_streaming.py) once that's diagnosed — see the "TEMPORARY"
+comment at the log call site.
 """
 
 from __future__ import annotations
@@ -396,16 +403,31 @@ def create_app() -> FastAPI:
                 # fixed error-type enum (never `.message`/`.body` text).
                 status_code = getattr(exc, "status_code", None)
                 error_type = None
+                error_message = None
                 error_body = getattr(exc, "body", None)
                 if isinstance(error_body, dict):
                     err = error_body.get("error")
                     if isinstance(err, dict):
                         error_type = err.get("type")
+                        error_message = err.get("message")
+                # TEMPORARY (test-only, revert once the intermittent
+                # invalid_request_error on large tool_result follow-up turns
+                # is diagnosed): the provider's validation message is the
+                # only place that names the actual complaint. The API key is
+                # the one piece of request material known to this closure, so
+                # it's redacted before anything is logged; this does not
+                # widen the guarantee to arbitrary echoed request content.
+                error_detail = error_message if error_message is not None else str(exc)
+                error_detail = error_detail.replace(api_key, "[REDACTED]")
+                error_detail = error_detail.encode("utf-8", "replace").decode("utf-8")
+                if len(error_detail) > 300:
+                    error_detail = error_detail[:300] + "...(truncated)"
                 logger.warning(
-                    "provider stream failed exception_type=%s status_code=%s error_type=%s",
+                    "provider stream failed exception_type=%s status_code=%s error_type=%s error_detail=%s",
                     type(exc).__name__,
                     status_code,
                     error_type,
+                    error_detail,
                 )
                 out.put(("error", None))
 

--- a/test_keyproxy_gateway.py
+++ b/test_keyproxy_gateway.py
@@ -190,7 +190,10 @@ class TestKeyProxyChatClient(GatewayTestBase):
         self.assertEqual(str(ctx.exception), keyproxy_gateway.PROVIDER_ERROR_MESSAGE)
         self.assertNotIn(API_KEY, str(ctx.exception))
         self.assertEqual(self.state.sessions._sessions, {})
-        self.assert_never_logged(API_KEY, "exploded")
+        # TEMPORARY: keyproxy's error_detail now logs the redacted message
+        # ("provider exploded: [REDACTED]") — the key itself must still
+        # never be logged.
+        self.assert_never_logged(API_KEY)
 
     def test_expired_session_mid_chat_surfaces_clean_resend_error(self):
         provider = ScriptedProvider(

--- a/test_keyproxy_streaming.py
+++ b/test_keyproxy_streaming.py
@@ -124,10 +124,13 @@ class TestStreamingTurn(StreamingTestBase):
         self.assertEqual(response.status_code, 200)
         _, events = parse_sse(response.text)
         self.assertEqual(events[-1], ("error", {"detail": "provider error"}))
-        # The exception message carried the key — it must never surface.
+        # The exception message carried the key — it must never surface on
+        # the wire (the SSE response), regardless of what reaches the log.
         self.assertNotIn(API_KEY, response.text)
         self.assertNotIn("blew up", response.text)
-        self.assert_never_logged(API_KEY, "blew up")
+        # TEMPORARY: error_detail now logs the redacted message ("provider
+        # blew up: [REDACTED]") — the key itself must still never be logged.
+        self.assert_never_logged(API_KEY)
 
     def test_call_budget_counted_then_exhausted_then_killed(self):
         scope = chat_scope(
@@ -245,20 +248,25 @@ class TestStreamingTurn(StreamingTestBase):
 
     def test_provider_error_logs_only_safe_metadata(self):
         # A bare exception (no .status_code) — e.g. the RuntimeError above,
-        # which embeds the key in its message — must log only its class name.
+        # which embeds the key in its message — must never log the key, even
+        # though the TEMPORARY error_detail field logs str(exc) verbatim
+        # otherwise (there's no structured .body to redact against here).
         stub = stub_stream("partial", error=True)
         with patch("keyproxy.providers.anthropic.stream_turn", stub):
             self.stream(self.open_session())
-        self.assert_never_logged(API_KEY, "blew up")
+        self.assert_never_logged(API_KEY)
         diag = [m for m in self.logged_messages() if "provider stream failed" in m]
         self.assertEqual(len(diag), 1)
         self.assertIn("exception_type=RuntimeError", diag[0])
         self.assertIn("status_code=None", diag[0])
+        self.assertIn("error_detail=provider blew up: [REDACTED]", diag[0])
 
     def test_provider_status_error_logs_code_and_type_not_message(self):
         # Duck-typed anthropic.APIStatusError shape: status_code + a body
-        # whose error.message carries request-derived text that must never
-        # reach a log, while status_code/error.type (a fixed enum) may.
+        # whose error.message carries request-derived text. TEMPORARY: this
+        # message is now logged (to diagnose an intermittent provider 400 on
+        # large follow-up turns), but the API key embedded in it must still
+        # never reach the log — only the message with the key redacted.
         class FakeAPIStatusError(Exception):
             status_code = 400
             body = {
@@ -275,12 +283,13 @@ class TestStreamingTurn(StreamingTestBase):
 
         with patch("keyproxy.providers.anthropic.stream_turn", stream_turn):
             self.stream(self.open_session())
-        self.assert_never_logged(API_KEY, "is malformed")
+        self.assert_never_logged(API_KEY)
         diag = [m for m in self.logged_messages() if "provider stream failed" in m]
         self.assertEqual(len(diag), 1)
         self.assertIn("exception_type=FakeAPIStatusError", diag[0])
         self.assertIn("status_code=400", diag[0])
         self.assertIn("error_type=invalid_request_error", diag[0])
+        self.assertIn("error_detail=tool_result for [REDACTED] is malformed", diag[0])
 
 
 class TestStreamingHeartbeat(StreamingTestBase):


### PR DESCRIPTION
## Summary
- Test-only diagnostic to chase the intermittent Anthropic `invalid_request_error` (HTTP 400) seen on the follow-up `stream_turn()` call after a large (44-tool) batch of tool_results — see the correlated Cloud Logging investigation from this session.
- The existing never-log policy strips `.message`/`.body` text from the `"provider stream failed"` diagnostic line by design, so the actual provider-side validation complaint isn't visible today.
- Adds an `error_detail=` field to that log line: the provider's error message, with the session's API key redacted (the only request material known to that closure) before logging. Nothing else about the never-log guarantee changes — key material and Authorization headers are still never logged.
- Updated the three existing keyproxy tests that assert the never-log policy so they reflect the new (temporary) behavior: the API key must still never appear in logs, but the redacted message text now may.

## This PR is meant to be reverted
Once we've captured the actual error detail from test logs and diagnosed the root cause, this commit should be reverted via a follow-up PR (`git revert`) to restore the original never-log-message-text guarantee. It's a single isolated commit specifically so that revert is clean.

## Test plan
- [x] `python -m unittest test_keyproxy_streaming test_keyproxy_gateway test_keyproxy_service` — all pass
- [x] Full suite (`python -m unittest discover`) shows the same pre-existing 45 errors/5 skips as the `main` baseline (unrelated DB-connectivity tests in this sandbox), 0 new failures
- [ ] Deploy to test, reproduce the large-batch chat query, pull `quantcore-keyproxy` Cloud Run logs for the `error_detail=` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)