### PR TITLE
fix(sidekick): drop fable-only `fallbacks`, surface truncated turns, stop shortening ranked lists

### DIFF
--- a/frontend/src/chat/ChatContext.tsx
+++ b/frontend/src/chat/ChatContext.tsx
@@ -297,6 +297,19 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         });
       };
 
+      // A `done` frame carrying truncated=true means the answer was cut off
+      // at the output-budget ceiling. It's message-level, not another
+      // segment: it describes how the turn ended, and always lands last.
+      const markTruncated = () => {
+        setMessages((prev) => {
+          const next = [...prev];
+          const last = next[next.length - 1];
+          if (last?.role !== 'assistant') return prev;
+          next[next.length - 1] = { ...last, truncated: true };
+          return next;
+        });
+      };
+
       // If the stream dies without a terminal frame (server restart, network
       // drop), tool chips stuck in 'running' would spin forever — flip any
       // survivors to 'error' once the stream is over, however it ended.
@@ -338,7 +351,9 @@ export function ChatProvider({ children }: { children: ReactNode }) {
               setError(event.message);
             } else if (event.type === 'parse_error') {
               setError('Received an unreadable chunk from the server.');
-            } else if (event.type !== 'done') {
+            } else if (event.type === 'done') {
+              if (event.truncated) markTruncated();
+            } else {
               applyToAssistant(event);
             }
           },

--- a/frontend/src/chat/types.ts
+++ b/frontend/src/chat/types.ts
@@ -32,7 +32,9 @@ export type ChatStreamEvent =
     }
   | { type: 'directive'; directive: ChatDirective }
   | { type: 'error'; message: string }
-  | { type: 'done'; stop_reason: string }
+  /** `truncated` = the model hit its output budget mid-answer (stop_reason
+   *  "max_tokens"), not a clean finish. The prose above it is still valid. */
+  | { type: 'done'; stop_reason: string; truncated?: boolean }
   /** Client-side only: a frame whose data payload failed to JSON-parse. */
   | { type: 'parse_error'; raw: string };
 
@@ -45,6 +47,9 @@ export type Segment =
 export interface ChatMessage {
   role: 'user' | 'assistant';
   segments: Segment[];
+  /** Assistant turn ran out of output budget mid-answer — the rail notes it
+   *  so a cut-off list isn't mistaken for a deliberately short one. */
+  truncated?: boolean;
 }
 
 /** History shape sent to the API (assistant segments serialized to text). */

--- a/frontend/src/components/chat/ChatRail.test.tsx
+++ b/frontend/src/components/chat/ChatRail.test.tsx
@@ -155,6 +155,48 @@ describe('ChatRail', () => {
     expect(screen.getByTestId('tool-chip-get_rsi').dataset.state).toBe('done');
   });
 
+  it('notes a truncated turn on the message that was cut off', async () => {
+    renderRail();
+    await sendPrompt('Rank the top 10 semis');
+    emit({ type: 'text', delta: '1. AMD\n2. NVDA' });
+    expect(screen.queryByTestId('message-truncated')).toBeNull();
+    // stop_reason max_tokens: the list above is real but unfinished, so the
+    // rail has to say so — otherwise it reads as a deliberately short answer.
+    emit({ type: 'done', stop_reason: 'max_tokens', truncated: true });
+    finishStream();
+    const assistant = screen.getByTestId('chat-message-assistant');
+    expect(within(assistant).getByTestId('message-truncated')).toHaveTextContent(/cut off/i);
+    expect(screen.getByText(/1\. AMD/)).toBeInTheDocument();
+  });
+
+  it('leaves a cleanly finished turn unmarked', async () => {
+    renderRail();
+    await sendPrompt('hi');
+    emit({ type: 'text', delta: 'all done' });
+    emit({ type: 'done', stop_reason: 'end_turn' });
+    finishStream();
+    expect(screen.queryByTestId('message-truncated')).toBeNull();
+  });
+
+  it('marks only the truncated turn, not the next one', async () => {
+    renderRail();
+    await sendPrompt('long one');
+    emit({ type: 'text', delta: 'partial' });
+    emit({ type: 'done', stop_reason: 'max_tokens', truncated: true });
+    finishStream();
+    await waitFor(() =>
+      expect(screen.getByTestId('chat-input').querySelector('textarea, input')).toBeEnabled(),
+    );
+    await sendPrompt('shorter one');
+    emit({ type: 'text', delta: 'complete' });
+    emit({ type: 'done', stop_reason: 'end_turn' });
+    finishStream();
+    expect(screen.getAllByTestId('message-truncated')).toHaveLength(1);
+    const bubbles = screen.getAllByTestId('chat-message-assistant');
+    expect(within(bubbles[0]).queryByTestId('message-truncated')).not.toBeNull();
+    expect(within(bubbles[1]).queryByTestId('message-truncated')).toBeNull();
+  });
+
   it('disables the input while streaming and re-enables on error', async () => {
     renderRail();
     await sendPrompt('hello');

--- a/frontend/src/components/chat/ChatRail.tsx
+++ b/frontend/src/components/chat/ChatRail.tsx
@@ -93,6 +93,19 @@ function MessageView({ message }: { message: ChatMessage }) {
             …
           </Typography>
         )}
+        {message.truncated && (
+          // Muted on purpose: the answer above is real, it's just incomplete.
+          // Without this a cut-off ranked list reads as a deliberately short
+          // one, and the user debugs the wrong thing (see issue #121).
+          <Typography
+            variant="caption"
+            color="text.secondary"
+            data-testid="message-truncated"
+            sx={{ display: 'block', mt: 0.75, fontStyle: 'italic' }}
+          >
+            Response cut off — length limit reached.
+          </Typography>
+        )}
       </Paper>
     </Box>
   );

