### PR TITLE
chore: remove temporary keyproxy provider-error detail logging

### DIFF
--- a/keyproxy/main.py
+++ b/keyproxy/main.py
@@ -19,16 +19,9 @@ FastAPI 422, which reflects input back, is overridden). Log lines this module
 emits are the allowlist lines — correlation id, sub, provider, status — on
 *successful* redemption/validation/teardown, plus one diagnostic line when a
 provider call fails: exception class name and, for anthropic.APIStatusError
-(detected structurally, not by import), its status code and fixed error-type
-enum. Never the exception message/body text itself, which may echo request
-material.
-
-TEMPORARY (test-only): the provider-error diagnostic line also logs the
-provider's error message/body text, with the session's API key redacted, to
-chase an intermittent invalid_request_error on large tool_result follow-up
-turns. Revert this block (and the matching test changes in
-test_keyproxy_streaming.py) once that's diagnosed — see the "TEMPORARY"
-comment at the log call site.
+(detected structurally, not by import), its status code, fixed error-type
+enum, and the classified reason code (see ``_provider_reason``). Never the
+exception message/body text itself, which may echo request material.
 """
 
 from __future__ import annotations
@@ -453,26 +446,13 @@ def create_app() -> FastAPI:
                     if isinstance(err, dict):
                         error_type = err.get("type")
                         error_message = err.get("message")
-                # TEMPORARY (test-only, revert once the intermittent
-                # invalid_request_error on large tool_result follow-up turns
-                # is diagnosed): the provider's validation message is the
-                # only place that names the actual complaint. The API key is
-                # the one piece of request material known to this closure, so
-                # it's redacted before anything is logged; this does not
-                # widen the guarantee to arbitrary echoed request content.
-                error_detail = error_message if error_message is not None else str(exc)
-                error_detail = error_detail.replace(api_key, "[REDACTED]")
-                error_detail = error_detail.encode("utf-8", "replace").decode("utf-8")
-                if len(error_detail) > 300:
-                    error_detail = error_detail[:300] + "...(truncated)"
                 reason = _provider_reason(status_code, error_type, error_message)
                 logger.warning(
-                    "provider stream failed exception_type=%s status_code=%s error_type=%s reason=%s error_detail=%s",
+                    "provider stream failed exception_type=%s status_code=%s error_type=%s reason=%s",
                     type(exc).__name__,
                     status_code,
                     error_type,
                     reason,
-                    error_detail,
                 )
                 out.put(("error", {"code": reason}))
 

--- a/test_keyproxy_gateway.py
+++ b/test_keyproxy_gateway.py
@@ -212,9 +212,7 @@ class TestKeyProxyChatClient(GatewayTestBase):
         self.assertEqual(str(ctx.exception), keyproxy_gateway.PROVIDER_ERROR_MESSAGE)
         self.assertNotIn(API_KEY, str(ctx.exception))
         self.assertEqual(self.state.sessions._sessions, {})
-        # TEMPORARY: keyproxy's error_detail now logs the redacted message
-        # ("provider exploded: [REDACTED]") — the key itself must still
-        # never be logged.
+        # The exception message (which carried the key) must never be logged.
         self.assert_never_logged(API_KEY)
 
     def test_insufficient_credits_surfaces_specific_copy(self):

--- a/test_keyproxy_streaming.py
+++ b/test_keyproxy_streaming.py
@@ -130,8 +130,7 @@ class TestStreamingTurn(StreamingTestBase):
         # the wire (the SSE response), regardless of what reaches the log.
         self.assertNotIn(API_KEY, response.text)
         self.assertNotIn("blew up", response.text)
-        # TEMPORARY: error_detail now logs the redacted message ("provider
-        # blew up: [REDACTED]") — the key itself must still never be logged.
+        # The exception message (which carried the key) must never be logged.
         self.assert_never_logged(API_KEY)
 
     def test_classifiable_provider_error_emits_specific_reason_code(self):
@@ -278,9 +277,9 @@ class TestStreamingTurn(StreamingTestBase):
 
     def test_provider_error_logs_only_safe_metadata(self):
         # A bare exception (no .status_code) — e.g. the RuntimeError above,
-        # which embeds the key in its message — must never log the key, even
-        # though the TEMPORARY error_detail field logs str(exc) verbatim
-        # otherwise (there's no structured .body to redact against here).
+        # which embeds the key in its message — logs only content-free
+        # metadata: class name, status, and the classified reason code. The
+        # provider's message text (and the key inside it) never reaches a log.
         stub = stub_stream("partial", error=True)
         with patch("keyproxy.providers.anthropic.stream_turn", stub):
             self.stream(self.open_session())
@@ -289,14 +288,16 @@ class TestStreamingTurn(StreamingTestBase):
         self.assertEqual(len(diag), 1)
         self.assertIn("exception_type=RuntimeError", diag[0])
         self.assertIn("status_code=None", diag[0])
-        self.assertIn("error_detail=provider blew up: [REDACTED]", diag[0])
+        self.assertIn("reason=provider_error", diag[0])
+        # The free-text provider message is never logged — not even redacted.
+        self.assertNotIn("error_detail", diag[0])
+        self.assertNotIn("blew up", diag[0])
 
     def test_provider_status_error_logs_code_and_type_not_message(self):
         # Duck-typed anthropic.APIStatusError shape: status_code + a body
-        # whose error.message carries request-derived text. TEMPORARY: this
-        # message is now logged (to diagnose an intermittent provider 400 on
-        # large follow-up turns), but the API key embedded in it must still
-        # never reach the log — only the message with the key redacted.
+        # whose error.message carries request-derived text. Only the safe
+        # metadata — status code, fixed error-type enum, and classified reason
+        # — is logged; the message text (and the key inside it) never is.
         class FakeAPIStatusError(Exception):
             status_code = 400
             body = {
@@ -319,7 +320,10 @@ class TestStreamingTurn(StreamingTestBase):
         self.assertIn("exception_type=FakeAPIStatusError", diag[0])
         self.assertIn("status_code=400", diag[0])
         self.assertIn("error_type=invalid_request_error", diag[0])
-        self.assertIn("error_detail=tool_result for [REDACTED] is malformed", diag[0])
+        self.assertIn("reason=provider_error", diag[0])
+        # The provider's free-text message is never logged, redacted or not.
+        self.assertNotIn("error_detail", diag[0])
+        self.assertNotIn("tool_result for", diag[0])
 
 
 class TestStreamingHeartbeat(StreamingTestBase):


### PR DESCRIPTION
## What

Removes the temporary `error_detail` diagnostic logging added in #115. That line logged the provider's raw error message (with the session API key redacted) to chase an intermittent `invalid_request_error` on large `tool_result` follow-up turns.

## Why now

The probe is done:
- **#116** fixed the root cause (strip the output-only `parsed_output` field before echoing content blocks back to the API).
- **#117** added a **safe, permanent channel** — a closed set of classified `reason` codes emitted on the same log line and surfaced to the user as curated copy.

With those merged and confirmed working in test (batch queries all completed successfully), the temporary free-text field is no longer needed. It's the one piece that could echo request material beyond the api_key, so removing it restores the strict never-log posture.

## What survives

Unclassified failures still log `exception_type`, `status_code`, `error_type`, and `reason` — so category-level diagnostics remain. #117's classifier and user-facing error copy are untouched.

## Tests

Log-format tests now assert the provider's free-text message is **absent** while `reason=` is **present**. All 43 keyproxy streaming + gateway tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)