### PR TITLE
Revert PR #117 + #118: restore pre-provider-error state for testing

### DIFF
--- a/keyproxy/main.py
+++ b/keyproxy/main.py
@@ -19,9 +19,16 @@ FastAPI 422, which reflects input back, is overridden). Log lines this module
 emits are the allowlist lines — correlation id, sub, provider, status — on
 *successful* redemption/validation/teardown, plus one diagnostic line when a
 provider call fails: exception class name and, for anthropic.APIStatusError
-(detected structurally, not by import), its status code, fixed error-type
-enum, and the classified reason code (see ``_provider_reason``). Never the
-exception message/body text itself, which may echo request material.
+(detected structurally, not by import), its status code and fixed error-type
+enum. Never the exception message/body text itself, which may echo request
+material.
+
+TEMPORARY (test-only): the provider-error diagnostic line also logs the
+provider's error message/body text, with the session's API key redacted, to
+chase an intermittent invalid_request_error on large tool_result follow-up
+turns. Revert this block (and the matching test changes in
+test_keyproxy_streaming.py) once that's diagnosed — see the "TEMPORARY"
+comment at the log call site.
 """
 
 from __future__ import annotations
@@ -446,13 +453,26 @@ def create_app() -> FastAPI:
                     if isinstance(err, dict):
                         error_type = err.get("type")
                         error_message = err.get("message")
+                # TEMPORARY (test-only, revert once the intermittent
+                # invalid_request_error on large tool_result follow-up turns
+                # is diagnosed): the provider's validation message is the
+                # only place that names the actual complaint. The API key is
+                # the one piece of request material known to this closure, so
+                # it's redacted before anything is logged; this does not
+                # widen the guarantee to arbitrary echoed request content.
+                error_detail = error_message if error_message is not None else str(exc)
+                error_detail = error_detail.replace(api_key, "[REDACTED]")
+                error_detail = error_detail.encode("utf-8", "replace").decode("utf-8")
+                if len(error_detail) > 300:
+                    error_detail = error_detail[:300] + "...(truncated)"
                 reason = _provider_reason(status_code, error_type, error_message)
                 logger.warning(
-                    "provider stream failed exception_type=%s status_code=%s error_type=%s reason=%s",
+                    "provider stream failed exception_type=%s status_code=%s error_type=%s reason=%s error_detail=%s",
                     type(exc).__name__,
                     status_code,
                     error_type,
                     reason,
+                    error_detail,
                 )
                 out.put(("error", {"code": reason}))
 

--- a/keyproxy/main.py
+++ b/keyproxy/main.py
@@ -103,48 +103,6 @@ def _sse(event: str, data: dict) -> str:
     return f"event: {event}\ndata: {json.dumps(data, separators=(',', ':'))}\n\n"
 
 
-# The complete, closed set of provider-error reason codes emitted on the SSE
-# `error` frame. Only a member of this set ever crosses the wire — never the
-# provider's raw message/body text (which may echo request material, e.g. an
-# API key embedded in a message). The gateway maps each code to user-facing
-# copy; an unknown/absent code falls back to the generic provider message, so
-# adding a code here is forward/backward compatible across a deploy skew.
-PROVIDER_REASON_CODES = frozenset({
-    "insufficient_credits",
-    "authentication",
-    "permission",
-    "rate_limit",
-    "overloaded",
-    "model_unavailable",
-    "provider_error",
-})
-
-
-def _provider_reason(status_code, error_type, error_message) -> str:
-    """Classify a provider failure into one closed-set reason code.
-
-    ``error_message`` is untrusted and is *inspected only* — for the billing
-    case it is matched against a fixed, request-material-free substring — and
-    is never itself forwarded. Generic ``invalid_request_error`` complaints
-    (e.g. a malformed follow-up turn) deliberately fall through to the opaque
-    ``provider_error`` bucket rather than leaking their structural text.
-    """
-    message = (error_message or "").lower()
-    if "credit balance is too low" in message:
-        return "insufficient_credits"
-    if error_type == "authentication_error":
-        return "authentication"
-    if error_type == "permission_error":
-        return "permission"
-    if error_type == "rate_limit_error" or status_code == 429:
-        return "rate_limit"
-    if error_type == "overloaded_error" or status_code == 529:
-        return "overloaded"
-    if error_type == "not_found_error":
-        return "model_unavailable"
-    return "provider_error"
-
-
 def _parse_key_bundle(text: str) -> list[tuple[str, object]]:
     """Parse ``KEYPROXY_PRIVATE_KEYS`` — the generate-script output format.
 