--- a/keyproxy/main.py
+++ b/keyproxy/main.py
@@ -222,12 +222,15 @@ class RedemptionRequest(BaseModel):
 
 
 class StreamTurnRequest(BaseModel):
-    # Mirrors AnthropicChatClient.stream_turn's surface; betas/fallbacks are
-    # fixed provider-side (keyproxy.providers.anthropic) — not caller inputs.
+    # Mirrors AnthropicChatClient.stream_turn's surface. The request shape is
+    # fixed provider-side (keyproxy.providers.anthropic) — not a caller input.
+    # max_tokens is only a floor for callers that omit it; KeyProxyChatClient
+    # always sends its own, so raising the budget there needs no keyproxy
+    # redeploy.
     session_id: str
     model: str
     effort: str
-    max_tokens: int = 8192
+    max_tokens: int = 16384
     system: Any = None
     tools: list = []
     messages: list

--- a/keyproxy/providers/anthropic.py
+++ b/keyproxy/providers/anthropic.py
@@ -30,11 +30,6 @@ ANTHROPIC_VERSION = "2023-06-01"
 
 VALIDATE_TIMEOUT_SECONDS = 10.0
 
-# Fixed turn parameters, mirroring AnthropicChatClient.stream_turn — callers
-# supply model/effort/max_tokens/system/tools/messages; nothing else.
-STREAM_BETAS = ["server-side-fallback-2026-06-01"]
-STREAM_FALLBACKS = [{"model": "claude-opus-4-8"}]
-
 # Sidekick model selector (issue #124). Keyproxy is a separate deployable —
 # it owns this copy rather than importing quantcore.chat_models.
 ALLOWED_MODELS = frozenset({"claude-sonnet-5", "claude-opus-4-8", "claude-fable-5"})
@@ -98,6 +93,11 @@ def stream_turn(api_key, *, model, effort, max_tokens, system, tools, messages):
     SDK's ``ANTHROPIC_BASE_URL`` environment override can never redirect
     egress. The SDK import is lazy — dev/CI environments don't ship it; the
     keyproxy image pins it in keyproxy/requirements.txt.
