### PR TITLE
feat(sidekick): arbitrage tools + GenUI card

### DIFF
--- a/frontend/src/api/arbitrage.ts
+++ b/frontend/src/api/arbitrage.ts
@@ -1,0 +1,81 @@
+/**
+ * Arbitrage scanner client — GET /api/arbitrage/*.
+ *
+ * Only the single-pair workup is wired to the UI today; the scan and
+ * discovery endpoints are driven from MCP and the sidekick's own tools.
+ */
+import { apiRequest } from './client';
+
+export interface ArbitrageFactors {
+  opportunity: number | null;
+  evidence: number | null;
+  convergence: number | null;
+  hedge: number | null;
+  carry: number | null;
+  trend: number | null;
+  freshness: number | null;
+}
+
+export interface ArbitrageNav {
+  available: boolean;
+  reason?: string;
+  /** NET of senior claims — the figure a common shareholder actually gets. */
+  premium_discount_pct?: number | null;
+  /** Gap to GROSS assets. Reported only so the difference is visible. */
+  gross_premium_discount_pct?: number | null;
+  carry_drag_pct?: number | null;
+  years_of_burn?: number | null;
+  exposure_ratio?: number | null;
+  nav_per_share?: number | null;
+  holdings_as_of?: string | null;
+  holdings_age_days?: number | null;
+  holdings_stale?: boolean;
+}
+
+export interface ArbitrageHedge {
+  instrument: string | null;
+  available: boolean;
+  futures_only: boolean;
+  note: string;
+}
+
+export interface ArbitrageStatistics {
+  n: number;
+  hedge_ratio: { beta: number | null; beta_stability: number | null; r_squared: number | null };
+  cointegration: { cointegrated: boolean; reject_at: number | null; statistic: number | null };
+  zscore: { z: number | null };
+  half_life: { half_life_days: number | null; mean_reverting: boolean };
+  trend: { widening: boolean | null; slope_tstat: number | null };
+  correlation: number | null;
+}
+
+export interface ArbitragePairResponse {
+  security: string;
+  name?: string;
+  kind: string;
+  underlying: string;
+  as_of?: string | null;
+  price?: number | null;
+  underlying_price?: number | null;
+  statistics: ArbitrageStatistics;
+  nav: ArbitrageNav | null;
+  hedge: ArbitrageHedge;
+  score: number | null;
+  verdict: string;
+  basis: string | null;
+  convergence: string;
+  factors?: ArbitrageFactors;
+  reasons: string[];
+  breaks_on: string[];
+  notes?: string | null;
+  /** Present instead of the analysis when the pair can't be resolved. */
+  error?: string;
+  hint?: string;
+}
+
+export const arbitrageApi = {
+  getPair: (security: string, days = 365) =>
+    apiRequest<ArbitragePairResponse>(
+      `/api/arbitrage/pairs/${encodeURIComponent(security)}?days=${days}`,
+    ),
+};

