### PR TITLE
chore: ignore personal Claude Code state, track shared .claude config

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "quantui-dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["--prefix", "frontend", "run", "dev"],
+      "port": 5173
+    }
+  ]
+}

--- a/.claude/with-test-db.sh
+++ b/.claude/with-test-db.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Runs a command with QUANTCORE_DB_DSN pointed at QUANTCORE_TEST_DB_DSN (127.0.0.1:5434, test).
+# Usage: ./.claude/with-test-db.sh env FOO=1 .venv/bin/python -m unittest some_test
+set -euo pipefail
+cd "$(dirname "$0")/.."
+TEST_DSN=$(grep -E '^QUANTCORE_TEST_DB_DSN=' .env | head -1 | cut -d= -f2-)
+if [ -z "$TEST_DSN" ]; then
+  echo "QUANTCORE_TEST_DB_DSN not found in .env" >&2
+  exit 1
+fi
+export QUANTCORE_DB_DSN="$TEST_DSN"
+exec "$@"

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ diff-cover.md
 frontend/coverage/
 frontend/tsconfig.tsbuildinfo
 frontend/test-results/
+.claude/settings.local.json
+.claude/.cc-writes/


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.local.json` and `.claude/.cc-writes/` to `.gitignore` — these are per-user Claude Code state (personal permission allowlist, internal write-tracking) that shouldn't be shared across contributors.
- Tracks `.claude/with-test-db.sh` (helper to point `QUANTCORE_DB_DSN` at the test DB) and `.claude/launch.json` (shared dev-server launch config) since they're useful project tooling, not personal preferences.

## Test plan
- N/A — tooling/config only.