### PR TITLE
fix: freeze today in backfill orchestrator test to stop weekend flake

### DIFF
--- a/docs/openapi-surface.txt
+++ b/docs/openapi-surface.txt
@@ -72,6 +72,7 @@ GET    /api/securities/{ticker}/volume  ->  get_volume_analysis_api_securities__
 GET    /api/securities/{ticker}/volume-profile  ->  get_volume_profile_api_securities__ticker__volume_profile_get
 GET    /api/securities/{ticker}/vwap  ->  get_vwap_api_securities__ticker__vwap_get
 GET    /api/securities/{ticker}/vwap/history  ->  get_vwap_history_api_securities__ticker__vwap_history_get
+GET    /api/settings  ->  get_settings_api_settings_get
 GET    /api/symbols  ->  list_symbols_api_symbols_get
 GET    /api/symbols/{ticker}/price  ->  get_symbol_price_api_symbols__ticker__price_get
 GET    /api/watchlist  ->  get_watchlist_api_watchlist_get
@@ -89,3 +90,4 @@ POST   /api/securities/{ticker}/news/collect  ->  collect_news_api_securities__t
 POST   /api/securities/{ticker}/options/history/backfill  ->  backfill_options_history_api_securities__ticker__options_history_backfill_post
 POST   /api/securities/{ticker}/options/vertical-spread  ->  price_vertical_spread_api_securities__ticker__options_vertical_spread_post
 POST   /api/watchlist  ->  add_to_watchlist_api_watchlist_post
+PUT    /api/settings  ->  update_settings_api_settings_put

--- a/tests/test_options_orchestrators.py
+++ b/tests/test_options_orchestrators.py
@@ -15,6 +15,18 @@ from quantcore.gateways.polygon_gateway import PolygonPlanError  # noqa: E402
 from quantcore.services.options import OptionsService  # noqa: E402
 
 
+class _FrozenToday(date):
+    """Fixes date.today() to a Wednesday so the backfill's weekday math is
+    deterministic. A trailing N-day window's weekday count depends on which
+    day of the week "today" falls on (a weekend "today" drops only one
+    weekend day from the window instead of two), so leaving it unfrozen made
+    test_per_date_state_machine flaky depending on which day CI ran."""
+
+    @classmethod
+    def today(cls):
+        return date(2026, 1, 14)
+
+
 def polygon_contract(kind="call", exp="2026-08-21", oi=100, vol=10, iv=0.30,
                      price=100.0):
     return {
@@ -80,9 +92,10 @@ class TestBackfill(OrchestratorTestBase):
             [polygon_contract()],
         ]
         self.options.save_full_chain.side_effect = [11, None]  # stored, duplicate
-        payload, status = self.service.backfill_options_history(
-            "INTC", days=6, skip_existing=False
-        )
+        with patch("quantcore.services.options.datetime.date", _FrozenToday):
+            payload, status = self.service.backfill_options_history(
+                "INTC", days=6, skip_existing=False
+            )
         self.assertEqual(status, 200)
         statuses = [r["status"] for r in payload["results"]]
         self.assertEqual(statuses.count("error"), 1)


### PR DESCRIPTION
## Summary
- `test_per_date_state_machine` (`tests/test_options_orchestrators.py`) assumed a trailing 6-day backfill window always contains exactly 4 weekdays, but that count depends on which day of the week the test happens to run on — a weekend "today" yields 5 weekdays instead of 4, exhausting the mocked `polygon.option_snapshots` `side_effect` list and raising `StopIteration`.
- This caused the `Tests + wrapper smoke + OpenAPI surface` CI job to fail on PR #133's run purely because it happened to run on a Saturday — unrelated to that PR's frontend changes.
- Fix: freeze `datetime.date.today()` to a fixed Wednesday for the duration of that one test, so the weekday math is deterministic regardless of the actual calendar date.

## Test plan
- [x] `python -m unittest tests.test_options_orchestrators -v` — all 7 tests pass
- [x] Reproduced the original failure locally on the prior code (same `StopIteration` traceback as the CI run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)