--- a/frontend/src/chat/componentRegistry.test.ts
+++ b/frontend/src/chat/componentRegistry.test.ts
@@ -10,9 +10,28 @@ import {
 // the frontend re-validates independently of the backend.
 describe('COMPONENT_REGISTRY', () => {
   it('resolves all registered component names', () => {
-    for (const name of ['signals', 'live_price', 'price_chart', 'spread_payoff']) {
+    for (const name of [
+      'signals',
+      'live_price',
+      'price_chart',
+      'spread_payoff',
+      'arbitrage_pair',
+    ]) {
       expect(COMPONENT_REGISTRY[name]?.component, name).toBeTypeOf('function');
     }
+  });
+
+  it('accepts a ticker-only arbitrage_pair directive and rejects extras', () => {
+    // Mirrors test_chat_protocol.py: curated pairs only, so an `underlying`
+    // prop must be rejected on both sides rather than silently ignored.
+    expect(validateDirective({ component: 'arbitrage_pair', props: { ticker: 'MSTR' } }).ok)
+      .toBe(true);
+    expect(
+      validateDirective({
+        component: 'arbitrage_pair',
+        props: { ticker: 'MSTR', underlying: 'BTC-USD' },
+      }).ok,
+    ).toBe(false);
   });
 });
 

--- a/frontend/src/chat/componentRegistry.tsx
+++ b/frontend/src/chat/componentRegistry.tsx
@@ -8,6 +8,7 @@ import SignalsTab from '../components/securities/SignalsTab';
 import LivePrice from '../components/symbols/LivePrice';
 import PriceChartCard from '../components/chat/PriceChartCard';
 import SpreadPayoffCard from '../components/chat/SpreadPayoffCard';
+import ArbitrageCard from '../components/chat/ArbitrageCard';
 import type { ChatDirective } from './types';
 
 type PropKind = 'string' | 'number';
@@ -42,6 +43,8 @@ export const COMPONENT_REGISTRY: Record<string, RegistryEntry> = {
       kind: 'string',
     },
   },
+  // Carries its own "SECURITY vs UNDERLYING" heading, so no titled wrapper.
+  arbitrage_pair: { component: ArbitrageCard, spec: TICKER_ONLY },
 };
 
 /**

--- a/frontend/src/components/chat/ArbitrageCard.test.tsx
+++ b/frontend/src/components/chat/ArbitrageCard.test.tsx
@@ -1,0 +1,176 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+
+import ArbitrageCard from './ArbitrageCard';
+import { mockApi, renderWithProviders } from '../../testUtils';
+
+afterEach(() => vi.unstubAllGlobals());
+
+/** A NAV vehicle in the MSTR shape — the case the card is designed around. */
+function navPair(overrides: object = {}) {
+  return {
+    security: 'MSTR',
+    name: 'Strategy (MicroStrategy)',
+    kind: 'nav_vehicle',
+    underlying: 'BTC-USD',
+    as_of: '2026-07-24',
+    price: 91.67,
+    underlying_price: 64709,
+    statistics: {
+      n: 250,
+      hedge_ratio: { beta: 1.44, beta_stability: 0.1, r_squared: 0.93 },
+      cointegration: { cointegrated: false, reject_at: null, statistic: -2.87 },
+      zscore: { z: -1.35 },
+      half_life: { half_life_days: 66.4, mean_reverting: true },
+      trend: { widening: false, slope_tstat: -1.0 },
+      correlation: 0.73,
+    },
+    nav: {
+      available: true,
+      premium_discount_pct: -16.92,
+      gross_premium_discount_pct: -41.79,
+      carry_drag_pct: 2.21,
+      years_of_burn: 7.6,
+      exposure_ratio: 1.72,
+      holdings_as_of: '2026-07-14',
+      holdings_age_days: 12,
+      holdings_stale: false,
+    },
+    hedge: { instrument: 'IBIT', available: true, futures_only: false, note: 'Hedge with IBIT.' },
+    score: 9.7,
+    verdict: 'reject',
+    basis: 'nav_discount',
+    convergence: 'buyback',
+    factors: {
+      opportunity: 42.3, evidence: 0.35, convergence: 0.7,
+      hedge: 1.0, carry: 0.936, trend: 1.0, freshness: 1.0,
+    },
+    reasons: ['Carry drag of 2.21%/yr erodes the NAV while you wait'],
+    breaks_on: ['Negative carry (senior claims serviced out of NAV)'],
+    ...overrides,
+  };
+}
+
+function mount(payload: object) {
+  mockApi([['/api/arbitrage/pairs/', payload]]);
+  return renderWithProviders(<ArbitrageCard ticker="MSTR" />);
+}
+
+describe('ArbitrageCard', () => {
+  it('shows a loading state before the workup arrives', () => {
+    mount(navPair());
+    expect(screen.getByText(/Analysing MSTR/i)).toBeInTheDocument();
+  });
+
+  it('shows an error alert when the fetch fails', async () => {
+    mockApi([['/api/arbitrage/pairs/', () => ({ __status: 500, error: 'boom' })]]);
+    renderWithProviders(<ArbitrageCard ticker="MSTR" />);
+    await waitFor(() =>
+      expect(screen.getByText(/Couldn't analyse MSTR/i)).toBeInTheDocument(),
+    );
+  });
+
+  it('surfaces an uncurated pair as guidance, not an error', async () => {
+    mount({
+      security: 'ZZZZ',
+      error: 'ZZZZ is not in the curated universe and no underlying was supplied.',
+      hint: 'Pass underlying= to analyse an ad-hoc pair.',
+    });
+    await waitFor(() =>
+      expect(screen.getByText(/not in the curated universe/i)).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/Pass underlying=/)).toBeInTheDocument();
+  });
+
+  describe('NAV vehicle', () => {
+    it('leads with the NET discount', async () => {
+      mount(navPair());
+      await waitFor(() => expect(screen.getByText('-16.92%')).toBeInTheDocument());
+      expect(screen.getByText(/discount to net asset value/i)).toBeInTheDocument();
+    });
+
+    it('shows the gross figure only as a struck-through caveat', async () => {
+      mount(navPair());
+      await waitFor(() => expect(screen.getByText('-16.92%')).toBeInTheDocument());
+
+      const gross = screen.getByText('-41.79%');
+      expect(gross).toBeInTheDocument();
+      // The misleading number must never occupy the headline slot.
+      expect(screen.getByTestId('headline-gap').textContent).toBe('-16.92%');
+      expect(getComputedStyle(gross).textDecoration).toContain('line-through');
+      expect(screen.getByText(/overstates what a shareholder gets/i)).toBeInTheDocument();
+    });
+
+    it('renders the supporting metrics', async () => {
+      mount(navPair());
+      await waitFor(() => expect(screen.getByText('2.21%/yr')).toBeInTheDocument());
+      expect(screen.getByText('1.72×')).toBeInTheDocument();
+      expect(screen.getByText('66.4d')).toBeInTheDocument();
+      expect(screen.getByText('IBIT')).toBeInTheDocument();
+      expect(screen.getByText('no')).toBeInTheDocument(); // not cointegrated
+    });
+
+    it('decomposes the score into its factors', async () => {
+      mount(navPair());
+      await waitFor(() => expect(screen.getByText('Opportunity')).toBeInTheDocument());
+      expect(screen.getByText('42.3')).toBeInTheDocument();
+      expect(screen.getByText('×0.35')).toBeInTheDocument();
+      expect(screen.getByText('×0.7')).toBeInTheDocument();
+      expect(screen.getByText('×0.936')).toBeInTheDocument();
+    });
+
+    it('lists what breaks the trade and the verdict', async () => {
+      mount(navPair());
+      await waitFor(() => expect(screen.getByText('reject')).toBeInTheDocument());
+      expect(screen.getByText(/Negative carry/i)).toBeInTheDocument();
+      expect(screen.getByText('score 9.7')).toBeInTheDocument();
+    });
+
+    it('warns when the curated holdings have gone stale', async () => {
+      mount(navPair({
+        nav: { ...navPair().nav, holdings_stale: true, holdings_age_days: 120 },
+      }));
+      await waitFor(() =>
+        expect(screen.getByText(/Holdings figures are 120 days old/i)).toBeInTheDocument(),
+      );
+    });
+  });
+
+  describe('non-NAV pair', () => {
+    const producer = navPair({
+      security: 'GDX',
+      kind: 'producer',
+      underlying: 'GC=F',
+      convergence: 'none',
+      nav: null,
+      basis: 'spread_zscore',
+      hedge: { instrument: 'GLD', available: true, futures_only: false, note: '' },
+    });
+
+    it('falls back to the spread z-score as the headline', async () => {
+      mount(producer);
+      await waitFor(() =>
+        expect(screen.getByTestId('headline-gap').textContent).toBe('-1.35σ'),
+      );
+      expect(screen.getByText(/spread vs its own history/i)).toBeInTheDocument();
+      expect(screen.queryByText('-16.92%')).toBeNull();
+    });
+
+    it('omits the NAV-only metric values entirely', async () => {
+      mount(producer);
+      await waitFor(() => expect(screen.getByTestId('headline-gap')).toBeInTheDocument());
+      // The metric readouts are gone. ("Carry" survives as a score-factor
+      // label, which is a different row — assert on the values, not the words.)
+      expect(screen.queryByText('2.21%/yr')).toBeNull();
+      expect(screen.queryByText('1.72×')).toBeNull();
+      expect(screen.queryByText('Exposure')).toBeNull();
+    });
+  });
+
+  it('marks an unhedgeable leg rather than naming a futures contract', async () => {
+    mount(navPair({
+      hedge: { instrument: null, available: false, futures_only: true, note: 'no equity hedge' },
+    }));
+    await waitFor(() => expect(screen.getByText('futures only')).toBeInTheDocument());
+  });
+});

--- a/frontend/src/components/chat/ArbitrageCard.tsx
+++ b/frontend/src/components/chat/ArbitrageCard.tsx
@@ -1,0 +1,258 @@
+/**
+ * Structural-spread card for the chat sidekick — self-fetching from a ticker,
+ * mirroring PriceChartCard's composition.
+ *
+ * Displays only what the API returns. Every number here is computed in
+ * quantcore/analytics and quantcore/services/arbitrage.py (arch-v2 Rule 8);
+ * this file formats, it never derives.
+ *
+ * The layout is built around one editorial decision: the NET discount is the
+ * headline and the GROSS figure is shown beneath it, struck through and
+ * labelled. Both numbers come back from the API, and showing the gross one
+ * alone — or larger — would reproduce the exact misreading the scanner exists
+ * to prevent.
+ */
+import {
+  Alert,
+  Box,
+  Chip,
+  CircularProgress,
+  Divider,
+  LinearProgress,
+  Stack,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import { useArbitragePair } from '../../hooks/useArbitrage';
+import type { ArbitrageFactors } from '../../api/arbitrage';
+
+const VERDICT_COLOR: Record<string, 'success' | 'warning' | 'default'> = {
+  candidate: 'success',
+  watch: 'warning',
+  reject: 'default',
+};
+
+/** Multiplicative factors, in the order the score applies them. */
+const FACTOR_LABELS: Array<[keyof ArbitrageFactors, string, string]> = [
+  ['evidence', 'Evidence', 'Cointegration strength and mean-reversion speed'],
+  ['convergence', 'Convergence', 'How strongly something forces the gap closed'],
+  ['hedge', 'Hedge', 'Halved when the only clean hedge is a futures contract'],
+  ['carry', 'Carry', 'Fraction of the gap surviving the wait'],
+  ['trend', 'Trend', 'Reduced when the spread is still widening'],
+  ['freshness', 'Freshness', 'Reduced when curated holdings have gone stale'],
+];
+
+function pct(value: number | null | undefined, digits = 2): string {
+  return value == null ? '—' : `${value.toFixed(digits)}%`;
+}
+
+export default function ArbitrageCard({ ticker }: { ticker: string }) {
+  const { data, isLoading, error } = useArbitragePair(ticker);
+
+  if (isLoading) {
+    return (
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 2 }}>
+        <CircularProgress size={18} />
+        <Typography variant="body2" color="text.secondary">
+          Analysing {ticker} against its underlying…
+        </Typography>
+      </Box>
+    );
+  }
+  if (error) {
+    return <Alert severity="error">Couldn&apos;t analyse {ticker}.</Alert>;
+  }
+  if (!data) return null;
+  if (data.error) {
+    return (
+      <Alert severity="info">
+        {data.error}
+        {data.hint ? ` ${data.hint}` : ''}
+      </Alert>
+    );
+  }
+
+  const nav = data.nav;
+  const navAvailable = Boolean(nav?.available);
+  const factors = data.factors;
+
+  return (
+    <Box data-testid="arbitrage-card">
+      <Stack direction="row" alignItems="center" spacing={1} sx={{ mb: 1 }}>
+        <Typography variant="subtitle2">
+          {data.security} vs {data.underlying}
+        </Typography>
+        <Chip size="small" label={data.kind.replace('_', ' ')} variant="outlined" />
+        <Chip
+          size="small"
+          label={data.verdict}
+          color={VERDICT_COLOR[data.verdict] ?? 'default'}
+        />
+        {data.score != null && (
+          <Typography variant="body2" color="text.secondary">
+            score {data.score}
+          </Typography>
+        )}
+      </Stack>
+
+      {/* Headline gap */}
+      {navAvailable ? (
+        <Box sx={{ mb: 1.5 }}>
+          <Typography variant="h5" component="div" data-testid="headline-gap">
+            {pct(nav?.premium_discount_pct)}
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            discount to net asset value — after debt and preferred ranking ahead
+            of the common
+          </Typography>
+          {nav?.gross_premium_discount_pct != null && (
+            <Typography variant="caption" display="block" sx={{ color: 'text.disabled' }}>
+              headline gap to gross assets{' '}
+              <Box component="span" sx={{ textDecoration: 'line-through' }}>
+                {pct(nav.gross_premium_discount_pct)}
+              </Box>{' '}
+              — overstates what a shareholder gets
+            </Typography>
+          )}
+        </Box>
+      ) : (
+        <Box sx={{ mb: 1.5 }}>
+          <Typography variant="h5" component="div" data-testid="headline-gap">
+            {data.statistics.zscore.z == null
+              ? '—'
+              : `${data.statistics.zscore.z.toFixed(2)}σ`}
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            spread vs its own history
+            {nav?.reason ? ' — no curated holdings, so no NAV math' : ''}
+          </Typography>
+        </Box>
+      )}
+
+      {/* Supporting numbers */}
+      <Stack direction="row" spacing={2} flexWrap="wrap" useFlexGap sx={{ mb: 1.5 }}>
+        {navAvailable && nav?.carry_drag_pct != null && (
+          <Metric label="Carry" value={`${nav.carry_drag_pct.toFixed(2)}%/yr`} />
+        )}
+        {navAvailable && nav?.exposure_ratio != null && (
+          <Metric label="Exposure" value={`${nav.exposure_ratio.toFixed(2)}×`} />
+        )}
+        <Metric
+          label="Half-life"
+          value={
+            data.statistics.half_life.half_life_days == null
+              ? 'none'
+              : `${data.statistics.half_life.half_life_days.toFixed(1)}d`
+          }
+        />
+        <Metric
+          label="Cointegrated"
+          value={data.statistics.cointegration.cointegrated ? 'yes' : 'no'}
+        />
+        <Metric
+          label="Hedge"
+          value={data.hedge.available ? (data.hedge.instrument ?? '—') : 'futures only'}
+        />
+      </Stack>
+
+      {/* Score decomposition */}
+      {factors && (
+        <>
+          <Divider sx={{ my: 1 }} />
+          <Typography variant="caption" color="text.secondary">
+            Score factors (multiplied)
+          </Typography>
+          <Stack spacing={0.5} sx={{ mt: 0.5 }}>
+            {factors.opportunity != null && (
+              <FactorRow
+                label="Opportunity"
+                hint="Gap size, scaled 0–100"
+                value={factors.opportunity}
+                display={factors.opportunity.toFixed(1)}
+                max={100}
+              />
+            )}
+            {FACTOR_LABELS.map(([key, label, hint]) => {
+              const value = factors[key];
+              if (value == null) return null;
+              return (
+                <FactorRow
+                  key={key}
+                  label={label}
+                  hint={hint}
+                  value={value}
+                  display={`×${value}`}
+                  max={1}
+                />
+              );
+            })}
+          </Stack>
+        </>
+      )}
+
+      {/* What breaks it */}
+      {data.breaks_on.length > 0 && (
+        <>
+          <Divider sx={{ my: 1 }} />
+          <Typography variant="caption" color="text.secondary">
+            What breaks it
+          </Typography>
+          <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap sx={{ mt: 0.5 }}>
+            {data.breaks_on.map((risk) => (
+              <Chip key={risk} size="small" label={risk} color="warning" variant="outlined" />
+            ))}
+          </Stack>
+        </>
+      )}
+
+      {nav?.holdings_stale && (
+        <Alert severity="warning" sx={{ mt: 1, py: 0 }}>
+          Holdings figures are {nav.holdings_age_days} days old.
+        </Alert>
+      )}
+    </Box>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <Box>
+      <Typography variant="caption" color="text.secondary" display="block">
+        {label}
+      </Typography>
+      <Typography variant="body2">{value}</Typography>
+    </Box>
+  );
+}
+
+function FactorRow({
+  label,
+  hint,
+  value,
+  display,
+  max,
+}: {
+  label: string;
+  hint: string;
+  value: number;
+  display: string;
+  max: number;
+}) {
+  return (
+    <Tooltip title={hint} placement="left">
+      <Stack direction="row" alignItems="center" spacing={1}>
+        <Typography variant="caption" sx={{ minWidth: 88 }}>
+          {label}
+        </Typography>
+        <LinearProgress
+          variant="determinate"
+          value={Math.min(100, (value / max) * 100)}
+          sx={{ flex: 1, height: 6, borderRadius: 3 }}
+        />
+        <Typography variant="caption" sx={{ minWidth: 44, textAlign: 'right' }}>
+          {display}
+        </Typography>
+      </Stack>
+    </Tooltip>
+  );
+}