+
+    The request shape carries only parameters that EVERY allow-listed model
+    accepts. No betas/fallbacks: the server-side-fallback beta was sent here
+    and removed, because only claude-fable-5 accepts ``fallbacks`` and the
+    others reject the whole turn with a 400 rather than ignoring it.
     """
     import anthropic  # lazy — see docstring
 
@@ -109,8 +109,6 @@ def stream_turn(api_key, *, model, effort, max_tokens, system, tools, messages):
         tools=tools,
         messages=messages,
         output_config={"effort": effort},
-        betas=STREAM_BETAS,
-        fallbacks=STREAM_FALLBACKS,
     ) as stream:
         for event in stream:
             if (

--- a/quantcore/gateways/anthropic_gateway.py
+++ b/quantcore/gateways/anthropic_gateway.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 class AnthropicChatClient:
     """Real client: streams one model turn via the Anthropic SDK."""
 
-    def __init__(self, model: str, effort: str, max_tokens: int = 8192):
+    def __init__(self, model: str, effort: str, max_tokens: int = 16384):
         import anthropic  # lazy — see module docstring
 
         self._client = anthropic.Anthropic()
@@ -27,8 +27,17 @@ class AnthropicChatClient:
         self._max_tokens = max_tokens
 
     def stream_turn(self, *, system, tools, messages):
-        # claude-fable-5: omit `thinking` entirely (always on); no sampling
-        # params. Refusal fallbacks are opt-in — include them by default.
+        # Deliberately minimal request shape — and it must stay that way: only
+        # parameters that EVERY selectable model accepts. `thinking` is omitted
+        # (on by default), sampling params are not accepted, and depth comes
+        # from output_config.effort.
+        #
+        # No betas/fallbacks. The server-side-fallback beta was sent here and
+        # removed: only claude-fable-5 accepts `fallbacks`, and a model that
+        # doesn't rejects the ENTIRE turn with a 400 ("'<model>' does not
+        # support the `fallbacks` parameter") rather than ignoring it. Any new
+        # parameter added here needs checking against all three models first.
+        # Mirrored in keyproxy/providers/anthropic.py.
         with self._client.beta.messages.stream(
             model=self._model,
             max_tokens=self._max_tokens,
@@ -36,8 +45,6 @@ class AnthropicChatClient:
             tools=tools,
             messages=messages,
             output_config={"effort": self._effort},
-            betas=["server-side-fallback-2026-06-01"],
-            fallbacks=[{"model": "claude-opus-4-8"}],
         ) as stream:
             for event in stream:
                 if (

--- a/quantcore/gateways/keyproxy_gateway.py
+++ b/quantcore/gateways/keyproxy_gateway.py
@@ -344,7 +344,7 @@ class KeyProxyChatClient:
         auth_token: str,
         model: str,
         effort: str,
-        max_tokens: int = 8192,
+        max_tokens: int = 16384,
     ):
         self._envelope = envelope
         self._scope = scope

--- a/quantcore/services/chat.py
+++ b/quantcore/services/chat.py
@@ -9,11 +9,20 @@ Design notes:
     §5.3; it is loaded lazily via _default_client_factory so this module —
     and the registry that imports it — never touches the SDK at import time
     (MCP stdio servers and requirements-base images depend on that).
-  * Model default is claude-sonnet-5: thinking is always on (the ``thinking``
-    parameter must be omitted entirely), sampling params are not accepted, and
-    depth is controlled via ``output_config.effort``. Server-side refusal
-    fallbacks to claude-opus-4-8 are opted in by default per current API
-    guidance.
+  * Model default is claude-sonnet-5. The turn request carries only what all
+    three selectable models accept: ``thinking`` is omitted entirely,
+    sampling params are not accepted, and depth comes from
+    ``output_config.effort`` (CHAT_EFFORT, default "medium"). Provider
+    parameters are NOT uniformly tolerated — an unsupported one 400s the
+    whole turn instead of being ignored (``fallbacks`` did exactly that to
+    claude-sonnet-5 and claude-opus-4-8), so anything new belongs in the
+    gateway only after it is checked against every allow-listed model.
+  * How much each model *thinks* varies (claude-sonnet-5 has been observed
+    returning usage.thinking_tokens == 0), and thinking counts against the
+    shared max_tokens budget — so the room left for visible output differs by
+    model on an identical request. A turn that exhausts the budget comes back
+    with stop_reason == "max_tokens" and is surfaced (Done.truncated) rather
+    than ending the stream as if the model had chosen to stop.
 """
 from __future__ import annotations
 
@@ -48,9 +57,11 @@ graph for a vertical spread — expiration payoff plus a value-today curve).
 After pricing a spread with price_vertical_spread, always render it with
 show_component('spread_payoff', {ticker, expiration, long_strike,
 short_strike, kind}) using the exact same parameters. After discussing a
-ticker, prefer showing the relevant component so the user sees live data —
-the component fetches its own data; never restate numbers the component will
-display.
+single ticker, prefer showing the relevant component so the user sees live
+data — the component fetches its own data; don't restate numbers that a
+component you just rendered is already showing. Components are single-ticker
+only: when the user asks about several symbols at once, give the numbers in
+prose instead.
 
 Rendered components are interactive: when the user clicks inside one (a
 strike on a spread_payoff chart, a point on a price_chart), their message
@@ -60,7 +71,58 @@ context from the user ("this strike" means the payload strike). Answer about
 the selected element directly; never echo the raw JSON back.
 
 Numbers you state in prose must come from tool results in this conversation,
