### PR TITLE
fix: strip output-only parsed_output field before echoing content blocks

### DIFF
--- a/quantcore/gateways/keyproxy_gateway.py
+++ b/quantcore/gateways/keyproxy_gateway.py
@@ -234,6 +234,25 @@ class KeyProxyMessage:
         ]
 
 
+# Fields the Messages API attaches to *response* content blocks that are not
+# valid on the *input* side of a subsequent request. `parsed_output` is emitted
+# on assistant text blocks when output_config/effort is set
+# (keyproxy/providers/anthropic.py); echoing it back on the follow-up tool turn
+# draws a hard `400 invalid_request_error` ("Extra inputs are not permitted").
+# Content blocks otherwise round-trip verbatim — thinking-block `signature`
+# MUST survive byte-exact — so this denylist is the one deliberate exception.
+_OUTPUT_ONLY_BLOCK_FIELDS = ("parsed_output",)
+
+
+def _strip_output_only(block):
+    """Drop response-only fields so an echoed block is valid as request input."""
+    if not isinstance(block, dict) or not any(
+        field in block for field in _OUTPUT_ONLY_BLOCK_FIELDS
+    ):
+        return block
+    return {k: v for k, v in block.items() if k not in _OUTPUT_ONLY_BLOCK_FIELDS}
+
+
 def _wire_messages(messages: list[dict]) -> list[dict]:
     """Unwrap ContentBlock views back to their raw dicts for the request body."""
     out = []
@@ -241,7 +260,9 @@ def _wire_messages(messages: list[dict]) -> list[dict]:
         content = message["content"]
         if isinstance(content, list):
             content = [
-                block.raw if isinstance(block, ContentBlock) else block
+                _strip_output_only(
+                    block.raw if isinstance(block, ContentBlock) else block
+                )
                 for block in content
             ]
         out.append({"role": message["role"], "content": content})

--- a/test_keyproxy_gateway.py
+++ b/test_keyproxy_gateway.py
@@ -31,6 +31,14 @@ from test_keyproxy_service import (
 )
 
 TEXT_BLOCK = {"type": "text", "text": "hi there"}
+# A response text block carrying the output-only `parsed_output` field the
+# Messages API attaches under output_config/effort. Valid on the way out of the
+# API, rejected as request input on the follow-up turn.
+TEXT_BLOCK_WITH_PARSED_OUTPUT = {
+    "type": "text",
+    "text": "checking the price",
+    "parsed_output": {"symbol": "AAPL"},
+}
 THINKING_BLOCK = {
     "type": "thinking",
     "thinking": "let me check the price",
@@ -323,6 +331,44 @@ class TestKeyProxyChatClient(GatewayTestBase):
         outbound = provider.calls[1]["messages"]
         assistant = next(m for m in outbound if m["role"] == "assistant")
         self.assertEqual(assistant["content"][0], THINKING_BLOCK)
+        self.assertEqual(assistant["content"][1], TOOL_USE_BLOCK)
+
+    def test_output_only_parsed_output_stripped_on_next_turn(self):
+        # Regression (2026-07-21): the API attaches an output-only
+        # `parsed_output` field to assistant text blocks under
+        # output_config/effort. Echoing it back verbatim on the follow-up tool
+        # turn draws a hard 400 invalid_request_error ("Extra inputs are not
+        # permitted"). The wire seam must drop it while leaving every other
+        # field — critically the adjacent tool_use block — untouched.
+        from quantcore.services.chat import ChatService, Done
+
+        provider = ScriptedProvider(
+            [
+                {"final": final_message(
+                    TEXT_BLOCK_WITH_PARSED_OUTPUT, TOOL_USE_BLOCK)},
+                {"final": final_message(TEXT_BLOCK)},
+            ]
+        )
+        prices = Mock()
+        prices.get_stock_price.return_value = {"symbol": "AAPL", "price": 123.45}
+        service = ChatService(
+            prices, Mock(), Mock(), Mock(),
+            client_factory=lambda context: self.make_client(),
+        )
+        with patch("keyproxy.providers.anthropic.stream_turn", provider):
+            events = list(
+                service.stream_chat([{"role": "user", "content": "price of AAPL?"}])
+            )
+        self.assertIsInstance(events[-1], Done)
+        outbound = provider.calls[1]["messages"]
+        assistant = next(m for m in outbound if m["role"] == "assistant")
+        # parsed_output stripped, but text + type preserved verbatim.
+        self.assertEqual(
+            assistant["content"][0],
+            {"type": "text", "text": "checking the price"},
+        )
+        self.assertNotIn("parsed_output", assistant["content"][0])
+        # The adjacent tool_use block is untouched.
         self.assertEqual(assistant["content"][1], TOOL_USE_BLOCK)
 
 


### PR DESCRIPTION
## Root cause

The batch-chat 400 failures traced to an **output-only** field the Messages API attaches to assistant text blocks under `output_config`/`effort` (see `keyproxy/providers/anthropic.py`): `parsed_output`.

The keyproxy gateway round-trips content blocks **verbatim** — deliberate, and necessary to preserve thinking-block `signature` values byte-exact (`test_thinking_block_signature_roundtrip`). But that same verbatim echo sends `parsed_output` back as *input* on the follow-up tool turn, which Anthropic rejects:

```
400 invalid_request_error:
messages.N.content.M.text.parsed_output: Extra inputs are not permitted
```

It read as "intermittent" only because the model emits `parsed_output` on some generations and not others — a retry regenerates a turn without it, which is why retries appeared to "fix" it.

Diagnosis was pinned down via the temporary redacted `error_detail` logging from #115 (to be reverted separately once this is confirmed clean in test).

## The fix

- Add a small denylist `_OUTPUT_ONLY_BLOCK_FIELDS = ("parsed_output",)` and a `_strip_output_only()` helper.
- Apply it at the single wire seam `_wire_messages` in `quantcore/gateways/keyproxy_gateway.py`, so output-only fields are dropped from outbound blocks while **every other field — critically thinking-block `signature` — round-trips byte-exact**.
- The helper returns the same object when nothing needs stripping (no needless copies).

## Tests

- New `test_output_only_parsed_output_stripped_on_next_turn`: full ChatService round-trip — turn 1 emits a text block carrying `parsed_output` alongside a `tool_use`; asserts turn 2's outbound assistant content has the field stripped, text preserved, and the adjacent `tool_use` untouched.
- Existing `test_thinking_block_signature_roundtrip` still passes (signature unaffected).
- Full gateway + streaming suite: 37/37 pass.

## Follow-up

Once the big batch query succeeds first-try in test, revert the temporary debug logging from #115 as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)