--- a/frontend/src/hooks/useArbitrage.ts
+++ b/frontend/src/hooks/useArbitrage.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+import { arbitrageApi } from '../api/arbitrage';
+
+export function useArbitragePair(security: string, days = 365) {
+  return useQuery({
+    queryKey: ['arbitrage-pair', security, days],
+    queryFn: () => arbitrageApi.getPair(security, days),
+    enabled: !!security,
+    // The workup pulls two price histories and (for NAV vehicles) a share
+    // count; nothing in it moves intraday enough to justify a tighter window.
+    staleTime: 10 * 60 * 1000,
+  });
+}

--- a/quantcore/services/arbitrage.py
+++ b/quantcore/services/arbitrage.py
@@ -223,6 +223,55 @@ class ArbitrageService:
             "errors": errors,
         }
 
+    def scan_summary(self, kinds: Optional[list[str]] = None, top_n: int = 10,
+                     days: int = 365) -> dict:
+        """``scan`` trimmed to one row per candidate, for the chat sidekick.
+
+        A full scan returns ten candidates each carrying complete spread
+        statistics, a NAV block, factors, reasons and breaks_on — far more than
+        an LLM needs to rank them, and enough to crowd a conversation's context
+        window. This keeps the fields that carry the judgement (score, verdict,
+        the *net* discount, convergence, hedgeability, what breaks it) and drops
+        the rest; the model calls ``analyze_pair`` for the full workup on
+        anything worth a closer look.
+
+        ``discount_pct`` is deliberately the NET figure. The gross number is
+        omitted here entirely rather than trimmed to it — a summary row is
+        exactly where a misread would happen.
+        """
+        full = self.scan(kinds=kinds, top_n=top_n, days=days)
+        rows = []
+        for c in full["candidates"]:
+            nav = c.get("nav") or {}
+            stats = c.get("statistics") or {}
+            rows.append({
+                "security": c["security"],
+                "name": c.get("name"),
+                "kind": c["kind"],
+                "underlying": c["underlying"],
+                "score": c.get("score"),
+                "verdict": c.get("verdict"),
+                "basis": c.get("basis"),
+                "discount_pct": nav.get("premium_discount_pct") if nav.get("available") else None,
+                "spread_zscore": (stats.get("zscore") or {}).get("z"),
+                "half_life_days": (stats.get("half_life") or {}).get("half_life_days"),
+                "cointegrated": (stats.get("cointegration") or {}).get("cointegrated"),
+                "convergence": c.get("convergence"),
+                "hedge_instrument": (c.get("hedge") or {}).get("instrument"),
+                "hedge_available": (c.get("hedge") or {}).get("available"),
+                "breaks_on": c.get("breaks_on", []),
+            })
+        return {
+            "scanned": full["scanned"],
+            "returned": len(rows),
+            "candidates": rows,
+            "errors": full["errors"],
+            "note": (
+                "Summary rows. discount_pct is NET of senior claims. Call "
+                "analyze_arbitrage_pair for the full workup on any row."
+            ),
+        }
+
     # ------------------------------------------------------------------ #
     # Statistical discovery
     # ------------------------------------------------------------------ #