@@ -434,8 +392,7 @@ def create_app() -> FastAPI:
                     out.put((kind, payload))
                     if kind == "final":
                         return
-                # Stream ended without a final frame — opaque provider fault.
-                out.put(("error", {"code": "provider_error"}))
+                out.put(("error", None))  # stream ended without a final
             except Exception as exc:
                 # Never let exception text (which may echo request material,
                 # e.g. an API key embedded in a message) reach a log — only
@@ -465,16 +422,14 @@ def create_app() -> FastAPI:
                 error_detail = error_detail.encode("utf-8", "replace").decode("utf-8")
                 if len(error_detail) > 300:
                     error_detail = error_detail[:300] + "...(truncated)"
-                reason = _provider_reason(status_code, error_type, error_message)
                 logger.warning(
-                    "provider stream failed exception_type=%s status_code=%s error_type=%s reason=%s error_detail=%s",
+                    "provider stream failed exception_type=%s status_code=%s error_type=%s error_detail=%s",
                     type(exc).__name__,
                     status_code,
                     error_type,
-                    reason,
                     error_detail,
                 )
-                out.put(("error", {"code": reason}))
+                out.put(("error", None))
 
         def event_stream():
             out: queue.Queue = queue.Queue()
@@ -517,13 +472,7 @@ def create_app() -> FastAPI:
                     )
                     return
                 else:
-                    # Only a closed-set reason code crosses the wire — never
-                    # provider text. Defensively re-validate the code against
-                    # the known set before it leaves the process.
-                    code = payload.get("code") if isinstance(payload, dict) else None
-                    if code not in PROVIDER_REASON_CODES:
-                        code = "provider_error"
-                    yield _sse("error", {"code": code})
+                    yield _sse("error", {"detail": "provider error"})
                     return
 
         # No compression middleware may ever touch text/event-stream — a

--- a/quantcore/gateways/keyproxy_gateway.py
+++ b/quantcore/gateways/keyproxy_gateway.py
@@ -75,40 +75,6 @@ AUTH_ERROR_MESSAGE = (
     "Your session's authorization was rejected — please refresh and try again."
 )
 
-# User-facing copy for each closed-set provider-error reason code the keyproxy
-# emits on the SSE `error` frame (keyproxy/main.py `PROVIDER_REASON_CODES`).
-# The keyproxy sends only the code, never the provider's raw message, so this
-# is the single place that turns a category into words. An unknown or absent
-# code falls through to PROVIDER_ERROR_MESSAGE, which keeps a new keyproxy code
-# (or an old keyproxy that sends no code at all) safe against this older map.
-_PROVIDER_REASON_COPY = {
-    "insufficient_credits": (
-        "Your Anthropic API key is out of credits. Add credits in the Anthropic "
-        "Console (Plans & Billing), then re-send your message."
-    ),
-    "authentication": (
-        "Anthropic rejected your API key. Re-enter it on the Settings page, then "
-        "re-send your message."
-    ),
-    "permission": (
-        "Your Anthropic API key doesn't have permission for this request."
-    ),
-    "rate_limit": RATE_LIMITED_MESSAGE,
-    "overloaded": (
-        "Anthropic is temporarily overloaded — please wait a moment and re-send "
-        "your message."
-    ),
-    "model_unavailable": (
-        "The selected model isn't available on your Anthropic API key."
-    ),
-}
-
-
-def _provider_error_message(data: object) -> str:
-    """Map a keyproxy `error` frame's reason code to user-facing copy."""
-    code = data.get("code") if isinstance(data, dict) else None
-    return _PROVIDER_REASON_COPY.get(code, PROVIDER_ERROR_MESSAGE)
-
 
 class KeyProxyError(RuntimeError):
     """A keyproxy interaction failed; the message is safe to show the user."""
@@ -435,7 +401,7 @@ class KeyProxyChatClient:
                         return
                     elif event == "error":
                         self.close()
-                        raise KeyProxyError(_provider_error_message(data))
+                        raise KeyProxyError(PROVIDER_ERROR_MESSAGE)
         except httpx.HTTPError:
             self.close()
             raise KeyProxyError(UNAVAILABLE_MESSAGE) from None

--- a/test_keyproxy_gateway.py
+++ b/test_keyproxy_gateway.py
@@ -62,17 +62,6 @@ def final_message(*blocks, stop_reason="end_turn", usage=None):
     }
 
 
