### PR TITLE
feat: surface classified provider errors (e.g. out-of-credits) to the user

### DIFF
--- a/keyproxy/main.py
+++ b/keyproxy/main.py
@@ -103,6 +103,48 @@ def _sse(event: str, data: dict) -> str:
     return f"event: {event}\ndata: {json.dumps(data, separators=(',', ':'))}\n\n"
 
 
+# The complete, closed set of provider-error reason codes emitted on the SSE
+# `error` frame. Only a member of this set ever crosses the wire — never the
+# provider's raw message/body text (which may echo request material, e.g. an
+# API key embedded in a message). The gateway maps each code to user-facing
+# copy; an unknown/absent code falls back to the generic provider message, so
+# adding a code here is forward/backward compatible across a deploy skew.
+PROVIDER_REASON_CODES = frozenset({
+    "insufficient_credits",
+    "authentication",
+    "permission",
+    "rate_limit",
+    "overloaded",
+    "model_unavailable",
+    "provider_error",
+})
+
+
+def _provider_reason(status_code, error_type, error_message) -> str:
+    """Classify a provider failure into one closed-set reason code.
+
+    ``error_message`` is untrusted and is *inspected only* — for the billing
+    case it is matched against a fixed, request-material-free substring — and
+    is never itself forwarded. Generic ``invalid_request_error`` complaints
+    (e.g. a malformed follow-up turn) deliberately fall through to the opaque
+    ``provider_error`` bucket rather than leaking their structural text.
+    """
+    message = (error_message or "").lower()
+    if "credit balance is too low" in message:
+        return "insufficient_credits"
+    if error_type == "authentication_error":
+        return "authentication"
+    if error_type == "permission_error":
+        return "permission"
+    if error_type == "rate_limit_error" or status_code == 429:
+        return "rate_limit"
+    if error_type == "overloaded_error" or status_code == 529:
+        return "overloaded"
+    if error_type == "not_found_error":
+        return "model_unavailable"
+    return "provider_error"
+
+
 def _parse_key_bundle(text: str) -> list[tuple[str, object]]:
     """Parse ``KEYPROXY_PRIVATE_KEYS`` — the generate-script output format.
 
@@ -392,7 +434,8 @@ def create_app() -> FastAPI:
                     out.put((kind, payload))
                     if kind == "final":
                         return
-                out.put(("error", None))  # stream ended without a final
+                # Stream ended without a final frame — opaque provider fault.
+                out.put(("error", {"code": "provider_error"}))
             except Exception as exc:
                 # Never let exception text (which may echo request material,
                 # e.g. an API key embedded in a message) reach a log — only
@@ -422,14 +465,16 @@ def create_app() -> FastAPI:
                 error_detail = error_detail.encode("utf-8", "replace").decode("utf-8")
                 if len(error_detail) > 300:
                     error_detail = error_detail[:300] + "...(truncated)"
+                reason = _provider_reason(status_code, error_type, error_message)
                 logger.warning(
-                    "provider stream failed exception_type=%s status_code=%s error_type=%s error_detail=%s",
+                    "provider stream failed exception_type=%s status_code=%s error_type=%s reason=%s error_detail=%s",
                     type(exc).__name__,
                     status_code,
                     error_type,
+                    reason,
                     error_detail,
                 )
-                out.put(("error", None))
+                out.put(("error", {"code": reason}))
 
         def event_stream():
             out: queue.Queue = queue.Queue()
@@ -472,7 +517,13 @@ def create_app() -> FastAPI:
                     )
                     return
                 else:
-                    yield _sse("error", {"detail": "provider error"})
+                    # Only a closed-set reason code crosses the wire — never
+                    # provider text. Defensively re-validate the code against
+                    # the known set before it leaves the process.
+                    code = payload.get("code") if isinstance(payload, dict) else None
+                    if code not in PROVIDER_REASON_CODES:
+                        code = "provider_error"
+                    yield _sse("error", {"code": code})
                     return
 
         # No compression middleware may ever touch text/event-stream — a

--- a/quantcore/gateways/keyproxy_gateway.py
+++ b/quantcore/gateways/keyproxy_gateway.py
@@ -75,6 +75,40 @@ AUTH_ERROR_MESSAGE = (
     "Your session's authorization was rejected — please refresh and try again."
 )
 
+# User-facing copy for each closed-set provider-error reason code the keyproxy
+# emits on the SSE `error` frame (keyproxy/main.py `PROVIDER_REASON_CODES`).
+# The keyproxy sends only the code, never the provider's raw message, so this
+# is the single place that turns a category into words. An unknown or absent
+# code falls through to PROVIDER_ERROR_MESSAGE, which keeps a new keyproxy code
+# (or an old keyproxy that sends no code at all) safe against this older map.
+_PROVIDER_REASON_COPY = {
+    "insufficient_credits": (
+        "Your Anthropic API key is out of credits. Add credits in the Anthropic "
+        "Console (Plans & Billing), then re-send your message."
+    ),
+    "authentication": (
+        "Anthropic rejected your API key. Re-enter it on the Settings page, then "
+        "re-send your message."
+    ),
+    "permission": (
+        "Your Anthropic API key doesn't have permission for this request."
+    ),
+    "rate_limit": RATE_LIMITED_MESSAGE,
+    "overloaded": (
+        "Anthropic is temporarily overloaded — please wait a moment and re-send "
+        "your message."
+    ),
+    "model_unavailable": (
+        "The selected model isn't available on your Anthropic API key."
+    ),
+}
+
+
+def _provider_error_message(data: object) -> str:
+    """Map a keyproxy `error` frame's reason code to user-facing copy."""
+    code = data.get("code") if isinstance(data, dict) else None
+    return _PROVIDER_REASON_COPY.get(code, PROVIDER_ERROR_MESSAGE)
+
 
 class KeyProxyError(RuntimeError):
     """A keyproxy interaction failed; the message is safe to show the user."""