--- a/quantcore/services/chat.py
+++ b/quantcore/services/chat.py
@@ -358,11 +358,12 @@ class ChatService:
                 # Summary rows, not the full scan — ten candidates with complete
                 # statistics each would crowd the conversation's context window.
                 "scan_arbitrage": (
-                    lambda kinds=None, top_n=10:
+                    lambda kinds=None, top_n=10, days=365:
                     self._arbitrage.scan_summary(
                         kinds=[k.strip() for k in (kinds or "").split(",") if k.strip()]
                         or None,
                         top_n=top_n,
+                        days=days,
                     )
                 ),
                 "list_arbitrage_universe": lambda: self._arbitrage.get_universe(),

--- a/quantcore/services/chat.py
+++ b/quantcore/services/chat.py
@@ -73,6 +73,15 @@ the selected element directly; never echo the raw JSON back.
 Numbers you state in prose must come from tool results in this conversation,
 never from memory.
 
+On arbitrage results: quote the NET discount
+(nav.premium_discount_pct), never nav.gross_premium_discount_pct — the gross
+figure ignores debt and preferred stock ranking ahead of the common and
+routinely overstates the gap by 20+ points. If you cite both, label which one
+a shareholder actually gets. A "reject" verdict is a finding worth reporting
+plainly, not a failed lookup: say what the gap is and what stops it closing
+(no forcing mechanism, negative carry, an unhedgeable leg), rather than
+implying the tool found nothing.
+
 The tools above are your only source of market data. You have no web access:
 never attempt a web search, never fetch a URL, and never pull prices, news,
 filings, earnings figures, or any other market data from outside those tool
@@ -288,6 +297,7 @@ class ChatService:
         fundamentals,
         sentiment,
         options,
+        arbitrage=None,
         model: str = "claude-sonnet-5",
         effort: str = "medium",
         max_iterations: int = 8,
@@ -299,6 +309,7 @@ class ChatService:
         self._fundamentals = fundamentals
         self._sentiment = sentiment
         self._options = options
+        self._arbitrage = arbitrage
         self._model = model
         self._effort = effort
         self._max_iterations = max_iterations
@@ -333,6 +344,29 @@ class ChatService:
                 )
             ),
         }
