### PR TITLE
docs: switch QuantUI URLs to project-number Cloud Run format

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,8 +96,8 @@ gated by **Identity-Aware Proxy (IAP)** so the team reaches the real UI from any
 code in the app — see [`docs/proposals/quantui-iap-plan.md`](docs/proposals/quantui-iap-plan.md)
 (status: **COMPLETE, Steps 1–8**). Live URLs:
 
-- **Test:** `https://quantui-uikpdb55ea-uc.a.run.app` (`quantcore-test-20260606`)
-- **Prod:** `https://quantui-swgixldxzq-uc.a.run.app` (`quantcore-prod-20260606`)
+- **Test:** `https://quantui-493357101423.us-central1.run.app` (`quantcore-test-20260606`)
+- **Prod:** `https://quantui-127961694257.us-central1.run.app` (`quantcore-prod-20260606`)
 
 The security detail page's Technical Analysis tab includes the **Support Confluence card**
 (`frontend/src/components/securities/SupportConfluenceCard.tsx`, issue #93 Phase 7), rendering the

--- a/readme.md
+++ b/readme.md
@@ -232,8 +232,8 @@ the app. It runs in both projects:
 
 | Environment | URL | Project | Auto-deploy? |
 |-------------|-----|---------|--------------|
-| **Test** | https://quantui-uikpdb55ea-uc.a.run.app | `quantcore-test-20260606` | **Yes** — every push to `main` |
-| **Prod** | https://quantui-swgixldxzq-uc.a.run.app | `quantcore-prod-20260606` | **No** — manual promotion only |
+| **Test** | https://quantui-493357101423.us-central1.run.app | `quantcore-test-20260606` | **Yes** — every push to `main` |
+| **Prod** | https://quantui-127961694257.us-central1.run.app | `quantcore-prod-20260606` | **No** — manual promotion only |
 
 ### How it's served
 


### PR DESCRIPTION
## Summary
- Updates QuantUI Cloud Run URLs in CLAUDE.md and readme.md from the hash-style format (`quantui-uikpdb55ea-uc.a.run.app`) to the project-number format (`quantui-<project-number>.us-central1.run.app`) for both test and prod.

## Test plan
- Docs-only change; no functional testing required.