### PR TITLE
Tests: backend coverage campaign — 69.6% → 85.5%, floor 84 (804 tests)

### DIFF
--- a/test_fundamentals_service.py
+++ b/test_fundamentals_service.py
@@ -489,5 +489,122 @@ class TestComputeEarningsCalendar(FundamentalsServiceTestBase):
         self.assertEqual(out["historical_avg_move_pct"], 10.0)
 
 
+# ---------------------------------------------------------------------------
+# Cache-backed collection surfaces (85%-campaign part 5)
+# ---------------------------------------------------------------------------
+
+import time as _time  # noqa: E402
+
+
+def cal_entry(sym, days_out, fetched_ago_s=60, risk="MODERATE"):
+    return {
+        "symbol": sym,
+        "earnings_date": (date.today() + timedelta(days=days_out)).isoformat(),
+        "risk_level": risk,
+        "pre_earnings_setup": risk == "MODERATE",
+        "historical_avg_move_pct": 5.5,
+        "fetched_at": "2026-07-24T00:00:00Z",
+        "_fetched_at_ts": int(_time.time()) - fetched_ago_s,
+    }
+
+
+class TestUpcomingEarnings(FundamentalsServiceTestBase):
+    def test_window_staleness_and_ordering(self):
+        self.repo.ttl_seconds.return_value = 3600.0
+        self.repo.get_all_latest.return_value = [
+            cal_entry("SOON", 3),
+            cal_entry("LATER", 10),
+            cal_entry("FAR", 40),                      # outside the 14d window
+            cal_entry("STALE", 5, fetched_ago_s=999_999),
+            {"symbol": "NODATE", "_fetched_at_ts": int(_time.time())},
+        ]
+        out = self.service.get_upcoming_earnings(days=14)
+        self.assertEqual([u["symbol"] for u in out["upcoming"]], ["SOON", "LATER"])
+        self.assertEqual(out["stale_excluded"], 1)
+        self.assertEqual(out["total_in_cache"], 5)
+
+    def test_include_stale_keeps_and_flags(self):
+        self.repo.ttl_seconds.return_value = 3600.0
+        self.repo.get_all_latest.return_value = [
+            cal_entry("STALE", 5, fetched_ago_s=999_999)
+        ]
+        out = self.service.get_upcoming_earnings(days=14, include_stale=True)
+        self.assertEqual(out["count"], 1)
+        self.assertTrue(out["upcoming"][0]["stale"])
+
+
+def score_entry(sym, score, sector="Tech", coverage=0.9):
+    return {"symbol": sym, "composite_score": score, "sector": sector,
+            "coverage": coverage, "fundamental_label": "solid"}
+
+
+class TestSectorBreakdown(FundamentalsServiceTestBase):
+    def test_grouping_ranking_and_filter(self):
+        self.repo.get_all_latest.return_value = [
+            score_entry("AAA", 3), score_entry("BBB", 9),
+            score_entry("CCC", 5, sector="Energy"),
+            {"symbol": "NOSECTOR", "composite_score": 1},   # -> "Unknown"
+        ]
+        out = self.service.get_sector_fundamental_breakdown(top_n=5)
+        self.assertEqual(out["sector_count"], 3)
+        tech = out["sectors"]["Tech"]
+        self.assertEqual([e["symbol"] for e in tech], ["BBB", "AAA"])
+        self.assertEqual(tech[0]["rank"], 1)
+
+        only_energy = self.service.get_sector_fundamental_breakdown(sector="energy")
+        self.assertEqual(list(only_energy["sectors"]), ["Energy"])
+
+    def test_cache_stats_passthrough(self):
+        self.repo.stats.return_value = {"data_types": []}
+        self.assertEqual(self.service.get_cache_stats(), {"data_types": []})
+
+
+class TestScoreChanges(FundamentalsServiceTestBase):
+    def arm_history(self, then, now):
+        self.repo.get_all_latest.return_value = [score_entry("MOVER", now)]
+        self.repo.history.return_value = [
+            {"composite_score": then, "fundamental_label": "weak",
+             "fetched_at": "t0"},
+            {"composite_score": now, "fundamental_label": "solid",
+             "fetched_at": "t1"},
+        ]
+
+    def test_improver_detected_with_delta(self):
+        self.arm_history(then=2, now=8)
+        out = self.service.get_fundamental_score_changes(min_delta=2)
+        self.assertEqual(len(out["changes"]), 1)
+        change = out["changes"][0]
+        self.assertEqual(change["delta"], 6)
+        self.assertEqual(change["direction"], "improving")
+
+    def test_direction_and_min_delta_filters(self):
+        self.arm_history(then=2, now=8)
+        out = self.service.get_fundamental_score_changes(direction="deteriorating")
+        self.assertEqual(out["changes"], [])
+        out = self.service.get_fundamental_score_changes(min_delta=10)
+        self.assertEqual(out["changes"], [])
+
+    def test_insufficient_history_counted(self):
+        self.repo.get_all_latest.return_value = [score_entry("NEWB", 5)]
+        self.repo.history.return_value = [{"composite_score": 5}]
+        out = self.service.get_fundamental_score_changes()
+        self.assertEqual(out["symbols_with_insufficient_history"], 1)
+        self.assertEqual(out["changes"], [])
+
+
+class TestFundamentalHistory(FundamentalsServiceTestBase):
+    def test_invalid_data_type_rejected(self):
+        out = self.service.get_fundamental_history("intc", "nonsense")
+        self.assertIn("error", out)
+
+    def test_score_trend_labels(self):
+        self.repo.history.return_value = [
+            {"composite_score": 2, "fetched_at": "t0"},
+            {"composite_score": 7, "fetched_at": "t1"},
+        ]
+        out = self.service.get_fundamental_history("INTC", "fundamental_score")
+        self.assertEqual(out.get("trend"), "improving")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test_harvester_repository_db.py
+++ b/test_harvester_repository_db.py
@@ -171,3 +171,67 @@ class HarvesterRepoTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+# ---------------------------------------------------------------------------
+# HarvesterService scan path (85%-campaign part 10) — real plans in the test
+# DB, price feed stubbed at the _latest_close seam.
+# ---------------------------------------------------------------------------
+
+from unittest.mock import Mock, patch  # noqa: E402
+
+from quantcore.services.harvester import HarvesterService  # noqa: E402
+
+
+class HarvesterScanTest(HarvesterRepoTest):
+    def make_service(self):
+        return HarvesterService(self.db, yfinance_gateway=Mock())
+
+    def test_scan_fires_on_target_touch_and_marks_the_rung(self):
+        plan = self.build()
+        rungs = self.db.get_rungs_for_plan(plan["instance_id"])
+        first = rungs[0]
+        service = self.make_service()
+
+        with patch.object(service, "_latest_close",
+                          return_value=float(first["target_price"]) * 1.001):
+            fired = service.scan_and_fire_alerts()
+
+        mine = [f for f in fired if f["symbol"] == SYM]
+        self.assertEqual(len(mine), 1)
+        self.assertEqual(mine[0]["rung_id"], first["rung_id"])
+        self.assertEqual(mine[0]["target_price"], float(first["target_price"]))
+        after = self.db.get_rung_by_id(first["rung_id"])
+        self.assertNotEqual(str(after.get("status", "")).upper(), "PENDING")
+
+        # Second scan at the same price: rung 1 is no longer pending and rung 2
+        # is above the price, so nothing fires for this symbol.
+        with patch.object(service, "_latest_close",
+                          return_value=float(first["target_price"]) * 1.001):
+            again = service.scan_and_fire_alerts()
+        self.assertEqual([f for f in again if f["symbol"] == SYM], [])
+
+    def test_scan_holds_below_target_or_without_price(self):
+        plan = self.build()
+        first = self.db.get_rungs_for_plan(plan["instance_id"])[0]
+        service = self.make_service()
+        with patch.object(service, "_latest_close",
+                          return_value=float(first["target_price"]) * 0.5):
+            self.assertEqual(
+                [f for f in service.scan_and_fire_alerts() if f["symbol"] == SYM], []
+            )
+        with patch.object(service, "_latest_close", return_value=None):
+            self.assertEqual(
+                [f for f in service.scan_and_fire_alerts() if f["symbol"] == SYM], []
+            )
+
+    def test_latest_close_seam_degrades(self):
+        gateway = Mock()
+        service = HarvesterService(self.db, yfinance_gateway=gateway)
+        gateway.fetch_history.return_value = bars(n=5)
+        self.assertAlmostEqual(service.poll_latest_close("ZZX"),
+                               float(bars(n=5)["Close"].iloc[-1]))
+        gateway.fetch_history.return_value = bars(n=5).iloc[0:0]   # empty
+        self.assertIsNone(service.poll_latest_close("ZZX"))
+        gateway.fetch_history.side_effect = RuntimeError("yahoo down")
+        self.assertIsNone(service.poll_latest_close("ZZX"))