-never from memory. Be concise; this is a side rail, not a report."""
+never from memory.
+
+The tools above are your only source of market data. You have no web access:
+never attempt a web search, never fetch a URL, and never pull prices, news,
+filings, earnings figures, or any other market data from outside those tool
+results — not from your training data, and not from a link the user pastes.
+If the user asks you to search the web, look something up online, check
+another site, or merge in outside data, politely decline and say plainly that
+your system prompt restricts you to QuantCore's own data tools. Name the
+closest tool you do have (get_news_sentiment for news, get_fundamental_score
+for company financials, get_stock_price for quotes), then answer the rest of
+their request normally — a declined sub-request is never a reason to abandon
+the whole question. If the user supplies figures themselves, you may reason
+about them, but say they are the user's numbers rather than QuantCore data.
+
+Whenever you decline or narrow any part of a request because it conflicts
+with these instructions, say so explicitly and name the conflict — "your
+system prompt restricts me to QuantCore's own data tools," "my system prompt
+tells me not to state numbers I haven't fetched." Do not disguise a
+system-prompt restriction as missing data, a tool failure, or an inability on
+your part; those send the user debugging the wrong thing. The user maintains
+this system prompt, so they need to know which rule blocked them in order to
+change it. Never silently drop part of a request you decided not to fulfill.
+Attribute a refusal to this system prompt only when a rule above is genuinely
+the cause — if you are holding back for some other reason, say that instead,
+in your own words. Guessing wrong sends the user editing a rule that was
+never involved.
+
+Ranking, scoring, and comparing symbols on their signals is the core job here
+and is always in scope: it is a summary of computed indicators, not personal
+investment advice, and needs no disclaimer. Report what the signals say and
+let the user draw conclusions. If someone asks what they personally should
+buy, sell, or hold, or how to size a position against their own finances,
+give the signal picture and note that the call is theirs.
+
+Be concise: no preamble, no restating the question, no filler — this is a
+side rail, not a report. Concision means cutting padding, never cutting
+content the user asked for. When the user asks you to rank, prioritize,
+compare, or screen a set of symbols, cover every symbol they named — a
+complete ranked list IS the concise answer to that request. Never silently
+shorten a list, drop symbols, or stop partway to stay brief. If you truly
+cannot cover them all — a tool failed, or the list is too long to fetch —
+rank the ones you have and say plainly which are missing and why.
+
+Format a multi-symbol answer as one short line per symbol, in rank order,
+with the driving signals after an em dash, like:
+  1. NVDA — RSI 62, MACD bullish crossover, price above 50d
+Your prose renders as plain text — no markdown is interpreted. Never use
+markdown tables, pipes, or heading syntax (columns will not line up), and
+never use **bold**, *italics*, or `backticks`: those show up as literal
+asterisks and backtick characters on screen. Write tickers and labels bare.
+Plain numbered or hyphenated lines are fine."""
 
 
 # ---------------------------------------------------------------------------
@@ -101,8 +163,16 @@ class ErrorEvent:
 
 @dataclass(frozen=True)
 class Done:
-    """Clean end of turn — always the final event on success."""
+    """End of turn — always the final event on success.
+
+    ``truncated`` means the model ran out of output budget mid-answer
+    (stop_reason "max_tokens") rather than finishing. The distinction matters
+    to the user: a truncated ranked list looks identical to a deliberately
+    short one, so the rail renders a visible note for it. Kept separate from
+    ErrorEvent because the partial answer above it is still worth reading.
+    """
     stop_reason: str = "end_turn"
+    truncated: bool = False
 
 
 ChatEvent = TextDelta | ToolStatus | Directive | ErrorEvent | Done
@@ -313,6 +383,21 @@ class ChatService:
                 tool_uses = [
                     b for b in final.content if getattr(b, "type", None) == "tool_use"
                 ]
+
+                # Budget exhausted mid-answer. Stop here even when the turn
+                # carries tool_use blocks: a block cut off mid-stream can hold
+                # incomplete argument JSON, and echoing that assistant turn
+                # back to the provider is itself an invalid_request_error risk.
+                # A partial answer the user can see beats a turn that dies
+                # opaquely one iteration later.
+                if final.stop_reason == "max_tokens":
+                    logger.warning(
+                        "chat turn truncated at max_tokens model=%s pending_tools=%d",
+                        context.model or self._model,
+                        len(tool_uses),
+                    )
+                    yield Done(stop_reason="max_tokens", truncated=True)
+                    return
                 if not tool_uses:
                     yield Done(stop_reason=str(final.stop_reason or "end_turn"))
                     return