-class FakeAPIStatusError(Exception):
-    """Shapes like anthropic.APIStatusError: a ``status_code`` int and a
-    ``body`` dict carrying ``error.type`` / ``error.message`` — the exact
-    attributes keyproxy's worker duck-types (it never imports the SDK)."""
-
-    def __init__(self, status_code, error_type, message):
-        super().__init__("api status error")
-        self.status_code = status_code
-        self.body = {"error": {"type": error_type, "message": message}}
-
-
 class ScriptedProvider:
     """Scripted stand-in for keyproxy.providers.anthropic.stream_turn.
 
@@ -95,9 +84,6 @@ class ScriptedProvider:
             self.emit_times.append(time.monotonic())
             yield ("delta", text)
         if turn.get("error"):
-            err = turn["error"]
-            if isinstance(err, BaseException):
-                raise err
             raise RuntimeError("provider exploded: " + api_key)
         if turn.get("delay"):
             time.sleep(turn["delay"])
@@ -215,67 +201,6 @@ class TestKeyProxyChatClient(GatewayTestBase):
         # TEMPORARY: keyproxy's error_detail now logs the redacted message
         # ("provider exploded: [REDACTED]") — the key itself must still
         # never be logged.
-        self.assert_never_logged(API_KEY)
-
-    def test_insufficient_credits_surfaces_specific_copy(self):
-        # The billing failure (a 400 invalid_request_error whose message is the
-        # static "credit balance is too low" string) must reach the user as its
-        # own actionable copy — not the opaque generic provider message.
-        billing = FakeAPIStatusError(
-            400, "invalid_request_error",
-            "Your credit balance is too low to access the Anthropic API. "
-            "Please go to Plans & Billing to upgrade or purchase credits.",
-        )
-        provider = ScriptedProvider([{"error": billing}])
-        client = self.make_client()
-        with patch("keyproxy.providers.anthropic.stream_turn", provider):
-            with self.assertRaises(keyproxy_gateway.KeyProxyError) as ctx:
-                self.run_turn(client)
-        self.assertEqual(
-            str(ctx.exception),
-            keyproxy_gateway._PROVIDER_REASON_COPY["insufficient_credits"],
-        )
-        self.assertNotEqual(
-            str(ctx.exception), keyproxy_gateway.PROVIDER_ERROR_MESSAGE
-        )
-        self.assertEqual(self.state.sessions._sessions, {})
-
-    def test_structural_invalid_request_stays_generic_and_unleaked(self):
-        # A structural invalid_request_error (the parsed_output-style complaint)
-        # names request material, so it must fall through to the OPAQUE generic
-        # message — its text must never reach the user.
-        structural = FakeAPIStatusError(
-            400, "invalid_request_error",
-            "messages.9.content.1.text.parsed_output: Extra inputs are not permitted",
-        )
-        provider = ScriptedProvider([{"error": structural}])
-        client = self.make_client()
-        with patch("keyproxy.providers.anthropic.stream_turn", provider):
-            with self.assertRaises(keyproxy_gateway.KeyProxyError) as ctx:
-                self.run_turn(client)
-        self.assertEqual(
-            str(ctx.exception), keyproxy_gateway.PROVIDER_ERROR_MESSAGE
-        )
-        self.assertNotIn("parsed_output", str(ctx.exception))
-
-    def test_provider_error_message_never_echoes_key_or_body(self):
-        # Safety net: even if the provider's message embeds the API key, the
-        # user-facing copy is our canned string and the key never surfaces —
-        # in the message or in any log line.
-        leaky = FakeAPIStatusError(
-            401, "authentication_error",
-            "invalid x-api-key: " + API_KEY,
-        )
-        provider = ScriptedProvider([{"error": leaky}])
-        client = self.make_client()
-        with patch("keyproxy.providers.anthropic.stream_turn", provider):
-            with self.assertRaises(keyproxy_gateway.KeyProxyError) as ctx:
-                self.run_turn(client)
-        self.assertEqual(
-            str(ctx.exception),
-            keyproxy_gateway._PROVIDER_REASON_COPY["authentication"],
-        )
-        self.assertNotIn(API_KEY, str(ctx.exception))
         self.assert_never_logged(API_KEY)
 
     def test_expired_session_mid_chat_surfaces_clean_resend_error(self):
@@ -445,59 +370,6 @@ class TestKeyProxyChatClient(GatewayTestBase):
         self.assertNotIn("parsed_output", assistant["content"][0])
         # The adjacent tool_use block is untouched.
         self.assertEqual(assistant["content"][1], TOOL_USE_BLOCK)
-
-
-class TestProviderErrorClassification(unittest.TestCase):
-    """The keyproxy classifier + gateway translator, as pure functions."""
-
-    def test_reason_codes_cover_every_branch(self):
-        from keyproxy.main import _provider_reason
-
-        cases = [
-            # (status_code, error_type, message) -> reason
-            (400, "invalid_request_error",
-             "Your credit balance is too low to access the Anthropic API.",
-             "insufficient_credits"),
-            (401, "authentication_error", "invalid x-api-key", "authentication"),
-            (403, "permission_error", "not allowed", "permission"),
-            (429, "rate_limit_error", "slow down", "rate_limit"),
-            (429, None, "slow down", "rate_limit"),          # status-only
-            (529, "overloaded_error", "busy", "overloaded"),
-            (529, None, "busy", "overloaded"),               # status-only
-            (404, "not_found_error", "no such model", "model_unavailable"),
-            (400, "invalid_request_error",
-             "messages.9.content.1.text.parsed_output: Extra inputs are not permitted",
-             "provider_error"),                              # structural -> opaque
-            (None, None, None, "provider_error"),            # nothing known
-        ]
-        for status, etype, msg, expected in cases:
-            with self.subTest(expected=expected):
-                self.assertEqual(_provider_reason(status, etype, msg), expected)
-
-    def test_every_reason_code_has_gateway_copy_or_generic(self):
-        from keyproxy.main import PROVIDER_REASON_CODES
-
-        # Every code the keyproxy can emit resolves to non-empty user copy.
-        for code in PROVIDER_REASON_CODES:
-            msg = keyproxy_gateway._provider_error_message({"code": code})
-            self.assertTrue(msg)
-        # provider_error and any unknown/absent code fall to the generic string.
-        self.assertEqual(
-            keyproxy_gateway._provider_error_message({"code": "provider_error"}),
-            keyproxy_gateway.PROVIDER_ERROR_MESSAGE,
-        )
-        self.assertEqual(
-            keyproxy_gateway._provider_error_message({"code": "nonexistent"}),
-            keyproxy_gateway.PROVIDER_ERROR_MESSAGE,
-        )
-        self.assertEqual(
-            keyproxy_gateway._provider_error_message({}),
-            keyproxy_gateway.PROVIDER_ERROR_MESSAGE,
-        )
-        self.assertEqual(
-            keyproxy_gateway._provider_error_message(None),
-            keyproxy_gateway.PROVIDER_ERROR_MESSAGE,
-        )
 
 
 class TestClientHeartbeatTolerance(GatewayTestBase):

--- a/test_keyproxy_gateway.py
+++ b/test_keyproxy_gateway.py
@@ -212,7 +212,9 @@ class TestKeyProxyChatClient(GatewayTestBase):
         self.assertEqual(str(ctx.exception), keyproxy_gateway.PROVIDER_ERROR_MESSAGE)
         self.assertNotIn(API_KEY, str(ctx.exception))
         self.assertEqual(self.state.sessions._sessions, {})
-        # The exception message (which carried the key) must never be logged.
+        # TEMPORARY: keyproxy's error_detail now logs the redacted message
+        # ("provider exploded: [REDACTED]") — the key itself must still
+        # never be logged.
         self.assert_never_logged(API_KEY)
 
     def test_insufficient_credits_surfaces_specific_copy(self):

--- a/test_keyproxy_streaming.py
+++ b/test_keyproxy_streaming.py
@@ -130,7 +130,8 @@ class TestStreamingTurn(StreamingTestBase):
         # the wire (the SSE response), regardless of what reaches the log.
         self.assertNotIn(API_KEY, response.text)
         self.assertNotIn("blew up", response.text)
-        # The exception message (which carried the key) must never be logged.
+        # TEMPORARY: error_detail now logs the redacted message ("provider
+        # blew up: [REDACTED]") — the key itself must still never be logged.
         self.assert_never_logged(API_KEY)
 
     def test_classifiable_provider_error_emits_specific_reason_code(self):
@@ -277,9 +278,9 @@ class TestStreamingTurn(StreamingTestBase):
 
     def test_provider_error_logs_only_safe_metadata(self):
         # A bare exception (no .status_code) — e.g. the RuntimeError above,
-        # which embeds the key in its message — logs only content-free
-        # metadata: class name, status, and the classified reason code. The
-        # provider's message text (and the key inside it) never reaches a log.
+        # which embeds the key in its message — must never log the key, even
+        # though the TEMPORARY error_detail field logs str(exc) verbatim
+        # otherwise (there's no structured .body to redact against here).
         stub = stub_stream("partial", error=True)
         with patch("keyproxy.providers.anthropic.stream_turn", stub):
             self.stream(self.open_session())
@@ -288,16 +289,14 @@ class TestStreamingTurn(StreamingTestBase):
         self.assertEqual(len(diag), 1)
         self.assertIn("exception_type=RuntimeError", diag[0])
         self.assertIn("status_code=None", diag[0])
-        self.assertIn("reason=provider_error", diag[0])
-        # The free-text provider message is never logged — not even redacted.
-        self.assertNotIn("error_detail", diag[0])
-        self.assertNotIn("blew up", diag[0])
+        self.assertIn("error_detail=provider blew up: [REDACTED]", diag[0])
 
     def test_provider_status_error_logs_code_and_type_not_message(self):
         # Duck-typed anthropic.APIStatusError shape: status_code + a body
-        # whose error.message carries request-derived text. Only the safe
-        # metadata — status code, fixed error-type enum, and classified reason
-        # — is logged; the message text (and the key inside it) never is.
+        # whose error.message carries request-derived text. TEMPORARY: this
+        # message is now logged (to diagnose an intermittent provider 400 on
+        # large follow-up turns), but the API key embedded in it must still
+        # never reach the log — only the message with the key redacted.
         class FakeAPIStatusError(Exception):
             status_code = 400
             body = {
@@ -320,10 +319,7 @@ class TestStreamingTurn(StreamingTestBase):
         self.assertIn("exception_type=FakeAPIStatusError", diag[0])
         self.assertIn("status_code=400", diag[0])
         self.assertIn("error_type=invalid_request_error", diag[0])
-        self.assertIn("reason=provider_error", diag[0])
-        # The provider's free-text message is never logged, redacted or not.
-        self.assertNotIn("error_detail", diag[0])
-        self.assertNotIn("tool_result for", diag[0])
+        self.assertIn("error_detail=tool_result for [REDACTED] is malformed", diag[0])
 
 
 class TestStreamingHeartbeat(StreamingTestBase):

--- a/test_keyproxy_streaming.py
+++ b/test_keyproxy_streaming.py
@@ -123,43 +123,13 @@ class TestStreamingTurn(StreamingTestBase):
             response = self.stream(self.open_session())
         self.assertEqual(response.status_code, 200)
         _, events = parse_sse(response.text)
-        # A bare RuntimeError classifies to the opaque provider_error code —
-        # only a closed-set reason code crosses the wire, never provider text.
-        self.assertEqual(events[-1], ("error", {"code": "provider_error"}))
+        self.assertEqual(events[-1], ("error", {"detail": "provider error"}))
         # The exception message carried the key — it must never surface on
         # the wire (the SSE response), regardless of what reaches the log.
         self.assertNotIn(API_KEY, response.text)
         self.assertNotIn("blew up", response.text)
         # TEMPORARY: error_detail now logs the redacted message ("provider
         # blew up: [REDACTED]") — the key itself must still never be logged.
-        self.assert_never_logged(API_KEY)
-
-    def test_classifiable_provider_error_emits_specific_reason_code(self):
-        # The billing failure (a 400 whose message is the static "credit
-        # balance is too low" string) must reach the SSE `error` frame as its
-        # specific reason code — but the provider's raw message must NOT.
-        class FakeAPIStatusError(Exception):
-            status_code = 400
-            body = {
-                "error": {
-                    "type": "invalid_request_error",
-                    "message": "Your credit balance is too low to access the "
-                    "Anthropic API. Please go to Plans & Billing. " + API_KEY,
-                },
-            }
-
-        def stream_turn(api_key, **params):
-            yield ("delta", "partial")
-            raise FakeAPIStatusError("unused")
-
-        with patch("keyproxy.providers.anthropic.stream_turn", stream_turn):
-            response = self.stream(self.open_session())
-        self.assertEqual(response.status_code, 200)
-        _, events = parse_sse(response.text)
-        self.assertEqual(events[-1], ("error", {"code": "insufficient_credits"}))
-        # Only the code crosses the wire — never the provider's message bytes.
-        self.assertNotIn("credit balance", response.text)
-        self.assertNotIn(API_KEY, response.text)
         self.assert_never_logged(API_KEY)
 
     def test_call_budget_counted_then_exhausted_then_killed(self):


### PR DESCRIPTION
Reverts **PR #117** (`feat: surface classified provider errors`) and **PR #118** (`chore: remove temporary keyproxy provider-error detail logging`) to roll `main` back to the state before those changes so we can do additional testing on the provider-error surfacing behavior.

Result: `main`'s content becomes identical to commit `0a26df2` (Merge PR #116). Verified locally — `git diff 0a26df2 <branch-head>` is empty.

Merging this triggers `deploy.yml` to roll the reverted state out to the **test** environment. Prod is unaffected.

**To restore the feature after testing:** revert these two revert commits (or cherry-pick `e9d3a35` and `3f4e2a4`) in a follow-up PR.