+        # Registered only when the service is wired. Absent, the loop's
+        # unknown-tool path returns a recoverable is_error to the model rather
+        # than raising AttributeError on a None service mid-stream.
+        if arbitrage is not None:
+            self._handlers.update({
+                "analyze_arbitrage_pair": (
+                    lambda security, underlying=None, days=365:
+                    self._arbitrage.analyze_pair(
+                        security, underlying=underlying, days=days
+                    )
+                ),
+                # Summary rows, not the full scan — ten candidates with complete
+                # statistics each would crowd the conversation's context window.
+                "scan_arbitrage": (
+                    lambda kinds=None, top_n=10:
+                    self._arbitrage.scan_summary(
+                        kinds=[k.strip() for k in (kinds or "").split(",") if k.strip()]
+                        or None,
+                        top_n=top_n,
+                    )
+                ),
+                "list_arbitrage_universe": lambda: self._arbitrage.get_universe(),
+            })
 
     def _resolve_model(self, context: TurnContext) -> str:
         """Requested model wins if allow-listed; else fall back to the

--- a/quantcore/services/chat_tools.py
+++ b/quantcore/services/chat_tools.py
@@ -25,6 +25,11 @@ BACKEND_COMPONENT_REGISTRY: dict[str, dict[str, object]] = {
         "short_strike": _NUMBER,
         "kind": str,
     },
+    # Curated pairs only: the card resolves the underlying from
+    # arb_universe.yaml. Ad-hoc pairs (analyze_arbitrage_pair with an explicit
+    # `underlying`) have no card — every prop here is required, so there is no
+    # way to make `underlying` optional without weakening the validator.
+    "arbitrage_pair": {"ticker": str},
 }
 
 
@@ -234,6 +239,88 @@ TOOL_SCHEMAS: list[dict] = [
         },
     },
     {
+        "name": "analyze_arbitrage_pair",
+        "description": (
+            "Analyse a security against the underlying it is structurally linked "
+            "to (a treasury company vs its coin stack, a fund vs its reference "
+            "future, a miner vs the metal it sells). Returns the gap, whether the "
+            "spread mean-reverts, whether anything forces it to close, and a "
+            "0-100 score with the factors that produced it.\n\n"
+            "CRITICAL — read 'nav.premium_discount_pct', the NET discount. The "
+            "response also carries 'nav.gross_premium_discount_pct', which "
+            "ignores convertible notes and preferred stock sitting senior to the "
+            "common and routinely overstates the gap by 20+ points. Quoting the "
+            "gross figure as the opportunity is the specific error this tool "
+            "exists to prevent. If you mention both, say plainly which is real.\n\n"
+            "Scoring is inverted by design: spread width only qualifies a "
+            "candidate, the convergence mechanism ranks it. Expect 'reject' — a "
+            "wide gap with no forcing mechanism, negative carry and a widening "
+            "trend is a directional bet, not an arbitrage. Report a rejection as "
+            "the finding, not as a failure. After analysing, render it with "
+            "show_component('arbitrage_pair', {'ticker': SYMBOL})."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "security": {
+                    "type": "string",
+                    "description": "Ticker of the listed vehicle/company, e.g. 'MSTR'",
+                },
+                "underlying": {
+                    "type": "string",
+                    "description": (
+                        "Optional: underlying symbol for an ad-hoc pair not in the "
+                        "curated universe, e.g. 'BTC-USD'. Omit for curated pairs."
+                    ),
+                },
+                "days": {
+                    "type": "integer",
+                    "description": "Days of daily history, 30-3650 (default 365)",
+                },
+            },
+            "required": ["security"],
+        },
+    },
+    {
+        "name": "scan_arbitrage",
+        "description": (
+            "Rank the curated arbitrage universe, one summary row per candidate: "
+            "score, verdict, NET discount, convergence mechanism, whether the "
+            "hedge is executable from an equity account, and what breaks the "
+            "trade. Use for 'any arbitrage opportunities?' style questions, then "
+            "call analyze_arbitrage_pair for detail on anything interesting.\n\n"
+            "Most scans return nothing above 'watch'. That is the scanner "
+            "working, not an error — say so rather than implying the data failed."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "kinds": {
+                    "type": "string",
+                    "description": (
+                        "Optional comma-separated families to include: "
+                        "nav_vehicle, commodity_etf, producer. Omit for all three."
+                    ),
+                },
+                "top_n": {
+                    "type": "integer",
+                    "description": "Max candidates to return, 1-100 (default 10)",
+                },
+            },
+            "required": [],
+        },
+    },
+    {
+        "name": "list_arbitrage_universe",
+        "description": (
+            "List the curated security-to-underlying pairs the scanner tracks, "
+            "with each one's family, hedge instrument, convergence mechanism, and "
+            "whether its hand-maintained holdings figures have gone stale. Use "
+            "when the user asks what the scanner covers or why a symbol is absent."
+        ),
+        "input_schema": {"type": "object", "properties": {}, "required": []},
+    },
+    {
         "name": "show_component",
         "description": (
             "Render a live, data-bound UI component inline in the conversation. "
@@ -243,7 +330,11 @@ TOOL_SCHEMAS: list[dict] = [
             "'price_chart' shows the price history chart with moving averages, "
             "'spread_payoff' shows an interactive risk graph for a vertical "
             "spread (requires ticker, expiration, long_strike, short_strike, "
-            "kind — the same parameters you passed to price_vertical_spread)."
+            "kind — the same parameters you passed to price_vertical_spread), "
+            "'arbitrage_pair' shows the structural-spread card for a curated "
+            "pair: net discount, the score's factor breakdown, and what breaks "
+            "the trade (requires ticker; curated securities only — check "
+            "list_arbitrage_universe if unsure)."
         ),
         "input_schema": {
             "type": "object",

--- a/quantcore/services/chat_tools.py
+++ b/quantcore/services/chat_tools.py
@@ -275,7 +275,9 @@ TOOL_SCHEMAS: list[dict] = [
                 },
                 "days": {
                     "type": "integer",
-                    "description": "Days of daily history, 30-3650 (default 365)",
+                    "minimum": 30,
+                    "maximum": 3650,
+                    "description": "Days of daily history (default 365)",
                 },
             },
             "required": ["security"],
@@ -304,7 +306,15 @@ TOOL_SCHEMAS: list[dict] = [
                 },
                 "top_n": {
                     "type": "integer",
-                    "description": "Max candidates to return, 1-100 (default 10)",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "description": "Max candidates to return (default 10)",
+                },
+                "days": {
+                    "type": "integer",
+                    "minimum": 30,
+                    "maximum": 3650,
+                    "description": "Days of daily history per pair (default 365)",
                 },
             },
             "required": [],

--- a/quantcore/services/registry.py
+++ b/quantcore/services/registry.py
@@ -172,11 +172,19 @@ def get_services() -> Services:
         def chat_client_factory(context: TurnContext):
             raise ChatKeyRequired(CHAT_NOT_CONFIGURED_MESSAGE)
 
+    # Hoisted so ChatService can compose it — the sidekick's arbitrage tools
+    # dispatch into this same instance the REST tier uses.
+    arbitrage = ArbitrageService(
+        arbitrage_repository=arbitrage_repository,
+        prices=prices,
+        yfinance_gateway=yfinance_gateway,
+    )
     chat = ChatService(
         prices=prices,
         fundamentals=fundamentals,
         sentiment=sentiment,
         options=options,
+        arbitrage=arbitrage,
         model=chat_model,
         effort=chat_effort,
         max_iterations=int(os.environ.get("CHAT_MAX_TOOL_ITERATIONS", "8")),
@@ -229,11 +237,7 @@ def get_services() -> Services:
             ohlcv_repository=ohlcv_repository,
             yfinance_gateway=yfinance_gateway,
         ),
-        arbitrage=ArbitrageService(
-            arbitrage_repository=arbitrage_repository,
-            prices=prices,
-            yfinance_gateway=yfinance_gateway,
-        ),
+        arbitrage=arbitrage,
         chat=chat,
         keyproxy=keyproxy,
         settings=settings,

--- a/tests/test_arbitrage_service.py
+++ b/tests/test_arbitrage_service.py
@@ -295,6 +295,70 @@ class ErrorHandlingTest(unittest.TestCase):
         self.assertEqual(result["score"], 0.0)
 
 
+class ScanSummaryTest(unittest.TestCase):
+    """The compact projection the chat sidekick consumes."""
+
+    def setUp(self):
+        n = 400
+        rng = np.random.default_rng(9)
+        btc = 64_709 * np.exp(np.cumsum(rng.normal(0, 0.005, n)))
+        btc[-1] = 64_709
+        mstr = 96.99 * np.exp(np.cumsum(rng.normal(0, 0.01, n)))
+        mstr[-1] = 96.99
+        y, x = cointegrated_pair()
+        self.frames = {
+            "MSTR": price_frame(mstr), "BTC-USD": price_frame(btc),
+            "AAA": price_frame(y), "ZZZ": price_frame(x),
+        }
+        self.entries = [
+            entry(security="MSTR", kind="nav_vehicle", underlying="BTC-USD",
+                  hedge="IBIT", mechanism="buyback", holdings_units=843_775,
+                  holdings_as_of="2026-07-14", senior_claims_usd=16_500_000_000,
+                  annual_senior_cost_usd=854_000_000, diluted_shares=350_000_000),
+            entry(security="AAA"),
+        ]
+
+    def test_rows_carry_the_judgement_fields(self):
+        summary = build(self.entries, self.frames).scan_summary()
+        row = next(r for r in summary["candidates"] if r["security"] == "MSTR")
+        for field in ("score", "verdict", "discount_pct", "convergence",
+                      "hedge_available", "breaks_on", "cointegrated"):
+            self.assertIn(field, row)
+        self.assertEqual(summary["returned"], len(summary["candidates"]))
+
+    def test_discount_is_the_net_figure_and_gross_is_absent(self):
+        """A summary row is exactly where a gross/net misread would happen, so
+        the gross number is dropped rather than trimmed alongside it."""
+        summary = build(self.entries, self.frames).scan_summary()
+        row = next(r for r in summary["candidates"] if r["security"] == "MSTR")
+        self.assertAlmostEqual(row["discount_pct"], -10.9, delta=0.5)
+        self.assertNotIn("gross_premium_discount_pct", row)
+        self.assertNotIn("nav", row)
+
+    def test_heavy_blocks_are_dropped(self):
+        summary = build(self.entries, self.frames).scan_summary()
+        row = summary["candidates"][0]
+        for heavy in ("statistics", "factors", "reasons", "hedge"):
+            self.assertNotIn(heavy, row)
+
+    def test_non_nav_rows_report_no_discount(self):
+        summary = build(self.entries, self.frames).scan_summary()
+        row = next(r for r in summary["candidates"] if r["security"] == "AAA")
+        self.assertIsNone(row["discount_pct"])
+        self.assertIsNotNone(row["spread_zscore"])
+
+    def test_errors_and_ordering_survive_the_projection(self):
+        entries = self.entries + [entry(security="BOOM")]
+        summary = build(entries, self.frames, broken={"BOOM"}).scan_summary()
+        scores = [r["score"] or 0 for r in summary["candidates"]]
+        self.assertEqual(scores, sorted(scores, reverse=True))
+        self.assertEqual([e["security"] for e in summary["errors"]], ["BOOM"])
+
+    def test_note_tells_the_reader_the_discount_is_net(self):
+        summary = build(self.entries, self.frames).scan_summary()
+        self.assertIn("NET", summary["note"])
+
+
 class UniverseTest(unittest.TestCase):
     def test_flags_stale_holdings_and_hedge_availability(self):
         entries = [

--- a/tests/test_chat_protocol.py
+++ b/tests/test_chat_protocol.py
@@ -109,9 +109,18 @@ class TestEventStream(unittest.TestCase):
 
 class TestValidateDirective(unittest.TestCase):
     def test_valid_components_accept_ticker(self):
-        for component in ("signals", "live_price", "price_chart"):
+        for component in ("signals", "live_price", "price_chart", "arbitrage_pair"):
             ok, reason = validate_directive(component, {"ticker": "INTC"})
             self.assertTrue(ok, f"{component} should accept ticker prop: {reason}")
+
+    def test_arbitrage_pair_rejects_an_underlying_prop(self):
+        """Curated pairs only — the card resolves the underlying itself. Every
+        registered prop is required, so an optional one cannot be expressed."""
+        ok, reason = validate_directive(
+            "arbitrage_pair", {"ticker": "MSTR", "underlying": "BTC-USD"}
+        )
+        self.assertFalse(ok)
+        self.assertIn("underlying", reason)
 
     def test_unknown_component_rejected_with_reason(self):
         ok, reason = validate_directive("nuclear_launch", {"ticker": "INTC"})
@@ -306,6 +315,9 @@ class TestToolSchemas(unittest.TestCase):
         "get_fundamental_score",
         "get_news_sentiment",
         "price_vertical_spread",
+        "analyze_arbitrage_pair",
+        "scan_arbitrage",
+        "list_arbitrage_universe",
         "show_component",
     }
 
@@ -322,6 +334,29 @@ class TestToolSchemas(unittest.TestCase):
         show = next(t for t in TOOL_SCHEMAS if t["name"] == "show_component")
         enum = show["input_schema"]["properties"]["component"]["enum"]
         self.assertEqual(set(enum), set(BACKEND_COMPONENT_REGISTRY))
+
+    def test_arbitrage_tool_steers_the_model_to_the_net_discount(self):
+        """Safety contract, not prose polish.
+
+        analyze_arbitrage_pair returns both premium_discount_pct (net of senior
+        claims) and gross_premium_discount_pct, which routinely overstates the
+        gap by 20+ points. A model that quotes the gross figure reproduces the
+        exact error the scanner exists to prevent, so the description must name
+        the right field and warn about the wrong one. If this fails, someone
+        trimmed the warning — restore it rather than deleting the test.
+        """
+        tool = next(t for t in TOOL_SCHEMAS if t["name"] == "analyze_arbitrage_pair")
+        description = tool["description"]
+        self.assertIn("premium_discount_pct", description)
+        self.assertIn("gross_premium_discount_pct", description)
+        self.assertIn("senior", description.lower())
+
+    def test_scan_tool_frames_an_empty_result_as_a_finding(self):
+        """Most scans return nothing above 'watch'; the model must report that
+        as the answer rather than implying a data failure."""
+        tool = next(t for t in TOOL_SCHEMAS if t["name"] == "scan_arbitrage")
+        self.assertIn("watch", tool["description"])
+        self.assertIn("not an error", tool["description"])
 
 
 if __name__ == "__main__":

--- a/tests/test_chat_service.py
+++ b/tests/test_chat_service.py
@@ -935,7 +935,7 @@ class TestModelResolution(ChatServiceTestBase):
 class TestArbitrageTools(ChatServiceTestBase):
     """The sidekick's arbitrage tools dispatch into ArbitrageService."""
 