--- a/tests/test_anthropic_gateway.py
+++ b/tests/test_anthropic_gateway.py
@@ -16,6 +16,7 @@ the ChatService->gateway wiring is covered behaviorally in test_chat_service.
 import re
 import subprocess
 import sys
+import types
 import unittest
 from pathlib import Path
 
@@ -71,5 +72,175 @@ class TestAnthropicGatewayExtraction(unittest.TestCase):
         self.assertIn("registry-ok", result.stdout)
 
 
+class _FakeStream:
+    """Stands in for the SDK's streaming context manager — yields nothing."""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def __iter__(self):
+        return iter(())
+
+    def get_final_message(self):
+        # The quantcore path uses the object directly; keyproxy serializes it.
+        return types.SimpleNamespace(
+            stop_reason="end_turn",
+            content=[],
+            model_dump=lambda mode="json": {"stop_reason": "end_turn", "content": []},
+        )
+
+
+class _FakeSDK:
+    """Minimal fake `anthropic` module recording the kwargs of each call."""
+
+    def __init__(self):
+        self.init_kwargs = None
+        self.stream_kwargs = None
+
+        def stream(**kwargs):
+            self.stream_kwargs = kwargs
+            return _FakeStream()
+
+        def Anthropic(**kwargs):  # noqa: N802 — mirrors the SDK's class name
+            self.init_kwargs = kwargs
+            return types.SimpleNamespace(
+                beta=types.SimpleNamespace(messages=types.SimpleNamespace(stream=stream))
+            )
+
+        self.module = types.SimpleNamespace(Anthropic=Anthropic)
+
+    def __enter__(self):
+        self._saved = sys.modules.get("anthropic")
+        sys.modules["anthropic"] = self.module
+        return self
+
+    def __exit__(self, *exc):
+        if self._saved is None:
+            sys.modules.pop("anthropic", None)
+        else:
+            sys.modules["anthropic"] = self._saved
+        return False
+
+
+class TestTurnRequestShape(unittest.TestCase):
+    """The outgoing request carries ONLY parameters every model accepts.
+
+    Regression guard for the sidekick model selector (issue #124). The request
+    shape was validated against claude-fable-5 and generalized to all three
+    models, but `fallbacks` is fable-only: claude-sonnet-5 and claude-opus-4-8
+    reject the entire turn with a 400 ("'<model>' does not support the
+    `fallbacks` parameter") rather than ignoring the unknown parameter. Every
+    non-fable sidekick turn failed. `fallbacks` was then dropped outright.
+
+    These assert on the kwargs actually handed to the SDK, so they also catch
+    a *new* unvetted parameter being added later — which is the failure mode
+    that produced the original bug.
+    """
+
+    ALLOWED_KWARGS = {
+        "model",
+        "max_tokens",
+        "system",
+        "tools",
+        "messages",
+        "output_config",
+    }
+
+    def _quantcore_kwargs(self, model):
+        from quantcore.gateways.anthropic_gateway import AnthropicChatClient
+
+        with _FakeSDK() as sdk:
+            client = AnthropicChatClient(model=model, effort="medium")
+            list(client.stream_turn(system="sys", tools=[], messages=[]))
+        return sdk.stream_kwargs
+
+    def _keyproxy_kwargs(self, model):
+        from keyproxy.providers import anthropic as kp
+
+        with _FakeSDK() as sdk:
+            list(
+                kp.stream_turn(
+                    "sk-test",
+                    model=model,
+                    effort="medium",
+                    max_tokens=16384,
+                    system="sys",
+                    tools=[],
+                    messages=[],
+                )
+            )
+        return sdk.stream_kwargs
+
+    def test_no_fallbacks_or_betas_on_any_model(self):
+        from keyproxy.providers.anthropic import ALLOWED_MODELS
+
+        for model in sorted(ALLOWED_MODELS):
+            for name, kwargs in (
+                ("quantcore", self._quantcore_kwargs(model)),
+                ("keyproxy", self._keyproxy_kwargs(model)),
+            ):
+                with self.subTest(model=model, path=name):
+                    self.assertNotIn("fallbacks", kwargs)
+                    self.assertNotIn("betas", kwargs)
+
+    def test_request_shape_is_the_vetted_set_on_both_paths(self):
+        # A new kwarg here must be checked against all three models first —
+        # an unsupported one 400s the whole turn instead of being ignored.
+        from keyproxy.providers.anthropic import ALLOWED_MODELS
+
+        for model in sorted(ALLOWED_MODELS):
+            for name, kwargs in (
+                ("quantcore", self._quantcore_kwargs(model)),
+                ("keyproxy", self._keyproxy_kwargs(model)),
+            ):
+                with self.subTest(model=model, path=name):
+                    self.assertEqual(set(kwargs), self.ALLOWED_KWARGS)
+                    self.assertEqual(kwargs["model"], model)
+                    self.assertEqual(kwargs["output_config"], {"effort": "medium"})
+
+    def test_thinking_is_never_sent(self):
+        # Omitted deliberately (on by default); sending it is not uniform.
+        self.assertNotIn("thinking", self._quantcore_kwargs("claude-sonnet-5"))
+        self.assertNotIn("thinking", self._keyproxy_kwargs("claude-sonnet-5"))
+
+    def test_keyproxy_pins_egress_base_url(self):
+        # The allowlist-by-construction guarantee: no env override may
+        # redirect a decrypted key somewhere other than api.anthropic.com.
+        from keyproxy.providers import anthropic as kp
+
+        with _FakeSDK() as sdk:
+            list(
+                kp.stream_turn(
+                    "sk-test",
+                    model="claude-sonnet-5",
+                    effort="medium",
+                    max_tokens=16384,
+                    system="sys",
+                    tools=[],
+                    messages=[],
+                )
+            )
+        self.assertEqual(sdk.init_kwargs["base_url"], kp.BASE_URL)
+        self.assertEqual(kp.BASE_URL, "https://api.anthropic.com")
+
+    def test_output_budget_matches_across_both_paths(self):
+        # Thinking tokens share this budget, so a mismatch between the
+        # in-process and the BYOK client means truncation behaviour depends on
+        # which one served the turn (issue #121 symptom).
+        import inspect
+
+        from quantcore.gateways.anthropic_gateway import AnthropicChatClient
+        from quantcore.gateways.keyproxy_gateway import KeyProxyChatClient
+
+        direct = inspect.signature(AnthropicChatClient.__init__).parameters
+        byok = inspect.signature(KeyProxyChatClient.__init__).parameters
+        self.assertEqual(direct["max_tokens"].default, byok["max_tokens"].default)
+        self.assertEqual(direct["max_tokens"].default, 16384)
+
+
 if __name__ == "__main__":
     unittest.main()