@@ -380,7 +414,7 @@ class KeyProxyChatClient:
                         return
                     elif event == "error":
                         self.close()
-                        raise KeyProxyError(PROVIDER_ERROR_MESSAGE)
+                        raise KeyProxyError(_provider_error_message(data))
         except httpx.HTTPError:
             self.close()
             raise KeyProxyError(UNAVAILABLE_MESSAGE) from None

--- a/test_keyproxy_gateway.py
+++ b/test_keyproxy_gateway.py
@@ -54,6 +54,17 @@ def final_message(*blocks, stop_reason="end_turn", usage=None):
     }
 
 
+class FakeAPIStatusError(Exception):
+    """Shapes like anthropic.APIStatusError: a ``status_code`` int and a
+    ``body`` dict carrying ``error.type`` / ``error.message`` — the exact
+    attributes keyproxy's worker duck-types (it never imports the SDK)."""
+
+    def __init__(self, status_code, error_type, message):
+        super().__init__("api status error")
+        self.status_code = status_code
+        self.body = {"error": {"type": error_type, "message": message}}
+
+
 class ScriptedProvider:
     """Scripted stand-in for keyproxy.providers.anthropic.stream_turn.
 
@@ -76,6 +87,9 @@ class ScriptedProvider:
             self.emit_times.append(time.monotonic())
             yield ("delta", text)
         if turn.get("error"):
+            err = turn["error"]
+            if isinstance(err, BaseException):
+                raise err
             raise RuntimeError("provider exploded: " + api_key)
         if turn.get("delay"):
             time.sleep(turn["delay"])
@@ -193,6 +207,67 @@ class TestKeyProxyChatClient(GatewayTestBase):
         # TEMPORARY: keyproxy's error_detail now logs the redacted message
         # ("provider exploded: [REDACTED]") — the key itself must still
         # never be logged.
+        self.assert_never_logged(API_KEY)
+
+    def test_insufficient_credits_surfaces_specific_copy(self):
+        # The billing failure (a 400 invalid_request_error whose message is the
+        # static "credit balance is too low" string) must reach the user as its
+        # own actionable copy — not the opaque generic provider message.
+        billing = FakeAPIStatusError(
+            400, "invalid_request_error",
+            "Your credit balance is too low to access the Anthropic API. "
+            "Please go to Plans & Billing to upgrade or purchase credits.",
+        )
+        provider = ScriptedProvider([{"error": billing}])
+        client = self.make_client()
+        with patch("keyproxy.providers.anthropic.stream_turn", provider):
+            with self.assertRaises(keyproxy_gateway.KeyProxyError) as ctx:
+                self.run_turn(client)
+        self.assertEqual(
+            str(ctx.exception),
+            keyproxy_gateway._PROVIDER_REASON_COPY["insufficient_credits"],
+        )
+        self.assertNotEqual(
+            str(ctx.exception), keyproxy_gateway.PROVIDER_ERROR_MESSAGE
+        )
+        self.assertEqual(self.state.sessions._sessions, {})
+
+    def test_structural_invalid_request_stays_generic_and_unleaked(self):
+        # A structural invalid_request_error (the parsed_output-style complaint)
+        # names request material, so it must fall through to the OPAQUE generic
+        # message — its text must never reach the user.
+        structural = FakeAPIStatusError(
+            400, "invalid_request_error",
+            "messages.9.content.1.text.parsed_output: Extra inputs are not permitted",
+        )
+        provider = ScriptedProvider([{"error": structural}])
+        client = self.make_client()
+        with patch("keyproxy.providers.anthropic.stream_turn", provider):
+            with self.assertRaises(keyproxy_gateway.KeyProxyError) as ctx:
+                self.run_turn(client)
+        self.assertEqual(
+            str(ctx.exception), keyproxy_gateway.PROVIDER_ERROR_MESSAGE
+        )
+        self.assertNotIn("parsed_output", str(ctx.exception))
+
+    def test_provider_error_message_never_echoes_key_or_body(self):
+        # Safety net: even if the provider's message embeds the API key, the
+        # user-facing copy is our canned string and the key never surfaces —
+        # in the message or in any log line.
+        leaky = FakeAPIStatusError(
+            401, "authentication_error",
+            "invalid x-api-key: " + API_KEY,
+        )
+        provider = ScriptedProvider([{"error": leaky}])
+        client = self.make_client()
+        with patch("keyproxy.providers.anthropic.stream_turn", provider):
+            with self.assertRaises(keyproxy_gateway.KeyProxyError) as ctx:
+                self.run_turn(client)
+        self.assertEqual(
+            str(ctx.exception),
+            keyproxy_gateway._PROVIDER_REASON_COPY["authentication"],
+        )
+        self.assertNotIn(API_KEY, str(ctx.exception))
         self.assert_never_logged(API_KEY)
 
     def test_expired_session_mid_chat_surfaces_clean_resend_error(self):
@@ -324,6 +399,59 @@ class TestKeyProxyChatClient(GatewayTestBase):
         assistant = next(m for m in outbound if m["role"] == "assistant")
         self.assertEqual(assistant["content"][0], THINKING_BLOCK)
         self.assertEqual(assistant["content"][1], TOOL_USE_BLOCK)
+
+
+class TestProviderErrorClassification(unittest.TestCase):
+    """The keyproxy classifier + gateway translator, as pure functions."""
+
+    def test_reason_codes_cover_every_branch(self):
+        from keyproxy.main import _provider_reason
+
+        cases = [
+            # (status_code, error_type, message) -> reason
+            (400, "invalid_request_error",
+             "Your credit balance is too low to access the Anthropic API.",
+             "insufficient_credits"),
+            (401, "authentication_error", "invalid x-api-key", "authentication"),
+            (403, "permission_error", "not allowed", "permission"),
+            (429, "rate_limit_error", "slow down", "rate_limit"),
+            (429, None, "slow down", "rate_limit"),          # status-only
+            (529, "overloaded_error", "busy", "overloaded"),
+            (529, None, "busy", "overloaded"),               # status-only
+            (404, "not_found_error", "no such model", "model_unavailable"),
+            (400, "invalid_request_error",
+             "messages.9.content.1.text.parsed_output: Extra inputs are not permitted",
+             "provider_error"),                              # structural -> opaque
+            (None, None, None, "provider_error"),            # nothing known
+        ]
+        for status, etype, msg, expected in cases:
+            with self.subTest(expected=expected):
+                self.assertEqual(_provider_reason(status, etype, msg), expected)
+
+    def test_every_reason_code_has_gateway_copy_or_generic(self):
+        from keyproxy.main import PROVIDER_REASON_CODES
+
+        # Every code the keyproxy can emit resolves to non-empty user copy.
+        for code in PROVIDER_REASON_CODES:
+            msg = keyproxy_gateway._provider_error_message({"code": code})
+            self.assertTrue(msg)
+        # provider_error and any unknown/absent code fall to the generic string.
+        self.assertEqual(
+            keyproxy_gateway._provider_error_message({"code": "provider_error"}),
+            keyproxy_gateway.PROVIDER_ERROR_MESSAGE,
+        )
+        self.assertEqual(
+            keyproxy_gateway._provider_error_message({"code": "nonexistent"}),
+            keyproxy_gateway.PROVIDER_ERROR_MESSAGE,
+        )
+        self.assertEqual(
+            keyproxy_gateway._provider_error_message({}),
+            keyproxy_gateway.PROVIDER_ERROR_MESSAGE,
+        )
+        self.assertEqual(
+            keyproxy_gateway._provider_error_message(None),
+            keyproxy_gateway.PROVIDER_ERROR_MESSAGE,
+        )
 
 
 class TestClientHeartbeatTolerance(GatewayTestBase):

--- a/test_keyproxy_streaming.py
+++ b/test_keyproxy_streaming.py
@@ -123,13 +123,43 @@ class TestStreamingTurn(StreamingTestBase):
             response = self.stream(self.open_session())
         self.assertEqual(response.status_code, 200)
         _, events = parse_sse(response.text)
-        self.assertEqual(events[-1], ("error", {"detail": "provider error"}))
+        # A bare RuntimeError classifies to the opaque provider_error code —
+        # only a closed-set reason code crosses the wire, never provider text.
+        self.assertEqual(events[-1], ("error", {"code": "provider_error"}))
         # The exception message carried the key — it must never surface on
         # the wire (the SSE response), regardless of what reaches the log.
         self.assertNotIn(API_KEY, response.text)
         self.assertNotIn("blew up", response.text)
         # TEMPORARY: error_detail now logs the redacted message ("provider
         # blew up: [REDACTED]") — the key itself must still never be logged.
+        self.assert_never_logged(API_KEY)
+
+    def test_classifiable_provider_error_emits_specific_reason_code(self):
+        # The billing failure (a 400 whose message is the static "credit
+        # balance is too low" string) must reach the SSE `error` frame as its
+        # specific reason code — but the provider's raw message must NOT.
+        class FakeAPIStatusError(Exception):
+            status_code = 400
+            body = {
+                "error": {
+                    "type": "invalid_request_error",
+                    "message": "Your credit balance is too low to access the "
+                    "Anthropic API. Please go to Plans & Billing. " + API_KEY,
+                },
+            }
+
+        def stream_turn(api_key, **params):
+            yield ("delta", "partial")
+            raise FakeAPIStatusError("unused")
+
+        with patch("keyproxy.providers.anthropic.stream_turn", stream_turn):
+            response = self.stream(self.open_session())
+        self.assertEqual(response.status_code, 200)
+        _, events = parse_sse(response.text)
+        self.assertEqual(events[-1], ("error", {"code": "insufficient_credits"}))
+        # Only the code crosses the wire — never the provider's message bytes.
+        self.assertNotIn("credit balance", response.text)
+        self.assertNotIn(API_KEY, response.text)
         self.assert_never_logged(API_KEY)
 
     def test_call_budget_counted_then_exhausted_then_killed(self):


### PR DESCRIPTION
## Problem

Anthropic provider failures reach the Sidekick user as the opaque **"The model provider returned an error — please try again."** — even when the real cause is actionable, like the out-of-credits failure hit while debugging #116. The cause was flattened to a constant at two points:

```
keyproxy worker → emits fixed {"detail": "provider error"} SSE frame
   → gateway stream_turn → raises fixed PROVIDER_ERROR_MESSAGE
      → ChatService → ErrorEvent(str(exc)) → frontend
```

The flattening is deliberate and load-bearing: the provider's raw `error.message` **may echo request material** (e.g. an API key embedded in a message), so it must never cross the wire to the browser or a log.

## Approach: classify to a closed enum, translate on the far side

The safety invariant is **only a member of a fixed reason-code set ever leaves keyproxy** — never provider bytes.

- **keyproxy** (`_provider_reason`, `PROVIDER_REASON_CODES`): inspects the untrusted status/type/message and returns one of `{insufficient_credits, authentication, permission, rate_limit, overloaded, model_unavailable, provider_error}`. The message is read only for a fixed substring match (the billing case); it is never forwarded. The error SSE frame now carries `{"code": <reason>}`, defensively re-validated against the known set before it leaves the process.
- **gateway** (`_provider_error_message`, `_PROVIDER_REASON_COPY`): maps each code to curated user copy; unknown/absent code → the generic `PROVIDER_ERROR_MESSAGE`.
- **ChatService / frontend**: unchanged — they already surface the KeyProxyError string.

### Why it stays safe
- Only enum members cross the wire; raw provider text never reaches the browser or a log.
- Structural `invalid_request_error` complaints (e.g. the `parsed_output` bug from #116) deliberately fall through to the opaque `provider_error` bucket — their text is **not** promoted.
- The never-log tests still hold; the classifier reads `message` only to categorize.

### Deploy-skew safe both directions
An unknown or absent `code` resolves to the generic message, so old↔new keyproxy and old↔new gateway interoperate without a lockstep deploy.

## Tests (+5 gateway, +2 streaming, all green)
- End-to-end through the real keyproxy server: billing error → specific "out of credits" copy; structural `invalid_request_error` → generic (text not leaked); a key-embedding provider message → canned copy, key never surfaces or logs.
- Pure-function coverage of every classifier branch and every code→copy mapping.
- Streaming-level: the SSE `error` frame carries the reason code, not the provider's message bytes.

## Relationship to the temporary #115 logging
This *reduces* reliance on that logging — classified failures now reach the user directly — but doesn't replace it: the redacted `error_detail` still illuminates the residual `provider_error` bucket, where a genuinely novel failure hides. Independent of #116 and the pending #115 revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)