--- a/test_harvester_repository_db.py
+++ b/test_harvester_repository_db.py
@@ -1,0 +1,173 @@
+"""Seeded-test-DB tests for HarvesterPlanDB's build/CRUD/harvest surfaces
+(85%-campaign; the service-level scan paths are pinned in
+test_harvester_service.py — this file exercises the repository directly,
+including the real build_plan with injected bars per the issue-#74 seam).
+"""
+import os
+import unittest
+from contextlib import closing
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+# Swap in the test DSN BEFORE quantcore.db is imported (frozen at import).
+_env_file = Path(__file__).parent / ".env"
+if _env_file.exists():
+    for _line in _env_file.read_text().splitlines():
+        if _line.strip().startswith("QUANTCORE_TEST_DB_DSN="):
+            os.environ["QUANTCORE_DB_DSN"] = _line.split("=", 1)[1].strip()
+            break
+
+from quantcore.db_safety import assert_not_production  # noqa: E402
+
+assert_not_production()
+
+from quantcore.db import get_connection  # noqa: E402
+from quantcore.repositories.harvester_repository import (  # noqa: E402
+    HarvesterPlanDB,
+    PlanBuildParams,
+)
+
+SYM = "ZZHARVREPO"
+TEMPLATE = "zz_harv_repo_template"
+
+
+def bars(n=500, start=50.0, end=150.0):
+    idx = pd.bdate_range(end="2026-07-17", periods=n)  # a Friday — bdate-safe
+    closes = np.linspace(start, end, n) + 2.0 * np.sin(np.arange(n) / 7.0)
+    return pd.DataFrame(
+        {
+            "Open": closes * 0.999,
+            "High": closes * 1.01,
+            "Low": closes * 0.99,
+            "Close": closes,
+            "Adj Close": closes,
+            "Volume": [1_000_000] * n,
+        },
+        index=idx,
+    )
+
+
+class HarvesterRepoTest(unittest.TestCase):
+    def setUp(self):
+        self._purge()
+        self.addCleanup(self._purge)
+        self.db = HarvesterPlanDB()
+
+    def _purge(self):
+        with closing(get_connection()) as conn:
+            conn.execute(
+                "DELETE FROM plan_instances WHERE symbol_id IN "
+                "(SELECT symbol_id FROM symbols WHERE ticker = %s)", (SYM,)
+            )
+            conn.execute("DELETE FROM symbols WHERE ticker = %s", (SYM,))
+            conn.execute("DELETE FROM plan_templates WHERE name = %s", (TEMPLATE,))
+            conn.commit()
+
+    def build(self, **params_kw):
+        return self.db.build_plan(
+            symbol=SYM, template_name=TEMPLATE,
+            params=PlanBuildParams(**params_kw), bars=bars(),
+        )
+
+    # -- build_plan ---------------------------------------------------------
+
+    def test_build_plan_creates_instance_and_ladder(self):
+        plan = self.build()
+        self.assertEqual(plan["symbol"], SYM)
+        self.assertIn("instance_id", plan)
+        rungs = self.db.get_rungs_for_plan(plan["instance_id"])
+        self.assertGreaterEqual(len(rungs), 1)
+        prices = [float(r["target_price"]) for r in rungs]
+        self.assertEqual(prices, sorted(prices))          # ascending ladder
+        # H respects the configured bounds.
+        self.assertGreaterEqual(float(plan["H"]), 0.05)
+        self.assertLessEqual(float(plan["H"]), 0.30)
+
+    def test_rebuild_supersedes_previous_active_plan(self):
+        first = self.build()
+        second = self.build()
+        self.assertNotEqual(first["instance_id"], second["instance_id"])
+        plans = [p for p in self.db.display_all_plans(status="ACTIVE")
+                 if p["symbol"] == SYM]
+        self.assertEqual(len(plans), 1)
+        self.assertEqual(plans[0]["instance_id"], second["instance_id"])
+
+    # -- CRUD surfaces --------------------------------------------------------
+
+    def test_get_update_delete_lifecycle(self):
+        plan = self.build()
+        iid = plan["instance_id"]
+        fetched = self.db.get_plan_by_id(iid)
+        self.assertEqual(fetched["symbol"], SYM)
+        self.assertIsNone(self.db.get_plan_by_id(99_999_999))
+
+        rung = self.db.get_rungs_for_plan(iid)[0]
+        self.assertEqual(
+            self.db.get_rung_by_id(rung["rung_id"])["rung_id"], rung["rung_id"]
+        )
+
+        self.assertTrue(self.db.update_plan_metadata(iid, notes="reviewed"))
+        self.assertEqual(self.db.get_plan_by_id(iid)["notes"], "reviewed")
+        self.assertFalse(self.db.update_plan_metadata(iid))   # nothing to update
+
+        # delete_plan is a SOFT delete: the row survives as SUPERSEDED.
+        self.assertTrue(self.db.delete_plan(iid))
+        self.assertEqual(self.db.get_plan_by_id(iid)["status"], "SUPERSEDED")
+        actives = [p for p in self.db.display_all_plans(status="ACTIVE")
+                   if p["symbol"] == SYM]
+        self.assertEqual(actives, [])
+
+    def test_list_symbols_and_dashboard_stats(self):
+        self.build()
+        symbols = [s for s in self.db.list_all_symbols() if s.get("ticker") == SYM
+                   or s.get("symbol") == SYM]
+        self.assertEqual(len(symbols), 1)
+        stats = self.db.get_dashboard_stats()
+        self.assertIsInstance(stats, dict)
+        self.assertTrue(stats)                            # non-empty aggregate
+
+    # -- Harvest evaluation ---------------------------------------------------
+
+    def test_harvest_points_and_rung_achievement(self):
+        plan = self.build()
+        iid = plan["instance_id"]
+        rungs = self.db.get_rungs_for_plan(iid)
+        first_target = float(rungs[0]["target_price"])
+
+        # Price above the first rung -> the symbol is at a harvest point.
+        hits = self.db.symbols_at_harvest_points(
+            price_lookup=lambda s: first_target * 1.01
+        )
+        mine = [h for h in hits if h["symbol"] == SYM]
+        self.assertGreaterEqual(len(mine), 1)
+
+        # Direct hit check + marking the rung achieved.
+        hit = self.db.harvest_hit_for_symbol(SYM, current_price=first_target * 1.01)
+        self.assertTrue(hit)
+        updated = self.db.mark_rungs_achieved(
+            [rungs[0]["rung_id"]], trigger_price=first_target * 1.01
+        )
+        self.assertEqual(updated, 1)
+        after = self.db.get_rung_by_id(rungs[0]["rung_id"])
+        self.assertNotEqual(str(after.get("status", "")).upper(), "PENDING")
+        self.assertEqual(self.db.mark_rungs_achieved([], trigger_price=1.0), 0)
+
+        # Below every rung -> no hit.
+        self.assertFalse(
+            self.db.harvest_hit_for_symbol(SYM, current_price=first_target * 0.5)
+        )
+
+    def test_purge_superseded_plans(self):
+        self.build()
+        self.build()                                       # supersedes the first
+        removed = self.db.purge_superseded_plans()
+        self.assertIsInstance(removed, (int, list))
+        actives = [p for p in self.db.display_all_plans(status="ACTIVE")
+                   if p["symbol"] == SYM]
+        self.assertEqual(len(actives), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_mcp_seam.py
+++ b/test_mcp_seam.py
@@ -1,0 +1,147 @@
+"""Tests for the MCP gateway seam and the company-fundamentals wrapper
+(85%-campaign part 9): mcp_gateway/rest_client.py — the SINGLE conduit every
+wrapper uses to reach the REST tier — plus the last 0%-covered wrapper's tool
+bodies (one rest_client call deep, Rule 6). httpx is mocked at the transport
+boundary; no network.
+"""
+import os
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import httpx
+
+# Defensive DSN preamble (quantcore.db freezes its DSN at first import).
+_env_file = Path(__file__).parent / ".env"
+if _env_file.exists():
+    for _line in _env_file.read_text().splitlines():
+        if _line.strip().startswith("QUANTCORE_TEST_DB_DSN="):
+            os.environ["QUANTCORE_DB_DSN"] = _line.split("=", 1)[1].strip()
+            break
+
+from fastMCPTest import company_fundamentals_server as cfs  # noqa: E402
+from mcp_gateway import rest_client  # noqa: E402
+
+
+def http_response(status=200, json_body=None, text_body=None):
+    request = httpx.Request("GET", "http://testserver/x")
+    if text_body is not None:
+        return httpx.Response(status, text=text_body, request=request)
+    return httpx.Response(status, json=json_body if json_body is not None else {},
+                          request=request)
+
+
+class TestRestClientConfig(unittest.TestCase):
+    def test_base_url_and_timeout_env_overrides(self):
+        with patch.dict(os.environ, {"QUANTCORE_REST_URL": "https://api.example.com/"}):
+            self.assertEqual(rest_client._base_url(), "https://api.example.com")
+        with patch.dict(os.environ, {"QUANTCORE_REST_TIMEOUT": "5.5"}):
+            self.assertEqual(rest_client._timeout(), 5.5)
+        with patch.dict(os.environ, {"QUANTCORE_REST_TIMEOUT": "not-a-number"}):
+            self.assertEqual(rest_client._timeout(), rest_client.DEFAULT_TIMEOUT)
+
+    def test_path_normalization(self):
+        self.assertEqual(rest_client._path("api/x"), "/api/x")
+        self.assertEqual(rest_client._path("/api/x"), "/api/x")
+
+    def test_headers_prefer_explicit_token(self):
+        headers = rest_client._headers("tok-123")
+        self.assertEqual(headers["Authorization"], "Bearer tok-123")
+
+    def test_incoming_bearer_lifted_from_mcp_request(self):
+        with patch("fastmcp.server.dependencies.get_http_headers",
+                   return_value={"authorization": "Bearer agent-jwt"}):
+            self.assertEqual(rest_client._incoming_auth_token(), "agent-jwt")
+        with patch("fastmcp.server.dependencies.get_http_headers",
+                   return_value={}):
+            self.assertIsNone(rest_client._incoming_auth_token())
+
+    def test_handle_success_error_and_non_json(self):
+        self.assertEqual(rest_client._handle(http_response(200, {"ok": 1})), {"ok": 1})
+        with self.assertRaises(rest_client.RestError) as ctx:
+            rest_client._handle(http_response(500, {"error": "boom"}))
+        self.assertEqual(ctx.exception.status_code, 500)
+        self.assertEqual(ctx.exception.payload, {"error": "boom"})
+        with self.assertRaises(rest_client.RestError) as ctx:
+            rest_client._handle(http_response(502, text_body="<html>bad gateway"))
+        self.assertIn("error", ctx.exception.payload)
+
+
+class TestRestClientVerbs(unittest.TestCase):
+    def arm_client(self, response):
+        client = Mock()
+        client.__enter__ = Mock(return_value=client)
+        client.__exit__ = Mock(return_value=False)
+        client.get.return_value = response
+        client.post.return_value = response
+        return client
+
+    def test_get_drops_none_params_and_returns_payload(self):
+        client = self.arm_client(http_response(200, {"ok": True}))
+        with patch.object(httpx, "Client", return_value=client):
+            out = rest_client.get("/api/x", days=30, kind=None,
+                                  strikes=[120.0, 125.0])
+        self.assertEqual(out, {"ok": True})
+        _, kwargs = client.get.call_args
+        self.assertEqual(kwargs["params"], {"days": 30, "strikes": [120.0, 125.0]})
+
+    def test_post_forwards_json_body_and_raises_on_error(self):
+        client = self.arm_client(http_response(402, {"error": "plan"}))
+        with patch.object(httpx, "Client", return_value=client):
+            with self.assertRaises(rest_client.RestError) as ctx:
+                rest_client.post("/api/y", json={"a": 1})
+        self.assertEqual(ctx.exception.status_code, 402)
+        _, kwargs = client.post.call_args
+        self.assertEqual(kwargs["json"], {"a": 1})
+
+
+class TestCompanyFundamentalsWrapper(unittest.TestCase):
+    """Every tool body must be exactly one rest_client call deep (Rule 6)."""
+
+    def test_symbol_tools_hit_their_routes(self):
+        cases = [
+            (lambda: cfs.get_earnings_calendar("intc"), "get", "earnings-calendar"),
+            (lambda: cfs.get_fundamental_score("intc"), "get", "fundamentals/score"),
+            (lambda: cfs.get_revenue_growth("intc"), "get", "revenue-growth"),
+            (lambda: cfs.get_earnings_acceleration("intc"), "get", "earnings-acceleration"),
+            (lambda: cfs.get_full_fundamental_profile("intc"), "get", "/fundamentals"),
+        ]
+        for call, verb, fragment in cases:
+            with patch.object(cfs, "rest_client") as rc:
+                getattr(rc, verb).return_value = {"ok": True}
+                out = call()
+                self.assertEqual(out, {"ok": True}, fragment)
+                path = getattr(rc, verb).call_args[0][0]
+                self.assertIn(fragment, path)
+                self.assertIn("intc", path)
+
+    def test_collection_tools(self):
+        with patch.object(cfs, "rest_client") as rc:
+            rc.post.return_value = {"ok": True}
+            rc.get.return_value = {"ok": True}
+
+            cfs.get_fundamental_scores_batch(["a", "b"])
+            self.assertIn("scores-batch", rc.post.call_args[0][0])
+            self.assertEqual(rc.post.call_args[1]["json"], {"symbols": ["a", "b"]})
+
+            cfs.get_top_fundamental_stocks(n=5, min_coverage=0.7)
+            self.assertIn("fundamentals/top", rc.get.call_args[0][0])
+            self.assertEqual(rc.get.call_args[1]["n"], 5)
+
+    def test_remaining_collection_tools_route_correctly(self):
+        with patch.object(cfs, "rest_client") as rc:
+            rc.get.return_value = {"ok": True}
+            cfs.get_upcoming_earnings(days=7)
+            self.assertIn("upcoming-earnings", rc.get.call_args[0][0])
+            cfs.get_cache_stats()
+            self.assertIn("cache-stats", rc.get.call_args[0][0])
+            cfs.get_sector_fundamental_breakdown(sector="Tech")
+            self.assertIn("sector-breakdown", rc.get.call_args[0][0])
+            cfs.get_fundamental_score_changes(min_delta=3)
+            self.assertIn("score-changes", rc.get.call_args[0][0])
+            cfs.get_fundamental_history("intc", "fundamental_score")
+            self.assertIn("history", rc.get.call_args[0][0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_options_analysis_cli.py
+++ b/test_options_analysis_cli.py
@@ -1,0 +1,267 @@
+"""Tests for fastMCPTest/options_analysis.py — the hybrid MCP-wrapper + CLI
+reporter (85%-coverage campaign; previously 0%).
+
+The console reporters are pure formatting over SecurityAnalysis fixtures and
+the real (pure) screening service methods; output is captured and asserted on
+the load-bearing strings/branches. The MCP tool bodies are one rest_client
+call deep — pinned with a mocked client (URL + params).
+"""
+import io
+import os
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+# Swap in the test DSN BEFORE quantcore.db is imported transitively (DB_DSN
+# freezes at import time; this module sorts ahead of DB-backed suites).
+_env_file = Path(__file__).parent / ".env"
+if _env_file.exists():
+    for _line in _env_file.read_text().splitlines():
+        if _line.strip().startswith("QUANTCORE_TEST_DB_DSN="):
+            os.environ["QUANTCORE_DB_DSN"] = _line.split("=", 1)[1].strip()
+            break
+
+from quantcore.db_safety import assert_not_production  # noqa: E402
+
+assert_not_production()
+
+from fastMCPTest import options_analysis as oa  # noqa: E402
+from quantcore.services.options_screening import (  # noqa: E402
+    BollingerBands,
+    IVAnalysis,
+    OptionsSummary,
+    PutCallAnalysis,
+    SecurityAnalysis,
+)
+
+
+def out_of(fn, *args, **kwargs) -> str:
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        fn(*args, **kwargs)
+    return buf.getvalue()
+
+
+def security(symbol="TST", price=100.0, **kw):
+    sec = SecurityAnalysis(
+        symbol=symbol, name=f"{symbol} Co", tags=[], price=price,
+        bands=BollingerBands(upper=110.0, middle=100.0, lower=90.0),
+        options=kw.pop("options", None),
+    )
+    for key, value in kw.items():
+        setattr(sec, key, value)
+    return sec
+
+
+def options_summary(**kw):
+    base = dict(expiration="2026-08-21", put_call_ratio=1.0,
+                total_call_oi=1_000, total_put_oi=1_000,
+                total_call_volume=1_000, total_put_volume=1_000,
+                avg_call_iv=40.0, avg_put_iv=40.0,
+                atm_calls=[], atm_puts=[])
+    base.update(kw)
+    return OptionsSummary(**base)
+
+
+def pc_analysis(**kw):
+    base = dict(near_expiry="2026-08-21", near_oi_pc=1.4, near_vol_pc=0.9,
+                near_atm_pc=1.1, mid_expiry="2026-09-18", mid_oi_pc=1.0,
+                term_skew=0.4, vol_oi_ratio=0.64,
+                put_unwinding=True, fresh_put_buying=False,
+                near_term_fear=True)
+    base.update(kw)
+    return PutCallAnalysis(**base)
+
+
+IV = IVAnalysis(current_iv=55.0, hv_30=40.0, iv_vs_hv=1.4, hv_52w_low=20.0,
+                hv_52w_high=80.0, iv_rank=58.0, iv_percentile=61.0,
+                label="elevated fear")
+
+ATM_CALL = {"strike": 100.0, "ask": 3.0, "iv": 40.0}
+ATM_PUT = {"strike": 100.0, "ask": 3.0, "iv": 40.0}
+
+
+class TestFormattingHelpers(unittest.TestCase):
+    def test_bb_bar_marker_placement_and_clamping(self):
+        self.assertEqual(oa._bb_bar(0.0)[1], "█")          # lower band -> far left
+        self.assertEqual(oa._bb_bar(1.2)[-2], "█")         # breakout clamps to far right
+        bar = oa._bb_bar(0.5, width=20)
+        self.assertEqual(len(bar), 22)                     # [ + 20 + ]
+        self.assertEqual(bar.index("█"), 11)               # middle
+
+    def test_pc_label_bands(self):
+        self.assertEqual(oa._pc_label(None), "n/a")
+        self.assertIn("very bullish", oa._pc_label(0.4))
+        self.assertIn("bullish", oa._pc_label(0.7))
+        self.assertIn("neutral", oa._pc_label(1.0))
+        self.assertIn("bearish", oa._pc_label(1.7))
+        self.assertIn("very bearish", oa._pc_label(2.5))
+
+    def test_print_section_frames_the_title(self):
+        text = out_of(oa.print_section, "HELLO")
+        self.assertIn("HELLO", text)
+        self.assertIn(oa.SEPARATOR, text)
+
+
+class TestTradePrinters(unittest.TestCase):
+    TRADE = {
+        "strike": 100.0, "expiration": "2026-08-21", "ask": 3.0, "iv": 70.0,
+        "target_price": 110.0, "profit_at_target_per_contract": 700.0,
+        "roi_at_target_pct": 233.0, "contracts": 1, "total_cost": 300.0,
+        "suggest_spread": True,
+    }
+
+    def test_call_trade_lines_include_spread_note_when_iv_high(self):
+        text = out_of(oa._print_call_trade, self.TRADE)
+        self.assertIn("CALL strike=100.0", text)
+        self.assertIn("bull call spread", text)
+        self.assertIn("ROI=233%", text)
+
+    def test_put_trade_without_spread_note(self):
+        trade = dict(self.TRADE, suggest_spread=False, iv=40.0)
+        text = out_of(oa._print_put_trade, trade)
+        self.assertIn("PUT  strike=100.0", text)
+        self.assertNotIn("debit spread", text)
+
+
+class TestCandidateSections(unittest.TestCase):
+    def bullish_sec(self):
+        sec = security(
+            symbol="UPP", price=91.0,
+            options=options_summary(put_call_ratio=0.4, total_call_volume=60_000,
+                                    atm_calls=[dict(ATM_CALL)],
+                                    atm_puts=[dict(ATM_PUT)]),
+            iv=IV, pc=pc_analysis(),
+            days_to_earnings=45, news_signal="BULLISH",
+            news_top_headline="Upgrade to overweight",
+        )
+        sec.long_score = 9.0
+        sec.put_score = 0.0
+        sec.long_reason = "oversold; very bullish P/C"
+        return sec
+
+    def bearish_sec(self):
+        sec = security(
+            symbol="DWN", price=111.0,
+            options=options_summary(put_call_ratio=2.4, total_put_oi=60_000,
+                                    atm_calls=[dict(ATM_CALL)],
+                                    atm_puts=[dict(ATM_PUT)]),
+            iv=IV,
+            pc=pc_analysis(put_unwinding=False, fresh_put_buying=True,
+                           near_term_fear=False),
+            days_to_earnings=3,   # trips the earnings guardrail on both sides
+        )
+        sec.put_score = 8.0
+        sec.long_score = 0.0
+        sec.put_reason = "overbought; heavy puts"
+        return sec
+
+    def test_long_candidates_full_render(self):
+        text = out_of(oa.print_long_candidates, [self.bullish_sec()], budget=1000.0)
+        self.assertIn("LONG / BOUNCE CANDIDATES", text)
+        self.assertIn("#1  UPP", text)
+        self.assertIn("[UNWINDING]", text)
+        self.assertIn("[NEAR-TERM-FEAR]", text)
+        self.assertIn("45d to earnings", text)
+        self.assertIn('NEWS BULLISH  "Upgrade to overweight"', text)
+        self.assertIn("CALL strike=", text)                # trade built + printed
+        self.assertIn("CALL PORTFOLIO SUMMARY", text)
+        self.assertIn("Total deployed", text)
+
+    def test_long_candidates_empty(self):
+        text = out_of(oa.print_long_candidates, [security()], budget=1000.0)
+        self.assertIn("No candidates met the scoring threshold.", text)
+
+    def test_put_candidates_guardrails_announced(self):
+        text = out_of(oa.print_put_candidates, [self.bearish_sec()], budget=1000.0)
+        self.assertIn("PUT / BEARISH CANDIDATES", text)
+        self.assertIn("[FRESH-PUTS]", text)
+        self.assertIn("GUARDRAIL (PUT)", text)             # earnings blackout
+        self.assertIn("earnings in 3d", text)
+        self.assertNotIn("PUT  strike=", text)             # trade vetoed
+        self.assertNotIn("PUT PORTFOLIO SUMMARY", text)    # nothing to summarize
+
+    def test_put_candidates_empty(self):
+        text = out_of(oa.print_put_candidates, [security()], budget=500.0)
+        self.assertIn("No candidates met the scoring threshold.", text)
+
+
+class TestPortfolioSummaries(unittest.TestCase):
+    TRADE = {
+        "symbol": "UPP", "strike": 100.0, "expiration": "2026-08-21",
+        "ask": 3.0, "iv": 40.0, "target_price": 110.0,
+        "profit_at_target_per_contract": 700.0, "roi_at_target_pct": 233.0,
+        "contracts": 1, "total_cost": 300.0, "suggest_spread": False,
+        "put_score": 8.0, "long_score": 8.0,
+    }
+
+    def test_put_summary_deploys_and_reports_leftover(self):
+        text = out_of(oa.print_put_portfolio_summary, [dict(self.TRADE)], 1000.0)
+        self.assertIn("PUT PORTFOLIO SUMMARY", text)
+        self.assertIn("Total deployed", text)
+        self.assertIn("Remaining:", text)
+
+    def test_call_summary(self):
+        text = out_of(oa.print_call_portfolio_summary, [dict(self.TRADE)], 1000.0)
+        self.assertIn("CALL PORTFOLIO SUMMARY", text)
+        self.assertIn("$100.0 call", text)
+
+    def test_empty_trades_print_nothing(self):
+        self.assertEqual(out_of(oa.print_put_portfolio_summary, [], 1000.0), "")
+        self.assertEqual(out_of(oa.print_call_portfolio_summary, [], 1000.0), "")
+
+    def test_unaffordable_trades_reported(self):
+        rich = dict(self.TRADE, ask=50.0)                  # $5,000/contract
+        text = out_of(oa.print_put_portfolio_summary, [rich], 1000.0)
+        self.assertIn("No trades fit within budget.", text)
+
+
+class TestSkipList(unittest.TestCase):
+    def test_lists_only_signal_free_securities(self):
+        quiet = security(symbol="ZZZ")
+        loud = security(symbol="AAA")
+        loud.long_score = 5.0
+        text = out_of(oa.print_skip_list, [quiet, loud])
+        self.assertIn("ZZZ", text)
+        self.assertNotIn("AAA", text)
+        self.assertEqual(out_of(oa.print_skip_list, [loud]), "")
+
+
+class TestMcpToolBodies(unittest.TestCase):
+    """The @mcp.tool bodies are exactly one rest_client call deep (Rule 6)."""
+
+    def test_health_check_shape(self):
+        out = oa.mcp_health_check()
+        self.assertEqual(out["server"], "options-analysis-server")
+        self.assertIn("fastmcp_version", out)
+        self.assertIn("watchlist_default", out)
+
+    def test_watchlist_and_symbol_tools_hit_their_routes(self):
+        with patch.object(oa, "rest_client") as rc:
+            rc.get.return_value = {"ok": True}
+            oa.analyze_options_watchlist(puts_budget=500.0, top_n=5)
+            path = rc.get.call_args[0][0]
+            self.assertIn("options/screen-watchlist", path)
+
+            oa.analyze_options_symbol("intc", puts_budget=250.0)
+            path = rc.get.call_args[0][0]
+            self.assertIn("/securities/intc/options/screen", path)
+
+    def test_contracts_and_spread_tools(self):
+        with patch.object(oa, "rest_client") as rc:
+            rc.get.return_value = {"ok": True}
+            rc.post.return_value = {"ok": True}
+            oa.get_option_contracts("WMT", ["2026-08-21"], [120.0], kind="put")
+            self.assertIn("options/contracts", rc.get.call_args[0][0])
+            self.assertEqual(rc.get.call_args[1]["kind"], "put")
+
+            oa.price_vertical_spread("WMT", "2026-08-21", 120.0, 125.0)
+            self.assertIn("options/vertical-spread", rc.post.call_args[0][0])
+            body = rc.post.call_args[1]["json"]
+            self.assertEqual(body["long_strike"], 120.0)
+            self.assertEqual(body["short_strike"], 125.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_options_analysis_cli.py
+++ b/test_options_analysis_cli.py
@@ -265,3 +265,39 @@ class TestMcpToolBodies(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestMainSingleSymbol(unittest.TestCase):
+    """End-to-end CLI run for --symbol: real screening scoring/printing over a
+    patched fetch, no DB writes (--no-persist), no news (--no-news)."""
+
+    def test_main_renders_the_full_report(self):
+        import sys
+        from types import SimpleNamespace
+        from quantcore.services.options_screening import OptionsScreeningService
+
+        svc = OptionsScreeningService(
+            ohlcv_repository=Mock(), yfinance_gateway=Mock(), prices=Mock()
+        )
+        sec = security(
+            symbol="UPP", price=91.0,
+            options=options_summary(put_call_ratio=0.4,
+                                    atm_calls=[dict(ATM_CALL)],
+                                    atm_puts=[dict(ATM_PUT)]),
+            iv=IV,
+        )
+        bag = SimpleNamespace(options_screening=svc)
+
+        argv = ["options_analysis.py", "--symbol", "upp",
+                "--no-persist", "--no-news", "--puts-budget", "500"]
+        with patch.object(oa, "get_services", return_value=bag), \
+             patch("quantcore.db.init_schema"), \
+             patch.object(svc, "fetch_security", return_value=sec), \
+             patch.object(sys, "argv", argv):
+            text = out_of(oa.main)
+
+        self.assertIn("Options Analysis Engine", text)
+        self.assertIn("Symbols   : 1", text)
+        self.assertIn("News      : disabled (--no-news)", text)
+        self.assertIn("LONG / BOUNCE CANDIDATES", text)
+        self.assertIn("UPP", text)

--- a/test_options_orchestrators.py
+++ b/test_options_orchestrators.py
@@ -1,0 +1,150 @@
+"""Tests for OptionsService's Polygon backfill + bulk snapshot refresh
+orchestrators (85%-campaign part 6). Polygon/prices/gateway are Mocks; the
+backfill's per-date state machine (stored/duplicate/no_data/error/402/400)
+is walked branch by branch with literal Polygon payloads.
+"""
+import os
+import unittest
+from datetime import date, timedelta
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import requests
+
+# Defensive DSN preamble (quantcore.db freezes its DSN at first import).
+_env_file = Path(__file__).parent / ".env"
+if _env_file.exists():
+    for _line in _env_file.read_text().splitlines():
+        if _line.strip().startswith("QUANTCORE_TEST_DB_DSN="):
+            os.environ["QUANTCORE_DB_DSN"] = _line.split("=", 1)[1].strip()
+            break
+
+from quantcore.gateways.polygon_gateway import PolygonPlanError  # noqa: E402
+from quantcore.services.options import OptionsService  # noqa: E402
+
+
+def polygon_contract(kind="call", exp="2026-08-21", oi=100, vol=10, iv=0.30,
+                     price=100.0):
+    return {
+        "details": {"contract_type": kind, "expiration_date": exp},
+        "open_interest": oi,
+        "implied_volatility": iv,
+        "day": {"volume": vol},
+        "underlying_asset": {"price": price},
+    }
+
+
+class OrchestratorTestBase(unittest.TestCase):
+    def setUp(self):
+        self.yf = Mock()
+        self.options = Mock()
+        self.polygon = Mock()
+        self.prices = Mock()
+        self.service = OptionsService(
+            ohlcv_repository=Mock(),
+            yfinance_gateway=self.yf,
+            options_repository=self.options,
+            polygon_gateway=self.polygon,
+            prices=self.prices,
+        )
+
+
+class TestBackfill(OrchestratorTestBase):
+    def test_missing_api_key_is_a_400(self):
+        self.polygon.has_key = False
+        payload, status = self.service.backfill_options_history("intc")
+        self.assertEqual(status, 400)
+        self.assertIn("POLYGON_API_KEY", payload["error"])
+
+    def test_fully_backfilled_range_short_circuits(self):
+        self.polygon.has_key = True
+        all_days = {
+            (date.today() - timedelta(days=o)).isoformat() for o in range(0, 20)
+        }
+        self.options.get_snapshot_dates.return_value = all_days
+        payload, status = self.service.backfill_options_history("INTC", days=5)
+        self.assertEqual(status, 200)
+        self.assertEqual(payload["stored"], 0)
+        self.assertIn("already have snapshots", payload["note"])
+
+    def test_plan_error_is_a_402(self):
+        self.polygon.has_key = True
+        self.options.get_snapshot_dates.return_value = set()
+        self.polygon.option_snapshots.side_effect = PolygonPlanError(
+            403, "upgrade required"
+        )
+        payload, status = self.service.backfill_options_history("INTC", days=5)
+        self.assertEqual(status, 402)
+        self.assertEqual(payload["polygon_status"], 403)
+
+    def test_per_date_state_machine(self):
+        self.polygon.has_key = True
+        self.options.get_snapshot_dates.return_value = set()
+        # Four trading days -> error, no_data, stored, duplicate (in order).
+        self.polygon.option_snapshots.side_effect = [
+            requests.RequestException("polygon hiccup"),
+            [],
+            [polygon_contract(), polygon_contract(kind="put", oi=200, vol=40)],
+            [polygon_contract()],
+        ]
+        self.options.save_full_chain.side_effect = [11, None]  # stored, duplicate
+        payload, status = self.service.backfill_options_history(
+            "INTC", days=6, skip_existing=False
+        )
+        self.assertEqual(status, 200)
+        statuses = [r["status"] for r in payload["results"]]
+        self.assertEqual(statuses.count("error"), 1)
+        self.assertGreaterEqual(statuses.count("no_data"), 1)
+        self.assertEqual(payload["stored"], 1)
+        self.assertEqual(payload["skipped"], 1)          # the duplicate
+        # The stored snapshot aggregated both sides at the 16:00 ET close.
+        _, kwargs = self.options.save_full_chain.call_args_list[0]
+        self.assertTrue(kwargs["captured_at"].endswith("T21:00:00Z"))
+        exp_data = kwargs["expirations_data"][0]
+        self.assertEqual(exp_data["put_call_ratio"], 2.0)   # 200 put / 100 call OI
+        self.assertEqual(exp_data["calls"]["avg_iv_pct"], 30.0)
+
+
+class TestRefreshSnapshots(OrchestratorTestBase):
+    PORTFOLIO = [{"symbol": "AAA"}, {"symbol": "BBB"}]
+    WATCHLIST = [{"symbol": "BBB"}, {"symbol": "CCC"}]
+
+    def run_refresh(self, **kw):
+        with patch("quantcore.services.options._time.sleep"):
+            return self.service.refresh_options_snapshots(
+                self.PORTFOLIO, self.WATCHLIST, **kw
+            )
+
+    def test_all_source_dedupes_and_reports(self):
+        self.prices.get_stock_price.return_value = {"ok": True}
+        out = self.run_refresh(source="all", chain_type="atm")
+        symbols = [r["symbol"] for r in out["results"]]
+        self.assertEqual(symbols, ["AAA", "BBB", "CCC"])   # deduped + sorted
+        self.assertEqual(out["succeeded"], 3)
+        self.assertEqual(out["failed"], 0)
+        self.yf.close_thread_caches.assert_called_once()   # issue-#75 cleanup
+
+    def test_full_chain_type_uses_the_chain_fetcher(self):
+        with patch.object(self.service, "get_full_options_chain",
+                          return_value={"ok": True}) as full:
+            out = self.run_refresh(source="portfolio", chain_type="full")
+        self.assertEqual(full.call_count, 2)
+        self.assertEqual(out["succeeded"], 2)
+
+    def test_failures_are_retried_then_reported(self):
+        # AAA fails twice (retry exhausted); BBB/CCC succeed.
+        def flaky(sym):
+            if sym == "AAA":
+                raise RuntimeError("yahoo down")
+            return {"ok": True}
+
+        self.prices.get_stock_price.side_effect = flaky
+        out = self.run_refresh(source="all")
+        self.assertEqual(out["failed"], 1)
+        failed = next(r for r in out["results"] if r["status"] == "error")
+        self.assertEqual(failed["symbol"], "AAA")
+        self.assertIn("yahoo down", failed["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_options_screening_fetch.py
+++ b/test_options_screening_fetch.py
@@ -1,0 +1,261 @@
+"""Tests for OptionsScreeningService's fetch_* pipeline (85%-campaign) —
+the data-assembly half that test_options_screening_service.py's pure-logic
+suite deliberately skipped. Gateway/prices are Mocks; every branch is driven
+by literal payloads (chain frames, calendar shapes, news items).
+"""
+import os
+import unittest
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import numpy as np
+import pandas as pd
+
+# Defensive DSN preamble (quantcore.db freezes its DSN at first import).
+_env_file = Path(__file__).parent / ".env"
+if _env_file.exists():
+    for _line in _env_file.read_text().splitlines():
+        if _line.strip().startswith("QUANTCORE_TEST_DB_DSN="):
+            os.environ["QUANTCORE_DB_DSN"] = _line.split("=", 1)[1].strip()
+            break
+
+from quantcore.services.options_screening import (  # noqa: E402
+    OptionsScreeningService,
+    OptionsSummary,
+    POSITIVE_CATALYST_KEYWORDS,
+)
+
+
+def chain_df(oi, vol, strikes=(90.0, 95.0, 100.0, 105.0, 110.0, 130.0), iv=0.42):
+    n = len(strikes)
+    return pd.DataFrame({
+        "strike": list(strikes),
+        "openInterest": [oi] * n,
+        "volume": [vol] * n,
+        "impliedVolatility": [iv] * n,
+        "lastPrice": [2.0] * n,
+        "bid": [1.9] * n,
+        "ask": [2.1] * n,
+        "inTheMoney": [s < 100 for s in strikes],
+    })
+
+
+def chains(calls, puts):
+    return SimpleNamespace(calls=calls, puts=puts)
+
+
+def history(n=320, base=100.0, daily_move=0.01):
+    rng = np.random.default_rng(7)
+    rets = rng.normal(0, daily_move, n)
+    closes = base * np.exp(np.cumsum(rets))
+    idx = pd.bdate_range(end="2026-07-17", periods=n)
+    return pd.DataFrame({"Close": closes}, index=idx)
+
+
+class FetchTestBase(unittest.TestCase):
+    def setUp(self):
+        self.yf = Mock()
+        self.prices = Mock()
+        self.service = OptionsScreeningService(
+            ohlcv_repository=Mock(), yfinance_gateway=self.yf, prices=self.prices
+        )
+
+
+class TestFetchBollingerBands(FetchTestBase):
+    def test_flat_tape_centers_the_bands(self):
+        self.prices.get_history.return_value = pd.DataFrame(
+            {"Close": [100.0] * 60}, index=pd.bdate_range(end="2026-07-17", periods=60)
+        )
+        bands = self.service.fetch_bollinger_bands("INTC")
+        self.assertEqual(bands.middle, 100.0)
+        self.assertEqual(bands.upper, 100.0)   # zero std on a flat tape
+
+    def test_thin_history_and_errors_return_none(self):
+        self.prices.get_history.return_value = pd.DataFrame({"Close": [1.0] * 5})
+        self.assertIsNone(self.service.fetch_bollinger_bands("INTC"))
+        self.prices.get_history.side_effect = RuntimeError("db away")
+        self.assertIsNone(self.service.fetch_bollinger_bands("INTC"))
+
+
+class TestFetchOptions(FetchTestBase):
+    def test_aggregates_and_atm_selection(self):
+        self.yf.expirations.return_value = ("2026-08-21", "2026-09-18")
+        self.yf.option_chain.return_value = chains(
+            chain_df(oi=100, vol=10), chain_df(oi=200, vol=40)
+        )
+        out = self.service.fetch_options("INTC", price=100.0)
+        self.assertEqual(out.expiration, "2026-08-21")
+        self.assertEqual(out.total_call_oi, 600)
+        self.assertEqual(out.total_put_oi, 1200)
+        self.assertEqual(out.put_call_ratio, 2.0)
+        self.assertEqual(len(out.atm_calls), 5)
+        strikes = [c["strike"] for c in out.atm_calls]
+        self.assertEqual(strikes, sorted(strikes))
+        self.assertNotIn(130.0, strikes)       # far strike excluded from ATM-5
+
+    def test_no_expirations_or_empty_side_returns_none(self):
+        self.yf.expirations.return_value = ()
+        self.assertIsNone(self.service.fetch_options("INTC", 100.0))
+        self.yf.expirations.return_value = ("2026-08-21",)
+        self.yf.option_chain.return_value = chains(chain_df(1, 1), pd.DataFrame())
+        self.assertIsNone(self.service.fetch_options("INTC", 100.0))
+
+
+class TestFetchPutCallAnalysis(FetchTestBase):
+    def arm(self, near_put_vol, mid_put_oi=100):
+        near = chains(chain_df(oi=100, vol=100), chain_df(oi=150, vol=near_put_vol))
+        mid = chains(chain_df(oi=100, vol=10), chain_df(oi=mid_put_oi, vol=10))
+        self.yf.expirations.return_value = ("2026-08-21", "2026-09-18")
+        self.yf.option_chain.side_effect = [near, mid]
+
+    def test_put_unwinding_detected(self):
+        # OI P/C 1.5, vol P/C 0.5 -> ratio 0.33 <= 0.75 -> unwinding.
+        self.arm(near_put_vol=50)
+        out = self.service.fetch_put_call_analysis("INTC", price=100.0)
+        self.assertEqual(out.near_oi_pc, 1.5)
+        self.assertEqual(out.near_vol_pc, 0.5)
+        self.assertTrue(out.put_unwinding)
+        self.assertFalse(out.fresh_put_buying)
+        self.assertEqual(out.mid_expiry, "2026-09-18")
+        self.assertEqual(out.term_skew, 0.5)   # 1.5 near - 1.0 mid
+        self.assertTrue(out.near_term_fear)    # skew >= 0.30
+        self.assertIsNotNone(out.near_atm_pc)
+
+    def test_fresh_put_buying_detected(self):
+        # OI P/C 1.5, vol P/C 4.0 -> ratio 2.67 >= 1.5 -> fresh buying.
+        self.arm(near_put_vol=400)
+        out = self.service.fetch_put_call_analysis("INTC", price=100.0)
+        self.assertTrue(out.fresh_put_buying)
+        self.assertFalse(out.put_unwinding)
+
+    def test_no_expirations_returns_none(self):
+        self.yf.expirations.return_value = ()
+        self.assertIsNone(self.service.fetch_put_call_analysis("INTC", 100.0))
+
+
+class TestFetchIvAnalysis(FetchTestBase):
+    def options_with_iv(self, call_iv, put_iv):
+        return OptionsSummary(
+            expiration="2026-08-21", put_call_ratio=1.0,
+            total_call_oi=1, total_put_oi=1, total_call_volume=1,
+            total_put_volume=1, avg_call_iv=call_iv, avg_put_iv=put_iv,
+        )
+
+    def test_current_iv_averages_the_chain_sides(self):
+        self.prices.get_history.return_value = history()
+        out = self.service.fetch_iv_analysis("INTC", self.options_with_iv(40.0, 50.0))
+        self.assertEqual(out.current_iv, 45.0)
+        self.assertGreater(out.hv_30, 0)
+        self.assertGreaterEqual(out.iv_rank, 0.0)
+        self.assertLessEqual(out.iv_rank, 100.0)
+        self.assertGreaterEqual(out.iv_percentile, 0.0)
+        self.assertTrue(out.label)
+
+    def test_without_options_falls_back_to_hv(self):
+        self.prices.get_history.return_value = history()
+        out = self.service.fetch_iv_analysis("INTC", None)
+        self.assertEqual(out.current_iv, out.hv_30)
+        self.assertEqual(out.iv_vs_hv, 1.0)
+
+    def test_thin_history_returns_none(self):
+        self.prices.get_history.return_value = pd.DataFrame({"Close": [1.0] * 10})
+        self.assertIsNone(self.service.fetch_iv_analysis("INTC", None))
+
+
+class TestEarningsProximity(FetchTestBase):
+    def test_dataframe_calendar(self):
+        earn = date.today() + timedelta(days=10)
+        self.yf.calendar.return_value = pd.DataFrame(
+            {0: [pd.Timestamp(earn)]}, index=["Earnings Date"]
+        )
+        self.assertEqual(self.service.fetch_earnings_proximity("INTC"), 10)
+
+    def test_dict_calendar_and_past_dates(self):
+        earn = date.today() + timedelta(days=25)
+        self.yf.calendar.return_value = {"Earnings Date": earn}
+        self.assertEqual(self.service.fetch_earnings_proximity("INTC"), 25)
+        self.yf.calendar.return_value = {"Earnings Date": date(2020, 1, 1)}
+        self.assertIsNone(self.service.fetch_earnings_proximity("INTC"))
+        self.yf.calendar.return_value = None
+        self.assertIsNone(self.service.fetch_earnings_proximity("INTC"))
+
+
+class TestPositiveCatalyst(FetchTestBase):
+    def news_item(self, title, days_ago=1.0):
+        ts = (datetime.now(timezone.utc) - timedelta(days=days_ago)).timestamp()
+        return {"title": title, "providerPublishTime": int(ts)}
+
+    def test_recent_keyword_headline_triggers(self):
+        keyword = sorted(POSITIVE_CATALYST_KEYWORDS)[0]
+        headline = f"Big news: {keyword} announced"
+        self.yf.news.return_value = [self.news_item(headline)]
+        hit, title = self.service.fetch_recent_positive_catalyst("INTC")
+        self.assertTrue(hit)
+        self.assertEqual(title, headline)
+
+    def test_stale_or_neutral_news_does_not_trigger(self):
+        keyword = sorted(POSITIVE_CATALYST_KEYWORDS)[0]
+        self.yf.news.return_value = [
+            self.news_item(f"{keyword} long ago", days_ago=45.0),
+            self.news_item("Quarterly filing published", days_ago=1.0),
+        ]
+        self.assertEqual(
+            self.service.fetch_recent_positive_catalyst("INTC"), (False, "")
+        )
+        self.yf.news.return_value = []
+        self.assertEqual(
+            self.service.fetch_recent_positive_catalyst("INTC"), (False, "")
+        )
+
+
+class TestFetchSecurity(FetchTestBase):
+    def arm_components(self):
+        self.yf.fast_info.return_value = SimpleNamespace(last_price=100.0)
+        patches = {
+            "fetch_bollinger_bands": Mock(return_value=Mock(lower=90, middle=100, upper=110)),
+            "fetch_options": Mock(return_value=None),
+            "fetch_iv_analysis": Mock(return_value=None),
+            "fetch_put_call_analysis": Mock(return_value=None),
+            "fetch_earnings_proximity": Mock(return_value=45),
+        }
+        for name, mock in patches.items():
+            patcher = patch.object(self.service, name, mock)
+            patcher.start()
+            self.addCleanup(patcher.stop)
+        return patches
+
+    def test_assembles_with_news_store_bullish_signal(self):
+        self.arm_components()
+        news_store = Mock()
+        news_store.get_sentiment_summary.return_value = {
+            "signal": "BULLISH", "scored_articles": 3,
+            "top_positive": ["Upgraded to buy"], "top_negative": [],
+        }
+        sec = self.service.fetch_security("intc", "Intel", ["chips"],
+                                          news_store=news_store)
+        self.assertEqual(sec.symbol, "INTC")
+        self.assertEqual(sec.news_signal, "BULLISH")
+        self.assertTrue(sec.recent_positive_catalyst)      # bullish news = catalyst
+        self.assertEqual(sec.catalyst_headline, "Upgraded to buy")
+        self.assertEqual(sec.days_to_earnings, 45)
+
+    def test_falls_back_to_keyword_scan_without_news_store(self):
+        self.arm_components()
+        with patch.object(self.service, "fetch_recent_positive_catalyst",
+                          return_value=(True, "Upgrade!")):
+            sec = self.service.fetch_security("INTC", "Intel", [])
+        self.assertTrue(sec.recent_positive_catalyst)
+        self.assertEqual(sec.catalyst_headline, "Upgrade!")
+
+    def test_missing_price_or_bands_returns_none(self):
+        self.yf.fast_info.return_value = SimpleNamespace(last_price=None)
+        self.assertIsNone(self.service.fetch_security("INTC", "Intel", []))
+        self.yf.fast_info.return_value = SimpleNamespace(last_price=100.0)
+        with patch.object(self.service, "fetch_bollinger_bands", return_value=None):
+            self.assertIsNone(self.service.fetch_security("INTC", "Intel", []))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_options_screening_fetch.py
+++ b/test_options_screening_fetch.py
@@ -259,3 +259,38 @@ class TestFetchSecurity(FetchTestBase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestFetchAndStoreFullChain(unittest.TestCase):
+    """fetch_and_store_full_chain — the shared live-refresh helper in
+    quantcore/services/options_contracts.py (85%-campaign closer)."""
+
+    def test_fetches_every_expiration_and_persists(self):
+        from quantcore.services.options_contracts import fetch_and_store_full_chain
+
+        gw = Mock()
+        gw.fast_info.return_value = SimpleNamespace(last_price=100.0)
+        gw.expirations.return_value = ("2026-08-21", "2026-09-18")
+        gw.option_chain.side_effect = [
+            chains(chain_df(oi=100, vol=10), chain_df(oi=200, vol=20)),
+            RuntimeError("second expiry unavailable"),   # skipped, not fatal
+        ]
+        store = Mock()
+        store.save_full_chain.return_value = 77
+        store.get_full_chain.return_value = {"price": 100.0}
+
+        out = fetch_and_store_full_chain("intc", store, gateway=gw)
+        self.assertEqual(out["snapshot_id"], 77)
+        self.assertEqual(out["expiration_count"], 1)     # bad expiry skipped
+        self.assertGreater(out["total_contracts"], 0)
+        _, kwargs = store.save_full_chain.call_args
+        self.assertEqual(kwargs["symbol"], "INTC")
+        self.assertEqual(kwargs["expirations_data"][0]["put_call_ratio"], 2.0)
+
+    def test_missing_price_raises(self):
+        from quantcore.services.options_contracts import fetch_and_store_full_chain
+
+        gw = Mock()
+        gw.fast_info.return_value = SimpleNamespace(last_price=None)
+        with self.assertRaises(ValueError):
+            fetch_and_store_full_chain("ZZNONE", Mock(), gateway=gw)

--- a/test_recommendations_service.py
+++ b/test_recommendations_service.py
@@ -260,3 +260,97 @@ class StopLossSynthesisTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+# ---------------------------------------------------------------------------
+# Relative strength (85%-campaign part 8)
+# ---------------------------------------------------------------------------
+
+import numpy as _np  # noqa: E402
+import pandas as _pd  # noqa: E402
+from unittest.mock import Mock as _Mock, patch as _patch  # noqa: E402
+
+from quantcore.services.recommendations import RecommendationsService as _RS  # noqa: E402
+
+
+def _mock_service():
+    return _RS(
+        prices=_Mock(), options=_Mock(), microstructure=_Mock(),
+        sentiment=_Mock(), fundamentals=_Mock(),
+        ohlcv_repository=_Mock(), yfinance_gateway=_Mock(),
+    )
+
+
+def _trend_df(total_return_pct, n=160):
+    idx = _pd.bdate_range(end="2026-07-17", periods=n)
+    closes = _np.linspace(100.0, 100.0 * (1 + total_return_pct / 100.0), n)
+    return _pd.DataFrame({"Close": closes}, index=idx)
+
+
+class RelativeStrengthHistoryTests(unittest.TestCase):
+    def test_outperformer_reads_positive_rs(self):
+        svc = _mock_service()
+        frames = {"WINNR": _trend_df(30), "SPY": _trend_df(8),
+                  "QQQ": _trend_df(10), "XLK": _trend_df(12)}
+        svc._prices.get_history.side_effect = (
+            lambda sym, interval="1d", days=0: frames[sym]
+        )
+        with _patch.object(svc, "_get_sector_etf", return_value="XLK"):
+            out = svc.get_relative_strength_history("winnr", since_days=30)
+        self.assertEqual(out["symbol"], "WINNR")
+        self.assertEqual(out["sector_etf"], "XLK")
+        self.assertEqual(out["data_points"], 30)
+        last = out["history"][-1]
+        self.assertGreater(last["rs_vs_spy"], 0)
+        self.assertGreater(last["rs_vs_qqq"], 0)
+        self.assertIsNotNone(last["rs_vs_sector"])
+        self.assertIn(last["rs_label"],
+                      {"leader", "outperforming", "neutral", "laggard", "weak"})
+
+    def test_missing_history_degrades(self):
+        svc = _mock_service()
+        svc._prices.get_history.return_value = _pd.DataFrame()
+        with _patch.object(svc, "_get_sector_etf", return_value=None):
+            out = svc.get_relative_strength_history("GHOST")
+        self.assertEqual(out["history"], [])
+        self.assertIn("error", out)
+
+
+class RelativeStrengthTests(unittest.TestCase):
+    def _download_frame(self, returns_by_ticker, n=300):
+        idx = _pd.bdate_range(end="2026-07-17", periods=n)
+        closes = _pd.DataFrame(
+            {t: _np.linspace(100.0, 100.0 * (1 + r / 100.0), n)
+             for t, r in returns_by_ticker.items()},
+            index=idx,
+        )
+        return _pd.concat({"Close": closes}, axis=1)
+
+    def test_market_leader_labels_and_sector_momentum(self):
+        svc = _mock_service()
+        svc._yf.info.return_value = {"sector": "Technology"}
+        svc._yf.download.return_value = self._download_frame(
+            {"HERO": 45.0, "SPY": 10.0, "QQQ": 15.0, "XLK": 20.0}
+        )
+        out = svc.get_relative_strength("hero")
+        self.assertEqual(out["sector"], "Technology")
+        returns = out["returns"]
+        for leg in ("stock", "spy", "qqq", "sector"):
+            self.assertIsNotNone(returns[leg]["12m"], leg)
+        # Self-consistent ratio math.
+        self.assertAlmostEqual(
+            out["rs_ratio_vs_spy"],
+            round(returns["stock"]["12m"] - returns["spy"]["12m"], 2),
+        )
+        self.assertEqual(out["relative_strength_label"], "leader")
+        self.assertIn(out["sector_momentum"],
+                      {"sector_leading", "sector_neutral", "sector_lagging"})
+
+    def test_provider_failures_leave_safe_defaults(self):
+        svc = _mock_service()
+        svc._yf.info.side_effect = RuntimeError("info down")
+        svc._yf.download.side_effect = RuntimeError("download down")
+        out = svc.get_relative_strength("GHOST")
+        self.assertEqual(out["relative_strength_label"], "unknown")
+        self.assertEqual(out["sector_momentum"], "unknown")
+        self.assertIsNone(out["rs_ratio_vs_spy"])

--- a/test_repositories_db.py
+++ b/test_repositories_db.py
@@ -221,3 +221,55 @@ class TestOhlcvRepositoryFacade(RepoTestBase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+# ---------------------------------------------------------------------------
+# Fundamentals cache edge branches (85%-campaign part 10)
+# ---------------------------------------------------------------------------
+
+from unittest.mock import patch  # noqa: E402
+
+from quantcore.repositories import fundamentals_repository as fr  # noqa: E402
+
+
+class TestFundamentalsCacheEdges(RepoTestBase):
+    def test_ttl_env_parsing(self):
+        with patch.dict(os.environ, {"FUNDAMENTALS_CACHE_TTL_HOURS": "2"}):
+            self.assertEqual(fr._get_ttl_seconds(), 7200.0)
+        with patch.dict(os.environ, {"FUNDAMENTALS_CACHE_TTL_HOURS": "-5"}):
+            self.assertEqual(fr._get_ttl_seconds(), 0.0)      # clamped
+        with patch.dict(os.environ, {"FUNDAMENTALS_CACHE_TTL_HOURS": "nope"}):
+            self.assertEqual(fr._get_ttl_seconds(), 86400.0)  # default on garbage
+
+    def test_ttl_zero_disables_reads(self):
+        fr.cache_set(SYM, "fundamental_score", {"composite_score": 5})
+        with patch.dict(os.environ, {"FUNDAMENTALS_CACHE_TTL_HOURS": "0"}):
+            self.assertIsNone(fr.cache_get(SYM, "fundamental_score"))
+
+    def test_expired_entry_is_a_miss(self):
+        fr.cache_set(SYM, "fundamental_score", {"composite_score": 5})
+        # Age the row far past any TTL.
+        with closing(get_connection()) as conn:
+            conn.execute(
+                "UPDATE fundamentals_history SET fetched_at = fetched_at - 999999 "
+                "WHERE symbol = %s", (SYM,)
+            )
+            conn.commit()
+        self.assertIsNone(fr.cache_get(SYM, "fundamental_score"))
+        # ...but history still sees it.
+        self.assertGreaterEqual(len(fr.cache_history(SYM, "fundamental_score")), 1)
+
+    def test_unserializable_and_none_payloads_are_skipped(self):
+        fr.cache_set(SYM, "fundamental_score", None)          # no-op
+        fr.cache_set(SYM, "fundamental_score", {"bad": object()})  # unserializable
+        self.assertIsNone(fr.cache_get(SYM, "fundamental_score"))
+
+    def test_corrupt_json_entry_is_a_miss(self):
+        fr.cache_set(SYM, "fundamental_score", {"ok": 1})
+        with closing(get_connection()) as conn:
+            conn.execute(
+                "UPDATE fundamentals_history SET payload = 'not json' "
+                "WHERE symbol = %s", (SYM,)
+            )
+            conn.commit()
+        self.assertIsNone(fr.cache_get(SYM, "fundamental_score"))

--- a/test_repositories_db.py
+++ b/test_repositories_db.py
@@ -1,0 +1,223 @@
+"""Seeded-test-DB round trips for the four thin repositories that lacked
+coverage (85%-campaign): FundamentalsRepository, NewsStore,
+OptionsPositionStore, and the OhlcvRepository facade. Test database only.
+"""
+import os
+import unittest
+from contextlib import closing
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+import pandas as pd
+
+# Swap in the test DSN BEFORE quantcore.db is imported (frozen at import).
+_env_file = Path(__file__).parent / ".env"
+if _env_file.exists():
+    for _line in _env_file.read_text().splitlines():
+        if _line.strip().startswith("QUANTCORE_TEST_DB_DSN="):
+            os.environ["QUANTCORE_DB_DSN"] = _line.split("=", 1)[1].strip()
+            break
+
+from quantcore.db_safety import assert_not_production  # noqa: E402
+
+assert_not_production()
+
+from quantcore.db import get_connection  # noqa: E402
+from quantcore.repositories.fundamentals_repository import FundamentalsRepository  # noqa: E402
+from quantcore.repositories.news_repository import NewsStore  # noqa: E402
+from quantcore.repositories.ohlcv_repository import OhlcvRepository  # noqa: E402
+from quantcore.repositories.options_position_repository import OptionsPositionStore  # noqa: E402
+
+SYM = "ZZREPOS"
+
+
+def purge():
+    with closing(get_connection()) as conn:
+        conn.execute("DELETE FROM fundamentals_history WHERE symbol = %s", (SYM,))
+        conn.execute("DELETE FROM news_articles WHERE symbol = %s", (SYM,))
+        conn.execute("DELETE FROM options_positions WHERE symbol = %s", (SYM,))
+        conn.execute("DELETE FROM ohlcv WHERE symbol = %s", (SYM,))
+        conn.commit()
+
+
+class RepoTestBase(unittest.TestCase):
+    def setUp(self):
+        purge()
+        self.addCleanup(purge)
+
+
+class TestFundamentalsRepository(RepoTestBase):
+    def setUp(self):
+        super().setUp()
+        self.repo = FundamentalsRepository()
+
+    def test_set_get_roundtrip_and_miss(self):
+        self.assertIsNone(self.repo.get(SYM, "fundamental_score"))
+        self.repo.set(SYM, "fundamental_score", {"composite_score": 7, "symbol": SYM})
+        cached = self.repo.get(SYM, "fundamental_score")
+        self.assertEqual(cached["composite_score"], 7)
+
+    def test_history_and_all_latest(self):
+        self.repo.set(SYM, "fundamental_score", {"composite_score": 9, "symbol": SYM})
+        history = self.repo.history(SYM, "fundamental_score")
+        self.assertGreaterEqual(len(history), 1)
+        latest = [e for e in self.repo.get_all_latest("fundamental_score")
+                  if e.get("symbol") == SYM]
+        self.assertEqual(len(latest), 1)
+        self.assertEqual(latest[0]["composite_score"], 9)
+
+    def test_invalidate_specific_and_all(self):
+        self.repo.set(SYM, "fundamental_score", {"composite_score": 1, "symbol": SYM})
+        self.repo.set(SYM, "revenue_growth", {"trajectory": "stable", "symbol": SYM})
+        self.repo.invalidate(SYM, "fundamental_score")
+        self.assertIsNone(self.repo.get(SYM, "fundamental_score"))
+        self.assertIsNotNone(self.repo.get(SYM, "revenue_growth"))
+        self.repo.invalidate(SYM)          # all types for the symbol
+        self.assertIsNone(self.repo.get(SYM, "revenue_growth"))
+
+    def test_stats_and_ttl(self):
+        self.repo.set(SYM, "fundamental_score", {"composite_score": 1, "symbol": SYM})
+        stats = self.repo.stats()
+        self.assertIn("data_types", stats)
+        self.assertGreater(self.repo.ttl_seconds(), 0)
+
+
+def article(i, published_days_ago=0.5):
+    ts = datetime.now(timezone.utc) - timedelta(days=published_days_ago)
+    return {
+        "title": f"Headline {i}",
+        "url": f"https://example.com/{SYM}/{i}",
+        "summary": f"Body {i}",
+        "publisher": "TestWire",
+        "published_at": ts.isoformat(),
+        "source": "rss",
+    }
+
+
+class TestNewsStore(RepoTestBase):
+    def setUp(self):
+        super().setUp()
+        self.store = NewsStore()
+
+    def test_save_dedupes_on_url(self):
+        first = self.store.save_articles(SYM, [article(1), article(2)])
+        self.assertEqual(first, 2)
+        again = self.store.save_articles(SYM, [article(1), article(3)])
+        self.assertEqual(again, 1)                     # url 1 deduped
+        self.assertEqual(self.store.article_count(SYM), 3)
+        self.assertIn(SYM, self.store.get_symbols())
+
+    def test_scoring_flow_and_scored_only_filter(self):
+        self.store.save_articles(SYM, [article(1), article(2)])
+        unscored = self.store.get_unscored_articles(limit=50)
+        mine = [a for a in unscored if a["symbol"] == SYM] if unscored and "symbol" in unscored[0] else unscored
+        self.assertGreaterEqual(len(mine), 2)
+        target = mine[0]
+        self.store.update_sentiment(
+            article_id=target["article_id"], sentiment="positive",
+            sentiment_score=0.91, positive_score=0.91,
+            negative_score=0.04, neutral_score=0.05,
+        )
+        scored = self.store.get_articles(SYM, days=7, scored_only=True)
+        self.assertEqual(len(scored), 1)
+        self.assertEqual(scored[0]["sentiment"], "positive")
+        every = self.store.get_articles(SYM, days=7, scored_only=False)
+        self.assertEqual(len(every), 2)
+
+    def test_summary_and_trend_shapes(self):
+        self.store.save_articles(SYM, [article(1)])
+        summary = self.store.get_sentiment_summary(SYM, days=7)
+        self.assertEqual(summary.get("symbol"), SYM)
+        trend = self.store.get_sentiment_trend(SYM, days=30)
+        self.assertIsInstance(trend, list)
+
+
+class TestOptionsPositionStore(RepoTestBase):
+    def setUp(self):
+        super().setUp()
+        self.store = OptionsPositionStore()
+
+    def add(self, kind="call", strike=100.0, expiration_days=30,
+            purchase_price=3.0, target=None):
+        exp = (date.today() + timedelta(days=expiration_days)).isoformat()
+        return self.store.add_position(
+            symbol=SYM, kind=kind, strike=strike, expiration=exp,
+            contracts=2, purchase_price=purchase_price,
+            purchase_date=date.today().isoformat(), target_price=target,
+        )
+
+    def test_add_get_close_lifecycle(self):
+        pid = self.add()
+        pos = self.store.get_position(pid)
+        self.assertEqual(pos["symbol"], SYM)
+        self.assertEqual(self.store.position_count("ACTIVE"), 1)
+        self.store.close_position(pid, reason="took profit")
+        self.assertEqual(self.store.position_count("ACTIVE"), 0)
+
+    def test_invalid_kind_rejected(self):
+        with self.assertRaises(ValueError):
+            self.add(kind="straddle")
+
+    def test_auto_expire_past_positions(self):
+        self.add(expiration_days=-2)                   # already expired
+        live = self.add(expiration_days=30)
+        expired = self.store.auto_expire_past_positions()
+        expired_ids = [p["position_id"] for p in expired]
+        self.assertEqual(len(expired_ids), 1)
+        active = self.store.get_active_positions()
+        self.assertEqual([p["position_id"] for p in active], [live])
+
+    def test_pending_alerts_itm_and_expiry(self):
+        self.add(kind="call", strike=100.0, expiration_days=5,
+                 purchase_price=1.0)                   # ITM + <=7d expiry
+        alerts = self.store.get_pending_alerts({SYM: 110.0})
+        types = {a["alert_type"] for a in alerts}
+        self.assertIn("ITM", types)
+        self.assertIn("EXPIRATION_7D", types)
+        itm = next(a for a in alerts if a["alert_type"] == "ITM")
+        self.assertEqual(itm["intrinsic_value"], 10.0)
+        # Missing price -> position silently skipped.
+        self.assertEqual(self.store.get_pending_alerts({}), [])
+
+
+def bars_df(n=5, start_price=100.0):
+    # Fixed past business days: deterministic, and always CLOSED bars.
+    idx = pd.bdate_range(end="2026-07-17", periods=n, tz="UTC")
+    prices = [start_price + i for i in range(n)]
+    return pd.DataFrame(
+        {"Open": prices, "High": [p + 1 for p in prices],
+         "Low": [p - 1 for p in prices], "Close": prices,
+         "Volume": [1_000_000] * n},
+        index=idx,
+    )
+
+
+class TestOhlcvRepositoryFacade(RepoTestBase):
+    def setUp(self):
+        super().setUp()
+        self.repo = OhlcvRepository()
+
+    def test_store_and_read_back(self):
+        self.assertEqual(self.repo.count_cached(SYM, "1d"), 0)
+        self.repo.store_bars(SYM, "1d", bars_df())
+        self.assertEqual(self.repo.count_cached(SYM, "1d"), 5)
+        out = self.repo.get_bars(SYM, "1d", days=30)
+        self.assertEqual(len(out), 5)
+        self.assertIn("Close", out.columns)
+
+    def test_closed_bar_bookkeeping(self):
+        self.repo.store_bars(SYM, "1d", bars_df())
+        ts = self.repo.latest_closed_ts(SYM, "1d")
+        self.assertIsNotNone(ts)
+        self.assertFalse(self.repo.has_open_bar(SYM, "1d"))  # all bars days old
+
+    def test_daily_bars_for_symbols(self):
+        self.repo.store_bars(SYM, "1d", bars_df())
+        rows = self.repo.daily_bars_for_symbols([SYM])
+        self.assertEqual(len(rows), 5)
+        self.assertEqual(rows[0]["symbol"], SYM)
+        self.assertIn("close", rows[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_routers_passthrough.py
+++ b/test_routers_passthrough.py
@@ -1,0 +1,144 @@
+"""Passthrough tests for the prices/options routers (85%-campaign).
+
+Every route here is exactly one service call deep (arch-v2 Rule 6). These
+tests pin that contract mechanically: with the service layer mocked, each
+route must return the service payload verbatim on success and the plain
+{"error": ...} 500 shape on failure — proving no route grows hidden logic.
+"""
+import os
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+# Swap in the test DSN BEFORE quantcore.db is imported (frozen at import).
+_env_file = Path(__file__).parent / ".env"
+if _env_file.exists():
+    for _line in _env_file.read_text().splitlines():
+        if _line.strip().startswith("QUANTCORE_TEST_DB_DSN="):
+            os.environ["QUANTCORE_DB_DSN"] = _line.split("=", 1)[1].strip()
+            break
+
+from quantcore.db_safety import assert_not_production  # noqa: E402
+
+assert_not_production()
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from api.main import create_app  # noqa: E402
+from api.routers import options as options_router  # noqa: E402
+from api.routers import prices as prices_router  # noqa: E402
+
+PAYLOAD = {"ok": True, "marker": "passthrough"}
+
+PRICES_GETS = [
+    "/api/securities/TST/ohlcv",
+    "/api/securities/TST/technicals",
+    "/api/securities/TST/price-summary",
+    "/api/securities/TST/rsi",
+    "/api/securities/TST/macd",
+    "/api/securities/TST/stochastic",
+    "/api/securities/TST/volume",
+    "/api/securities/TST/obv",
+    "/api/securities/TST/vwap",
+    "/api/securities/TST/vwap/history",
+    "/api/securities/TST/candlestick",
+    "/api/securities/TST/higher-lows",
+    "/api/securities/TST/gaps",
+    "/api/securities/TST/drawdown",
+    "/api/securities/TST/signals/technical",
+    "/api/securities/TST/signals/risk",
+]
+
+OPTIONS_GETS = [
+    "/api/securities/TST/options/latest",
+    "/api/securities/TST/options/history",
+    "/api/securities/TST/options/analytics",
+    "/api/securities/TST/options/chain",
+    "/api/securities/TST/options/iv-rank",
+    "/api/securities/TST/options/full-chain",
+    "/api/securities/TST/options/unusual-calls",
+    "/api/securities/TST/options/delta-adjusted-oi",
+    "/api/securities/TST/options/gamma-wall-history",
+    "/api/securities/TST/signals/options-flow",
+]
+
+
+class _UniversalService:
+    """Any method call returns PAYLOAD — routes must pass it through verbatim."""
+
+    def __getattr__(self, name):
+        return lambda *a, **k: PAYLOAD
+
+
+class _UniversalBag:
+    def __getattr__(self, name):
+        return _UniversalService()
+
+
+def happy_services():
+    return _UniversalBag()
+
+
+class RouterPassthroughTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.client = TestClient(create_app(), raise_server_exceptions=False)
+
+    def with_services(self, factory):
+        p1 = patch.object(prices_router, "services", factory)
+        p2 = patch.object(options_router, "services", factory)
+        p1.start(); p2.start()
+        self.addCleanup(p1.stop)
+        self.addCleanup(p2.stop)
+
+    def test_every_get_route_passes_the_service_payload_through(self):
+        self.with_services(lambda: happy_services())
+        for path in PRICES_GETS + OPTIONS_GETS:
+            resp = self.client.get(path)
+            self.assertEqual(resp.status_code, 200, path)
+            self.assertEqual(resp.json().get("marker"), "passthrough", path)
+
+    def test_guarded_routes_degrade_to_plain_500(self):
+        class ExplodingService:
+            def __getattr__(self, name):
+                def boom(*a, **k):
+                    raise RuntimeError("service exploded")
+                return boom
+
+        class ExplodingBag:
+            def __getattr__(self, name):
+                return ExplodingService()
+
+        self.with_services(lambda: ExplodingBag())
+        # Routes with the try/except guard return the legacy plain-error shape.
+        for path in ("/api/securities/TST/ohlcv", "/api/securities/TST/rsi",
+                     "/api/securities/TST/options/latest"):
+            resp = self.client.get(path)
+            self.assertEqual(resp.status_code, 500, path)
+            self.assertIn("service exploded", resp.json()["error"])
+
+    def test_contracts_route_forwards_query_lists(self):
+        captured = {}
+
+        class ContractsService:
+            def get_option_contracts(self, symbol, expirations, strikes, kind):
+                captured.update(symbol=symbol, expirations=expirations,
+                                strikes=strikes, kind=kind)
+                return PAYLOAD
+
+        class BagWithContracts:
+            def __getattr__(self, name):
+                return ContractsService()
+
+        self.with_services(lambda: BagWithContracts())
+        resp = self.client.get(
+            "/api/securities/TST/options/contracts"
+            "?expirations=2026-08-21&strikes=120&strikes=125&kind=put"
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(captured["kind"], "put")
+        self.assertEqual(captured["strikes"], [120.0, 125.0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_routers_passthrough.py
+++ b/test_routers_passthrough.py
@@ -60,6 +60,8 @@ OPTIONS_GETS = [
     "/api/securities/TST/options/delta-adjusted-oi",
     "/api/securities/TST/options/gamma-wall-history",
     "/api/securities/TST/signals/options-flow",
+    "/api/securities/TST/options/screen",
+    "/api/options/screen-watchlist",
 ]
 
 

--- a/test_sentiment_service.py
+++ b/test_sentiment_service.py
@@ -263,5 +263,76 @@ class TestGetNews(SentimentServiceTestBase):
         self.assertEqual(out["symbol"], "INTC")
 
 
+# ---------------------------------------------------------------------------
+# Dashboard + scoring wrapper (85%-campaign part 7)
+# ---------------------------------------------------------------------------
+
+def snap(sentiment, neg=0):
+    return {
+        "captured_at": "2026-07-24T00:00:00Z", "overall_sentiment": sentiment,
+        "positive_count": 1, "negative_count": neg, "neutral_count": 0,
+        "scored_count": 1 + neg, "article_count": 2 + neg,
+    }
+
+
+class TestSentimentDashboard(SentimentServiceTestBase):
+    PORTFOLIO = [{"symbol": "AAA", "name": "Alpha", "source": "portfolio", "tags": []}]
+    WATCHLIST = [
+        {"symbol": "AAA", "name": "Alpha", "source": "watchlist", "tags": ["dual"]},
+        {"symbol": "BBB", "name": "Beta", "source": "watchlist", "tags": []},
+    ]
+
+    def arm(self):
+        self.snapshots.get_all_latest.return_value = {
+            "AAA": snap("positive"),
+            "BBB": snap("negative", neg=5),
+            "ORPHAN": snap("neutral"),   # scored but untracked -> watchlist src
+        }
+
+    def test_ranked_negative_first_with_dual_source(self):
+        self.arm()
+        out = self.service.get_sentiment_dashboard(
+            [dict(s) for s in self.PORTFOLIO], [dict(s) for s in self.WATCHLIST]
+        )
+        self.assertEqual(out["count"], 3)
+        self.assertEqual(out["items"][0]["symbol"], "BBB")       # negative first
+        aaa = next(i for i in out["items"] if i["symbol"] == "AAA")
+        self.assertEqual(aaa["source"], "both")
+        self.assertEqual(aaa["tags"], ["dual"])
+
+    def test_source_filters(self):
+        self.arm()
+        portfolio_only = self.service.get_sentiment_dashboard(
+            [dict(s) for s in self.PORTFOLIO], [dict(s) for s in self.WATCHLIST],
+            source_filter="portfolio",
+        )
+        self.assertEqual([i["symbol"] for i in portfolio_only["items"]], ["AAA"])
+        watch_only = self.service.get_sentiment_dashboard(
+            [dict(s) for s in self.PORTFOLIO], [dict(s) for s in self.WATCHLIST],
+            source_filter="watchlist",
+        )
+        self.assertEqual({i["symbol"] for i in watch_only["items"]},
+                         {"AAA", "BBB", "ORPHAN"})
+
+
+class TestScoreSentimentWrapper(unittest.TestCase):
+    def test_blank_text_short_circuits(self):
+        self.assertIsNone(sentiment_mod._score_sentiment("   "))
+
+    def test_rounds_and_slims_the_finbert_result(self):
+        full = {"sentiment": "negative", "sentiment_score": 0.87654321,
+                "positive_score": 0.1, "negative_score": 0.88, "neutral_score": 0.02}
+        with patch.object(sentiment_mod, "_score_text", return_value=full):
+            out = sentiment_mod._score_sentiment("bad quarter")
+        self.assertEqual(out, {"sentiment": "negative", "sentiment_score": 0.8765})
+
+    def test_model_unavailable_or_error_returns_none(self):
+        with patch.object(sentiment_mod, "_score_text", return_value=None):
+            self.assertIsNone(sentiment_mod._score_sentiment("text"))
+        with patch.object(sentiment_mod, "_score_text",
+                          side_effect=RuntimeError("torch OOM")):
+            self.assertIsNone(sentiment_mod._score_sentiment("text"))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Tommy's target: 85% coverage. **Backend: done — 69.6% → 85.5%** in ten parts, 231 → 804 tests, floor ratcheted 62 → **84**. (Frontend to 85% is the remaining half — tracked separately; it needs a component-test harness and is a comparable-sized effort.)

## Where the 16 points came from

| Part | Target | Before → After |
|---|---|---|
| 1 | `options_analysis.py` CLI/reporters + repo batch (fundamentals/news/ohlcv/positions) | 0→68% / 17–43→75–90% |
| 2 | `harvester_repository` (real `build_plan` with injected bars) | 42→85% |
| 3 | screening `fetch_*` pipeline | 54→85% |
| 4 | prices/options router passthrough contract (Rule 6 pinned mechanically) | 47→66–76% |
| 5 | fundamentals collection surfaces | 67→82% |
| 6 | Polygon backfill + refresh orchestrators | 75→92% |
| 7 | sentiment dashboard + scoring wrapper | 70→82% |
| 8 | relative-strength history/snapshot | 77→85% |
| 9 | `rest_client` seam + company-fundamentals wrapper | 28→95% / 0→98% |
| 10 | Harvester scan-and-fire, cache edges, CLI `main()` | 66→89% etc. |

Same discipline throughout: engineered fixtures with analytically known outcomes (a 200/100 OI book **must** read P/C 2.0; a rung touch **must** fire once and never refire; a corrupt cache row **must** be a miss, not a crash). No production code changes anywhere in the campaign.

## Notable coverage now standing guard

- The harvest ladder's full lifecycle: build → supersede → scan → fire → mark, on real DB plans
- The identity-passthrough seam (`rest_client`): bearer lifting from MCP request headers, error-body preservation
- Backfill's HTTP status contract (400/402/200) and per-date state machine
- Router passthrough: any route that grows hidden logic now fails a test by construction

🤖 Generated with [Claude Code](https://claude.com/claude-code)