+

--- a/tests/test_chat_service.py
+++ b/tests/test_chat_service.py
@@ -449,6 +449,77 @@ class TestInteractions(ChatServiceTestBase):
 
         self.assertIn("[UI_INTERACTION]", SYSTEM_PROMPT)
 
+    def test_system_prompt_allows_complete_multi_symbol_answers(self):
+        """Concision must not read as permission to truncate (issue #121).
+
+        "Be concise; this is a side rail, not a report" was being applied to
+        multi-symbol ranking requests, so "prioritize these symbols by bullish
+        signals" came back partial. The prompt must scope concision to padding
+        and explicitly require full coverage of a requested set.
+        """
+        from quantcore.services.chat import SYSTEM_PROMPT
+
+        self.assertIn("cover every symbol they named", SYSTEM_PROMPT)
+        self.assertIn("Never silently", SYSTEM_PROMPT)
+        # Concision is defined, not left bare — the bare form is what misfired.
+        self.assertIn("never cutting", SYSTEM_PROMPT)
+
+    def test_system_prompt_forbids_external_data_sources(self):
+        """The sidekick is closed over its own tools — no web, no training
+        data. Numbers on screen must be traceable to a QuantCore tool call,
+        and a refused "search the web for X" must not abort the whole turn."""
+        from quantcore.services.chat import SYSTEM_PROMPT
+
+        self.assertIn("no web access", SYSTEM_PROMPT)
+        self.assertIn("politely decline", SYSTEM_PROMPT)
+        self.assertIn("only source of market data", SYSTEM_PROMPT)
+
+    def test_system_prompt_requires_attributing_refusals_to_itself(self):
+        """A partial refusal must name the system prompt as the cause.
+
+        The user maintains this prompt; a restriction disguised as "no data
+        available" or a tool failure sends them debugging the wrong layer.
+        """
+        from quantcore.services.chat import SYSTEM_PROMPT
+
+        self.assertIn("name the conflict", SYSTEM_PROMPT)
+        self.assertIn("Do not disguise a", SYSTEM_PROMPT)
+        self.assertIn("Never silently drop part of a request", SYSTEM_PROMPT)
+
+    def test_system_prompt_forbids_markdown_tables(self):
+        """ChatRail renders assistant text as plain text (whiteSpace:
+        pre-wrap, proportional font) — markdown tables would render as raw
+        pipes with misaligned columns, so the prompt must rule them out."""
+        from quantcore.services.chat import SYSTEM_PROMPT
+
+        self.assertIn("markdown tables", SYSTEM_PROMPT)
+        # Bold/backticks are the ones models actually reach for in ranked
+        # lists ("**NVDA** — ..."), and they render as literal asterisks.
+        self.assertIn("**bold**", SYSTEM_PROMPT)
+        self.assertIn("backticks", SYSTEM_PROMPT)
+
+    def test_system_prompt_scopes_refusal_attribution(self):
+        """Only blame this prompt when this prompt is actually the cause.
+
+        The attribution rule primes the model to point at the system prompt;
+        without scoping, a refusal driven by anything else gets misattributed
+        and sends the user editing a rule that was never involved.
+        """
+        from quantcore.services.chat import SYSTEM_PROMPT
+
+        self.assertIn("only when a rule above is genuinely", SYSTEM_PROMPT)
+
+    def test_system_prompt_puts_ranking_in_scope(self):
+        """Ranking on signals is the product, not investment advice.
+
+        Left unstated, each model improvises its own disclaimer/decline
+        threshold, so the same request behaves differently per model.
+        """
+        from quantcore.services.chat import SYSTEM_PROMPT
+
+        self.assertIn("always in scope", SYSTEM_PROMPT)
+        self.assertIn("not personal", SYSTEM_PROMPT)
+
 
 class TestDirectiveComponentIds(ChatServiceTestBase):
     def test_each_directive_gets_a_unique_component_id(self):