-    def tool_turn(self, name, args, result, **service_kwargs):
+    def tool_turn(self, name, args, **service_kwargs):
         """One tool_use turn followed by a text turn; returns the events."""
         client = ScriptedClient(
             [
@@ -949,7 +949,7 @@ class TestArbitrageTools(ChatServiceTestBase):
 
     def test_analyze_pair_dispatch_with_defaults(self):
         self.arbitrage.analyze_pair.return_value = {"security": "MSTR", "score": 9.7}
-        self.tool_turn("analyze_arbitrage_pair", {"security": "MSTR"}, None)
+        self.tool_turn("analyze_arbitrage_pair", {"security": "MSTR"})
         self.arbitrage.analyze_pair.assert_called_once_with(
             "MSTR", underlying=None, days=365
         )
@@ -959,7 +959,6 @@ class TestArbitrageTools(ChatServiceTestBase):
         self.tool_turn(
             "analyze_arbitrage_pair",
             {"security": "RIOT", "underlying": "BTC-USD", "days": 180},
-            None,
         )
         self.arbitrage.analyze_pair.assert_called_once_with(
             "RIOT", underlying="BTC-USD", days=180
@@ -968,28 +967,35 @@ class TestArbitrageTools(ChatServiceTestBase):
     def test_scan_uses_the_compact_projection_not_the_full_scan(self):
         """A full scan's payload would crowd the context window."""
         self.arbitrage.scan_summary.return_value = {"candidates": []}
-        self.tool_turn("scan_arbitrage", {}, None)
-        self.arbitrage.scan_summary.assert_called_once_with(kinds=None, top_n=10)
+        self.tool_turn("scan_arbitrage", {})
+        self.arbitrage.scan_summary.assert_called_once_with(
+            kinds=None, top_n=10, days=365
+        )
         self.arbitrage.scan.assert_not_called()
+
+    def test_scan_forwards_a_custom_history_window(self):
+        """'Scan over two years' must not silently run with the 365-day
+        default (Hermes review on #143)."""
+        self.arbitrage.scan_summary.return_value = {"candidates": []}
+        self.tool_turn("scan_arbitrage", {"days": 730})
+        self.assertEqual(self.arbitrage.scan_summary.call_args.kwargs["days"], 730)
 
     def test_scan_splits_the_kinds_string(self):
         self.arbitrage.scan_summary.return_value = {"candidates": []}
-        self.tool_turn(
-            "scan_arbitrage", {"kinds": "nav_vehicle, producer", "top_n": 3}, None
-        )
+        self.tool_turn("scan_arbitrage", {"kinds": "nav_vehicle, producer", "top_n": 3})
         self.arbitrage.scan_summary.assert_called_once_with(
-            kinds=["nav_vehicle", "producer"], top_n=3
+            kinds=["nav_vehicle", "producer"], top_n=3, days=365
         )
 
     def test_blank_kinds_becomes_none_not_an_empty_list(self):
         """An empty list would filter every family out — the opposite of 'all'."""
         self.arbitrage.scan_summary.return_value = {"candidates": []}
-        self.tool_turn("scan_arbitrage", {"kinds": " , "}, None)
+        self.tool_turn("scan_arbitrage", {"kinds": " , "})
         self.assertIsNone(self.arbitrage.scan_summary.call_args.kwargs["kinds"])
 
     def test_universe_dispatch(self):
         self.arbitrage.get_universe.return_value = {"count": 10, "entries": []}
-        self.tool_turn("list_arbitrage_universe", {}, None)
+        self.tool_turn("list_arbitrage_universe", {})
         self.arbitrage.get_universe.assert_called_once_with()
 
     def test_tool_result_reaches_the_model(self):
@@ -997,7 +1003,7 @@ class TestArbitrageTools(ChatServiceTestBase):
             "security": "MSTR",
             "nav": {"premium_discount_pct": -16.92},
         }
-        _, client = self.tool_turn("analyze_arbitrage_pair", {"security": "MSTR"}, None)
+        _, client = self.tool_turn("analyze_arbitrage_pair", {"security": "MSTR"})
         result_block = client.calls[1]["messages"][-1]["content"][0]
         self.assertEqual(result_block["type"], "tool_result")
         self.assertIn("-16.92", result_block["content"])
@@ -1006,7 +1012,7 @@ class TestArbitrageTools(ChatServiceTestBase):
         """A ChatService built without arbitrage must not raise AttributeError
         mid-stream; the loop's unknown-tool path lets the model recover."""
         events, client = self.tool_turn(
-            "analyze_arbitrage_pair", {"security": "MSTR"}, None, arbitrage=None
+            "analyze_arbitrage_pair", {"security": "MSTR"}, arbitrage=None
         )
         statuses = [e for e in events if isinstance(e, ToolStatus)]
         self.assertEqual([s.state for s in statuses], ["running", "error"])

--- a/tests/test_chat_service.py
+++ b/tests/test_chat_service.py
@@ -63,19 +63,24 @@ class ScriptedClient:
         yield ("final", turn["final"])
 
 
+_UNSET = object()
+
+
 class ChatServiceTestBase(unittest.TestCase):
     def setUp(self):
         self.prices = Mock()
         self.fundamentals = Mock()
         self.sentiment = Mock()
         self.options = Mock()
+        self.arbitrage = Mock()
 
-    def make_service(self, client, max_iterations=8):
+    def make_service(self, client, max_iterations=8, arbitrage=_UNSET):
         return ChatService(
             prices=self.prices,
             fundamentals=self.fundamentals,
             sentiment=self.sentiment,
             options=self.options,
+            arbitrage=self.arbitrage if arbitrage is _UNSET else arbitrage,
             max_iterations=max_iterations,
             client_factory=lambda context: client,
         )
@@ -925,6 +930,89 @@ class TestModelResolution(ChatServiceTestBase):
             service.stream_chat([{"role": "user", "content": "hi"}], context=context)
         )
         self.assertEqual(seen[0], context)
+
+
+class TestArbitrageTools(ChatServiceTestBase):
+    """The sidekick's arbitrage tools dispatch into ArbitrageService."""
+
+    def tool_turn(self, name, args, result, **service_kwargs):
+        """One tool_use turn followed by a text turn; returns the events."""
+        client = ScriptedClient(
+            [
+                {"final": final("tool_use", tool_use("tu_1", name, args))},
+                {"final": final("end_turn", text_block("done"))},
+            ]
+        )
+        service = self.make_service(client, **service_kwargs)
+        events = list(service.stream_chat([{"role": "user", "content": "hi"}]))
+        return events, client
+
+    def test_analyze_pair_dispatch_with_defaults(self):
+        self.arbitrage.analyze_pair.return_value = {"security": "MSTR", "score": 9.7}
+        self.tool_turn("analyze_arbitrage_pair", {"security": "MSTR"}, None)
+        self.arbitrage.analyze_pair.assert_called_once_with(
+            "MSTR", underlying=None, days=365
+        )
+
+    def test_analyze_pair_forwards_ad_hoc_underlying_and_window(self):
+        self.arbitrage.analyze_pair.return_value = {"security": "RIOT"}
+        self.tool_turn(
+            "analyze_arbitrage_pair",
+            {"security": "RIOT", "underlying": "BTC-USD", "days": 180},
+            None,
+        )
+        self.arbitrage.analyze_pair.assert_called_once_with(
+            "RIOT", underlying="BTC-USD", days=180
+        )
+
+    def test_scan_uses_the_compact_projection_not_the_full_scan(self):
+        """A full scan's payload would crowd the context window."""
+        self.arbitrage.scan_summary.return_value = {"candidates": []}
+        self.tool_turn("scan_arbitrage", {}, None)
+        self.arbitrage.scan_summary.assert_called_once_with(kinds=None, top_n=10)
+        self.arbitrage.scan.assert_not_called()
+
+    def test_scan_splits_the_kinds_string(self):
+        self.arbitrage.scan_summary.return_value = {"candidates": []}
+        self.tool_turn(
+            "scan_arbitrage", {"kinds": "nav_vehicle, producer", "top_n": 3}, None
+        )
+        self.arbitrage.scan_summary.assert_called_once_with(
+            kinds=["nav_vehicle", "producer"], top_n=3
+        )
+
+    def test_blank_kinds_becomes_none_not_an_empty_list(self):
+        """An empty list would filter every family out — the opposite of 'all'."""
+        self.arbitrage.scan_summary.return_value = {"candidates": []}
+        self.tool_turn("scan_arbitrage", {"kinds": " , "}, None)
+        self.assertIsNone(self.arbitrage.scan_summary.call_args.kwargs["kinds"])
+
+    def test_universe_dispatch(self):
+        self.arbitrage.get_universe.return_value = {"count": 10, "entries": []}
+        self.tool_turn("list_arbitrage_universe", {}, None)
+        self.arbitrage.get_universe.assert_called_once_with()
+
+    def test_tool_result_reaches_the_model(self):
+        self.arbitrage.analyze_pair.return_value = {
+            "security": "MSTR",
+            "nav": {"premium_discount_pct": -16.92},
+        }
+        _, client = self.tool_turn("analyze_arbitrage_pair", {"security": "MSTR"}, None)
+        result_block = client.calls[1]["messages"][-1]["content"][0]
+        self.assertEqual(result_block["type"], "tool_result")
+        self.assertIn("-16.92", result_block["content"])
+
+    def test_without_the_service_the_tools_degrade_to_a_recoverable_error(self):
+        """A ChatService built without arbitrage must not raise AttributeError
+        mid-stream; the loop's unknown-tool path lets the model recover."""
+        events, client = self.tool_turn(
+            "analyze_arbitrage_pair", {"security": "MSTR"}, None, arbitrage=None
+        )
+        statuses = [e for e in events if isinstance(e, ToolStatus)]
+        self.assertEqual([s.state for s in statuses], ["running", "error"])
+        result_block = client.calls[1]["messages"][-1]["content"][0]
+        self.assertTrue(result_block["is_error"])
+        self.assertIn("Unknown tool", result_block["content"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The scanner shipped MCP-first, so the sidekick had **no access to it at all** — `ChatService` is constructed with `prices`/`fundamentals`/`sentiment`/`options` and nothing else. This adds three tools and a card.

| Tool | Purpose |
|---|---|
| `analyze_arbitrage_pair` | Full workup; `underlying` escape hatch for ad-hoc pairs |
| `scan_arbitrage` | Ranked summary rows |
| `list_arbitrage_universe` | What's curated, with staleness flags |

Plus `arbitrage_pair`, a GenUI card the model can render inline.

## Guarding the misread that motivates the whole feature

`analyze_pair` returns **both** `premium_discount_pct` (net of senior claims, −16.9% for MSTR) and `gross_premium_discount_pct` (−41.8%). An LLM glancing at that payload could confidently report a 42% discount to bitcoin — precisely the error the scanner was built to prevent. Four defences, because one wasn't enough:

1. **The tool description** names the right field and warns about the wrong one — and `test_arbitrage_tool_steers_the_model_to_the_net_discount` asserts that warning is still present, so a future trim fails CI rather than silently regressing.
2. **The system prompt** carries the same instruction.
3. **`scan_summary` omits the gross figure entirely** rather than trimming to it. A summary row is exactly where a misread happens, so the number simply isn't there.
4. **The card** puts the net figure in the headline slot and renders gross struck-through and labelled *"overstates what a shareholder gets"*, with a test pinning which number occupies the headline.

## Why `scan_arbitrage` doesn't call `scan`

A full scan returns ten candidates each carrying complete spread statistics, a NAV block, factors, reasons and `breaks_on`. That's far more than the model needs to rank them, and enough to crowd a conversation's context window. New `ArbitrageService.scan_summary` keeps the fields carrying the judgement — score, verdict, net discount, convergence, hedgeability, what breaks it — and drops the rest. The model calls `analyze_arbitrage_pair` for detail on anything interesting.

## GenUI compliance (arch-v2 Rules 8–9)

- Self-fetching from a ticker, scalar props, display-only
- Registered with matching strict specs in **both** `chat_tools.py` and `componentRegistry.tsx`
- **Formats but never derives** — every number comes from `quantcore/analytics` via the service
- **Curated pairs only.** `underlying` is deliberately *not* a prop: every registered prop is required, and there's no way to express an optional one without weakening the validator. Both registries reject it, asserted on both sides.
- Ships with vitest tests (loading/error/success + key values) and registry parity cases

## One robustness detail

The arbitrage handlers register **only when the service is injected**. A `ChatService` built without it hits the loop's existing unknown-tool path — a recoverable `is_error` the model can work around — instead of raising `AttributeError` on a `None` service mid-stream. Tested.

## Verification

| | Before | After |
|---|---|---|
| Backend tests | 969 | **986** |
| Frontend tests | 331 | **344** |
| Backend coverage | 86.2% | 86.2% |
| Frontend statements | 86.62% | **86.68%** |
| Frontend functions | 85.69% | **85.85%** |

Typecheck clean. Architecture guards pass. OpenAPI surface unchanged — no new routes; the card reuses `GET /api/arbitrage/pairs/{security}`.

**Note:** this needs a `prod-rollout.yml` dispatch to reach the deployed sidekick, same as the scanner itself did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)