### PR TITLE
chore: declare numpy as a direct dependency

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -7,6 +7,14 @@
 #
 # The ML extras live in requirements-ml.txt; requirements.txt = base + ml.
 pandas>=1.3.0
+# Declared explicitly even though pandas/matplotlib/yfinance all pull it in:
+# ~15 modules import numpy directly (api/json_response.py, main.py,
+# portfolio/metrics.py, quantcore/services/prices.py, quantcore/analytics/*),
+# so it is a first-order dependency of both the API image and the report job.
+# Relying on it arriving transitively means a pandas release that changes its
+# numpy constraint breaks imports here, and any environment installing this
+# file without the full stack has no numpy at all.
+numpy>=1.24
 yfinance>=0.2.0
 requests>=2.25.0
 matplotlib>=3.10.3


### PR DESCRIPTION
## Problem

`numpy` is imported **directly by ~15 modules** but appears in no requirements file. It has only ever been present transitively, via `pandas` / `matplotlib` / `yfinance` / `contourpy`.

Direct importers include production paths in both container images:

| Module | Ships in |
|---|---|
| `api/json_response.py` | API image |
| `main.py` | report job |
| `portfolio/metrics.py` | report job |
| `quantcore/services/prices.py` | API image |
| `quantcore/analytics/volume_profile.py` | API image |
| `quantcore/services/{fundamentals,options_screening}.py` | API image |
| 5 test modules | CI |

## Why it matters

1. **A pandas release that changes or drops its numpy constraint breaks imports across the codebase**, with no signal from our own manifests — we'd find out at container start, not at resolve time.
2. **Any environment installing `requirements-base.txt` without the full stack resolved gets no numpy at all.** Not hypothetical: the PR review agent on #137 reported it could not run the arbitrage test suites because "this environment lacks the declared `numpy` dependency."

## Change

One line (plus a comment explaining why it's declared despite being transitively available):

```
numpy>=1.24
```

Floor is the oldest release the current code is exercised against. No upper cap, following the file's existing convention for every other entry.

`requirements-ml.txt` and `requirements.txt` inherit it via `-r requirements-base.txt`, so all three images pick it up with no further edits.

## Verification

- Full backend suite passes unchanged: **832 tests, OK (skipped=5)**
- `pip install -r requirements-base.txt` resolves cleanly; installed numpy 2.4.4 satisfies the floor
- No code change — manifest only

Found while addressing the review on #137, but entirely independent of it, so it's split out rather than widening that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)