@@ -474,6 +545,48 @@ class TestDirectiveComponentIds(ChatServiceTestBase):
         self.assertEqual(len(directives), 2)
         self.assertTrue(all(d.component_id for d in directives))
         self.assertNotEqual(directives[0].component_id, directives[1].component_id)
+
+
+class TestOutputBudgetTruncation(ChatServiceTestBase):
+    """stop_reason "max_tokens" is a cut-off answer, not a clean finish.
+
+    Regression guard for issue #121: a ranked list that ran out of output
+    budget looked identical to a deliberately short one, so the flag has to
+    reach the UI instead of the turn ending as an ordinary Done.
+    """
+
+    def test_truncated_turn_flags_done_and_keeps_partial_text(self):
+        client = ScriptedClient(
+            [{"deltas": ["1. AMD", "\n2. NV"], "final": final("max_tokens", text_block("1. AMD\n2. NV"))}]
+        )
+        events = self.run_chat(client)
+        self.assertEqual([type(e) for e in events], [TextDelta, TextDelta, Done])
+        # The prose above the flag is real output — it must still be delivered.
+        self.assertEqual("".join(e.delta for e in events[:2]), "1. AMD\n2. NV")
+        self.assertTrue(events[-1].truncated)
+        self.assertEqual(events[-1].stop_reason, "max_tokens")
+
+    def test_normal_turn_is_not_flagged_truncated(self):
+        client = ScriptedClient([{"final": final("end_turn", text_block("done"))}])
+        events = self.run_chat(client)
+        self.assertFalse(events[-1].truncated)
+        self.assertEqual(events[-1].stop_reason, "end_turn")
+
+    def test_truncated_turn_with_tool_use_stops_without_executing_it(self):
+        # A tool_use block cut off mid-stream can hold incomplete argument
+        # JSON; running it (and echoing the turn back) is the worse failure.
+        client = ScriptedClient(
+            [
+                {"final": final("max_tokens", tool_use("tu_1", "get_rsi", {"symbol": "AMD"}))},
+                {"final": final("end_turn", text_block("unreachable"))},
+            ]
+        )
+        events = self.run_chat(client)
+        self.assertIsInstance(events[-1], Done)
+        self.assertTrue(events[-1].truncated)
+        self.assertEqual(self.prices.mock_calls, [])
+        # One turn only — no follow-up round trip carrying the partial block.
+        self.assertEqual(len(client.calls), 1)
 
 
 class TestFailureModes(ChatServiceTestBase):

--- a/tests/test_keyproxy_streaming.py
+++ b/tests/test_keyproxy_streaming.py
@@ -113,7 +113,10 @@ class TestStreamingTurn(StreamingTestBase):
         self.assertEqual(key, API_KEY)
         self.assertEqual(params["model"], "claude-fable-5")
         self.assertEqual(params["effort"], "high")
-        self.assertEqual(params["max_tokens"], 8192)
+        # The body omits max_tokens, so this is StreamTurnRequest's default —
+        # only a floor for callers that don't send one (KeyProxyChatClient
+        # always does, so raising its budget needs no keyproxy redeploy).
+        self.assertEqual(params["max_tokens"], 16384)
         self.assertEqual(params["system"], "you are a test")
         self.assertEqual(params["messages"], [{"role": "user", "content": "hi"}])
 


### PR DESCRIPTION
Follow-up to #133 (sidekick model selector). Three fixes found while exercising the shipped selector, plus two commits that were already on the previous branch and had no PR of their own.

## 1. `fallbacks` broke every non-fable turn

The selector shipped with a request shape that had been validated against `claude-fable-5` and generalized to the other two models without rechecking. `fallbacks` is fable-only: `claude-sonnet-5` (the default) and `claude-opus-4-8` reject the **entire turn** with a 400 —

```
'claude-opus-4-8' does not support the `fallbacks` parameter
```

— rather than ignoring the unknown parameter. So picking either non-fable model made the sidekick fail outright.

Removed the constants and `fallback_kwargs()` from both mirrors (`quantcore/gateways/anthropic_gateway.py` and `keyproxy/providers/anthropic.py`), leaving only parameters every allow-listed model accepts.

The guard rewrite matters as much as the fix: `tests/test_anthropic_gateway.py` now stubs the `anthropic` module and asserts on **the kwargs actually handed to the SDK**, for every allowed model on both the in-process and BYOK paths. A newly added unvetted parameter fails there instead of 400ing in production — which is exactly how this bug got in.

## 2. Output budget raised 8192 → 16384

Thinking tokens share `max_tokens`, and thinking volume varies by model (`claude-sonnet-5` has been observed returning `usage.thinking_tokens: 0`), so the headroom left for *visible* output differed per model on identical requests. Contributing cause of the short answers in #121.

Raised in all three places. keyproxy's `StreamTurnRequest` default moves too, but it's only a floor for callers that omit the field — `KeyProxyChatClient` always sends its own, so future budget changes need no keyproxy redeploy.

## 3. Short answers and silent truncation (#121)

Two halves of the same complaint: a ranked-list request came back short, and there was no way to tell whether the model chose to stop or ran out of room.

**Prompt** — `SYSTEM_PROMPT` said "Be concise; this is a side rail, not a report", which was being read as license to shorten a list the user explicitly asked for. Now:

- Concision is scoped to cutting padding, never content, with an explicit rule to cover every symbol named and to say which are missing and why when it can't.
- Ranking/scoring/comparing symbols is named as in scope and not personal investment advice, so those requests stop drawing disclaimers instead of answers.
- No web access is stated outright, plus a requirement to attribute any declined sub-request to the system prompt **by name** — a restriction disguised as a tool failure sends the user debugging the wrong thing.
- Markdown syntax is banned explicitly: the rail renders text plainly today, so asterisks and backticks show up literally. (Proposed markdown rendering is tracked separately in #135.) Multi-symbol answers get a one-line-per-symbol format instead of a table.
- Components are single-ticker, so multi-ticker questions are answered in prose rather than by rendering one and stopping.

**Truncation** — `stop_reason == "max_tokens"` now logs at WARNING and emits `Done(truncated=True)` instead of an ordinary `Done`. It stops even when the turn carries `tool_use` blocks: a block cut off mid-stream can hold incomplete argument JSON, and echoing that assistant turn back to the provider is itself an `invalid_request_error` risk — a partial answer the user can see beats a turn that dies opaquely one iteration later.

The flag reaches the wire for free (`api/sse.py` `asdict`s the event), `ChatContext` promotes it to message level, and `ChatRail` renders a muted italic caption. Without it a truncated ranked list is indistinguishable from a deliberately short one.

## Also included

Two commits from the previous branch that never got a PR: the backfill-orchestrator test date freeze (weekend flake) and the regenerated `openapi-surface.txt` for the `/api/settings` routes.

## Testing

| Suite | Result |
|---|---|
| `python -m unittest discover -s tests -t .` | 832 passed, 5 skipped |
| `npx vitest run --coverage` | 281 passed / 51 files, thresholds met |

New coverage: 3 backend truncation cases (flag set with partial text preserved; clean turn unmarked; truncated tool turn stops without executing the tool or making a second round trip), 3 vitest cases (caption shown, absent on a clean turn, scoped to the truncated message only), 5 request-shape cases across both provider paths, and the 6 prompt regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
