### PR TITLE
feat(arbitrage): visualization suite — spread, premium, scan, discovery

### DIFF
--- a/api/routers/arbitrage.py
+++ b/api/routers/arbitrage.py
@@ -75,6 +75,11 @@ def discover(
     days: int = Query(365, ge=MIN_DAYS, le=MAX_DAYS),
     min_abs_correlation: float = Query(0.4, ge=0.0, le=1.0),
     require_economic_link: bool = True,
+    include_all: bool = Query(
+        False,
+        description="Also return every tested pair with a `passed` flag, so "
+                    "near-misses are visible (the discovery scatter needs this)",
+    ),
 ) -> QuantCoreJSONResponse:
     symbol_list = _split(symbols)
     if not symbol_list:
@@ -99,7 +104,31 @@ def discover(
             days=days,
             min_abs_correlation=min_abs_correlation,
             require_economic_link=require_economic_link,
+            include_all=include_all,
         )
+    )
+
+
+@router.get("/pairs/{security}/spread-history")
+def spread_history(
+    security: str,
+    underlying: Optional[str] = Query(None, max_length=32),
+    days: int = Query(365, ge=MIN_DAYS, le=MAX_DAYS),
+) -> QuantCoreJSONResponse:
+    return QuantCoreJSONResponse(
+        services().arbitrage.get_spread_history(
+            security.upper(), underlying=underlying, days=days
+        )
+    )
+
+
+@router.get("/pairs/{security}/premium-history")
+def premium_history(
+    security: str,
+    days: int = Query(365, ge=MIN_DAYS, le=MAX_DAYS),
+) -> QuantCoreJSONResponse:
+    return QuantCoreJSONResponse(
+        services().arbitrage.get_premium_history(security.upper(), days=days)
     )
 
 

--- a/docs/openapi-surface.txt
+++ b/docs/openapi-surface.txt
@@ -2,6 +2,8 @@ DELETE /api/plans/{instance_id}  ->  delete_plan_api_plans__instance_id__delete
 DELETE /api/portfolio/{ticker}  ->  remove_from_portfolio_api_portfolio__ticker__delete
 GET    /api/arbitrage/discover  ->  discover_api_arbitrage_discover_get
 GET    /api/arbitrage/pairs/{security}  ->  analyze_pair_api_arbitrage_pairs__security__get
+GET    /api/arbitrage/pairs/{security}/premium-history  ->  premium_history_api_arbitrage_pairs__security__premium_history_get
+GET    /api/arbitrage/pairs/{security}/spread-history  ->  spread_history_api_arbitrage_pairs__security__spread_history_get
 GET    /api/arbitrage/scan  ->  scan_api_arbitrage_scan_get
 GET    /api/arbitrage/universe  ->  get_universe_api_arbitrage_universe_get
 GET    /api/dashboard/stats  ->  dashboard_stats_api_dashboard_stats_get

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import DashboardIcon from '@mui/icons-material/Dashboard';
 import ListAltIcon from '@mui/icons-material/ListAlt';
 import ShowChartIcon from '@mui/icons-material/ShowChart';
 import BarChartIcon from '@mui/icons-material/BarChart';
+import CompareArrowsIcon from '@mui/icons-material/CompareArrows';
 import SettingsIcon from '@mui/icons-material/Settings';
 import LightModeIcon from '@mui/icons-material/LightMode';
 import DarkModeIcon from '@mui/icons-material/DarkMode';
@@ -19,6 +20,7 @@ import PlanDetailPage from './components/plans/PlanDetailPage';
 import SymbolsPage from './components/symbols/SymbolsPage';
 import SecuritiesPage from './components/securities/SecuritiesPage';
 import SecurityDetailPage from './components/securities/SecurityDetailPage';
+import ArbitragePage from './components/arbitrage/ArbitragePage';
 import SettingsPage from './components/settings/SettingsPage';
 import { useAppTheme } from './ThemeContext';
 
@@ -32,6 +34,7 @@ function Layout() {
   const navItems = [
     { label: 'Dashboard', path: '/', icon: <DashboardIcon /> },
     { label: 'Securities', path: '/securities', icon: <BarChartIcon /> },
+    { label: 'Arbitrage', path: '/arbitrage', icon: <CompareArrowsIcon /> },
     { label: 'Plans', path: '/plans', icon: <ListAltIcon /> },
     { label: 'Symbols', path: '/symbols', icon: <ShowChartIcon /> },
     { label: 'Settings', path: '/settings', icon: <SettingsIcon /> },
@@ -167,6 +170,7 @@ export default function App() {
         <Route path="/" element={<DashboardPage />} />
         <Route path="/securities" element={<SecuritiesPage />} />
         <Route path="/securities/:symbol" element={<SecurityDetailPage />} />
+        <Route path="/arbitrage" element={<ArbitragePage />} />
         <Route path="/plans" element={<PlansPage />} />
         <Route path="/plans/:id" element={<PlanDetailPage />} />
         <Route path="/symbols" element={<SymbolsPage />} />

--- a/frontend/src/api/arbitrage.ts
+++ b/frontend/src/api/arbitrage.ts
@@ -73,9 +73,131 @@ export interface ArbitragePairResponse {
   hint?: string;
 }
 
+export interface SpreadPoint {
+  date: string;
+  spread: number;
+}
+
+export interface SpreadHistoryResponse {
+  security: string;
+  name?: string;
+  kind: string;
+  underlying: string;
+  points: SpreadPoint[];
+  mean: number;
+  std: number;
+  /** Precomputed band levels — the chart draws, it does not derive. */
+  bands: {
+    plus_one: number;
+    minus_one: number;
+    plus_two: number;
+    minus_two: number;
+  };
+  latest: { date: string | null; spread: number | null; z: number | null };
+  hedge_ratio: { beta: number | null; alpha: number | null };
+  half_life: { half_life_days: number | null };
+  cointegration: { cointegrated: boolean; statistic: number | null };
+  trend: {
+    slope_per_day: number | null;
+    intercept: number | null;
+    slope_tstat: number | null;
+    widening: boolean | null;
+  };
+  error?: string;
+  hint?: string;
+}
+
+export interface PremiumPoint {
+  date: string;
+  premium_discount_pct: number;
+  nav_per_share: number;
+  price: number;
+}
+
+export interface PremiumHistoryResponse {
+  security: string;
+  name?: string;
+  underlying: string;
+  points: PremiumPoint[];
+  latest: PremiumPoint | null;
+  holdings_as_of?: string | null;
+  holdings_age_days?: number | null;
+  holdings_stale?: boolean;
+  /** Always "current_capital_structure" today — the series is an approximation. */
+  method: string;
+  note: string;
+  error?: string;
+}
+
+export interface ScanRow {
+  security: string;
+  name?: string;
+  kind: string;
+  underlying: string;
+  score: number | null;
+  verdict: string;
+  basis: string | null;
+  discount_pct: number | null;
+  spread_zscore: number | null;
+  half_life_days: number | null;
+  cointegrated: boolean | null;
+  convergence: string;
+  hedge_instrument: string | null;
+  hedge_available: boolean;
+  breaks_on: string[];
+}
+
+export interface ScanResponse {
+  scanned: number;
+  returned: number;
+  candidates: ScanRow[];
+  errors: Array<{ security: string; error: string }>;
+}
+
+export interface TestedPair {
+  security: string;
+  underlying: string;
+  economic_link: boolean;
+  correlation: number | null;
+  statistic: number | null;
+  reject_at: number | null;
+  half_life_days: number | null;
+  passed: boolean;
+  failed_because: string | null;
+}
+
+export interface DiscoveryResponse {
+  count: number;
+  pairs: Array<{ security: string; underlying: string; correlation: number | null }>;
+  skipped: Array<{ symbol: string; reason: string }>;
+  references: string[];
+  /** Present only with include_all — every tested pair, near-misses included. */
+  tested?: TestedPair[];
+  critical_values?: Record<string, number>;
+}
+
 export const arbitrageApi = {
   getPair: (security: string, days = 365) =>
     apiRequest<ArbitragePairResponse>(
       `/api/arbitrage/pairs/${encodeURIComponent(security)}?days=${days}`,
+    ),
+
+  getSpreadHistory: (security: string, days = 365) =>
+    apiRequest<SpreadHistoryResponse>(
+      `/api/arbitrage/pairs/${encodeURIComponent(security)}/spread-history?days=${days}`,
+    ),
+
+  getPremiumHistory: (security: string, days = 365) =>
+    apiRequest<PremiumHistoryResponse>(
+      `/api/arbitrage/pairs/${encodeURIComponent(security)}/premium-history?days=${days}`,
+    ),
+
+  scan: (topN = 20, days = 365) =>
+    apiRequest<ScanResponse>(`/api/arbitrage/scan?top_n=${topN}&days=${days}`),
+
+  discover: (symbols: string, requireEconomicLink = true) =>
+    apiRequest<DiscoveryResponse>(
+      `/api/arbitrage/discover?symbols=${encodeURIComponent(symbols)}` +
+        `&include_all=true&require_economic_link=${requireEconomicLink}`,
     ),
 };

--- a/frontend/src/chat/componentRegistry.test.ts
+++ b/frontend/src/chat/componentRegistry.test.ts
@@ -16,9 +16,32 @@ describe('COMPONENT_REGISTRY', () => {
       'price_chart',
       'spread_payoff',
       'arbitrage_pair',
+      'arbitrage_spread',
+      'arbitrage_premium',
+      'arbitrage_scan',
+      'arbitrage_discovery',
     ]) {
       expect(COMPONENT_REGISTRY[name]?.component, name).toBeTypeOf('function');
     }
+  });
+
+  it('accepts the arbitrage chart directives and rejects wrong props', () => {
+    // Mirrors test_chat_protocol.py — both sides validate independently.
+    for (const name of ['arbitrage_spread', 'arbitrage_premium']) {
+      expect(validateDirective({ component: name, props: { ticker: 'MSTR' } }).ok).toBe(true);
+    }
+    // Universe-wide: a ticker is meaningless here.
+    expect(validateDirective({ component: 'arbitrage_scan', props: {} }).ok).toBe(true);
+    expect(
+      validateDirective({ component: 'arbitrage_scan', props: { ticker: 'MSTR' } }).ok,
+    ).toBe(false);
+    // Discovery sweeps a list, so it takes symbols rather than a ticker.
+    expect(
+      validateDirective({ component: 'arbitrage_discovery', props: { symbols: 'NEM,AEM' } }).ok,
+    ).toBe(true);
+    expect(
+      validateDirective({ component: 'arbitrage_discovery', props: { ticker: 'NEM' } }).ok,
+    ).toBe(false);
   });
 
   it('accepts a ticker-only arbitrage_pair directive and rejects extras', () => {

--- a/frontend/src/chat/componentRegistry.tsx
+++ b/frontend/src/chat/componentRegistry.tsx
@@ -9,6 +9,12 @@ import LivePrice from '../components/symbols/LivePrice';
 import PriceChartCard from '../components/chat/PriceChartCard';
 import SpreadPayoffCard from '../components/chat/SpreadPayoffCard';
 import ArbitrageCard from '../components/chat/ArbitrageCard';
+import {
+  SpreadHistoryCard,
+  PremiumHistoryCard,
+  ArbScanCard,
+  DiscoveryCard,
+} from '../components/chat/ArbitrageChartCards';
 import type { ChatDirective } from './types';
 
 type PropKind = 'string' | 'number';
@@ -45,6 +51,11 @@ export const COMPONENT_REGISTRY: Record<string, RegistryEntry> = {
   },
   // Carries its own "SECURITY vs UNDERLYING" heading, so no titled wrapper.
   arbitrage_pair: { component: ArbitrageCard, spec: TICKER_ONLY },
+  arbitrage_spread: { component: SpreadHistoryCard, spec: TICKER_ONLY },
+  arbitrage_premium: { component: PremiumHistoryCard, spec: TICKER_ONLY },
+  // Universe-wide: no props at all.
+  arbitrage_scan: { component: ArbScanCard, spec: {}, titled: false },
+  arbitrage_discovery: { component: DiscoveryCard, spec: { symbols: 'string' } },
 };
 
 /**

--- a/frontend/src/components/arbitrage/ArbitragePage.test.tsx
+++ b/frontend/src/components/arbitrage/ArbitragePage.test.tsx
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+
+import ArbitragePage from './ArbitragePage';
+import { mockApi, renderWithProviders } from '../../testUtils';
+
+afterEach(() => vi.unstubAllGlobals());
+
+const SCAN = {
+  scanned: 2,
+  returned: 2,
+  candidates: [
+    {
+      security: 'MSTR', name: 'Strategy', kind: 'nav_vehicle', underlying: 'BTC-USD',
+      score: 9.7, verdict: 'reject', basis: 'nav_discount', discount_pct: -16.92,
+      spread_zscore: -1.35, half_life_days: 66.4, cointegrated: false,
+      convergence: 'buyback', hedge_instrument: 'IBIT', hedge_available: true,
+      breaks_on: ['Negative carry'],
+    },
+    {
+      security: 'GDX', name: 'Gold Miners', kind: 'producer', underlying: 'GC=F',
+      score: 2.6, verdict: 'reject', basis: 'spread_zscore', discount_pct: null,
+      spread_zscore: -0.35, half_life_days: 12.0, cointegrated: false,
+      convergence: 'none', hedge_instrument: 'GLD', hedge_available: true,
+      breaks_on: [],
+    },
+  ],
+  errors: [],
+};
+
+const SPREAD = {
+  security: 'MSTR', kind: 'nav_vehicle', underlying: 'BTC-USD',
+  points: [{ date: '2026-05-01', spread: 0.1 }, { date: '2026-05-02', spread: -0.1 }],
+  mean: 0, std: 0.12,
+  bands: { plus_one: 0.12, minus_one: -0.12, plus_two: 0.24, minus_two: -0.24 },
+  latest: { date: '2026-05-02', spread: -0.1, z: -0.8 },
+  hedge_ratio: { beta: 1.4, alpha: 0.1 },
+  half_life: { half_life_days: 20 },
+  cointegration: { cointegrated: false, statistic: -2.8 },
+  trend: { slope_per_day: -0.001, intercept: 0.05, slope_tstat: -1, widening: false },
+};
+
+const PREMIUM = {
+  security: 'MSTR', underlying: 'BTC-USD',
+  points: [{ date: '2026-05-01', premium_discount_pct: -12, nav_per_share: 110, price: 96 }],
+  latest: { date: '2026-05-01', premium_discount_pct: -12, nav_per_share: 110, price: 96 },
+  method: 'current_capital_structure',
+  note: 'Approximation: today’s holdings applied to past prices.',
+};
+
+function arm(extra: Array<[string, unknown]> = []) {
+  return mockApi([
+    ...(extra as Array<[string, never]>),
+    ['/spread-history', SPREAD],
+    ['/premium-history', PREMIUM],
+    ['/api/arbitrage/scan', SCAN],
+    ['/api/arbitrage/pairs/', { security: 'MSTR', error: 'stub' }],
+    ['/api/arbitrage/discover', { count: 0, pairs: [], skipped: [], references: [], tested: [] }],
+  ]);
+}
+
+describe('ArbitragePage', () => {
+  it('explains the wait while the scan runs', () => {
+    arm();
+    renderWithProviders(<ArbitragePage />);
+    expect(screen.getByText(/Scanning the curated universe/i)).toBeInTheDocument();
+  });
+
+  it('renders the ranked rows once the scan lands', async () => {
+    arm();
+    renderWithProviders(<ArbitragePage />);
+    await waitFor(() => expect(screen.getByText('MSTR')).toBeInTheDocument());
+    expect(screen.getByText('GDX')).toBeInTheDocument();
+    expect(screen.getByText('2 of 2 pairs')).toBeInTheDocument();
+  });
+
+  it('surfaces a scan failure', async () => {
+    mockApi([['/api/arbitrage/scan', () => ({ __status: 500, error: 'scan blew up' })]]);
+    renderWithProviders(<ArbitragePage />);
+    await waitFor(() => expect(screen.getByText(/scan blew up/i)).toBeInTheDocument());
+  });
+
+  it('flags pairs that errored during the scan', async () => {
+    arm([['/api/arbitrage/scan', { ...SCAN, errors: [{ security: 'BOOM', error: 'x' }] }]]);
+    renderWithProviders(<ArbitragePage />);
+    await waitFor(() => expect(screen.getByText('1 errored')).toBeInTheDocument());
+  });
+
+  it('opens the pair detail with a spread chart on row click', async () => {
+    arm();
+    renderWithProviders(<ArbitragePage />);
+    await waitFor(() => expect(screen.getByText('MSTR')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('MSTR'));
+    await waitFor(() =>
+      expect(screen.getByTestId('spread-chart')).toBeInTheDocument(),
+    );
+  });
+
+  it('shows the NAV premium chart only for nav_vehicle rows', async () => {
+    arm();
+    renderWithProviders(<ArbitragePage />);
+    await waitFor(() => expect(screen.getByText('GDX')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('GDX'));
+    await waitFor(() => expect(screen.getByTestId('spread-chart')).toBeInTheDocument());
+    // GDX is a producer — no net asset value to discount against.
+    expect(screen.queryByTestId('premium-chart')).toBeNull();
+
+    fireEvent.click(screen.getByText('MSTR'));
+    await waitFor(() => expect(screen.getByTestId('premium-chart')).toBeInTheDocument());
+  });
+
+  it('runs a discovery sweep on demand', async () => {
+    const api = arm();
+    renderWithProviders(<ArbitragePage />);
+    await waitFor(() => expect(screen.getByText('MSTR')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: /Discovery/i }));
+    const input = screen.getByLabelText(/Symbols/i);
+    fireEvent.change(input, { target: { value: 'NEM, AEM' } });
+    fireEvent.click(screen.getByRole('button', { name: /^Sweep$/i }));
+
+    await waitFor(() =>
+      expect(api.calls.some(([url]) => url.includes('include_all=true'))).toBe(true),
+    );
+  });
+
+  it('keeps Sweep disabled until symbols are entered', async () => {
+    arm();
+    renderWithProviders(<ArbitragePage />);
+    fireEvent.click(screen.getByRole('button', { name: /Discovery/i }));
+    expect(screen.getByRole('button', { name: /^Sweep$/i })).toBeDisabled();
+  });
+});

--- a/frontend/src/components/arbitrage/ArbitragePage.tsx
+++ b/frontend/src/components/arbitrage/ArbitragePage.tsx
@@ -1,0 +1,160 @@
+/**
+ * ArbitragePage — the scanner's home in QuantUI.
+ *
+ * Scan table on top; selecting a row opens the full workup beneath it (card +
+ * spread chart, plus the NAV premium chart when the pair has one). A
+ * collapsible discovery panel runs cointegration sweeps.
+ *
+ * Composed entirely from the same components the sidekick renders, so the two
+ * surfaces cannot drift.
+ */
+import { useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Collapse,
+  Divider,
+  Paper,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import ScienceIcon from '@mui/icons-material/Science';
+import ScanTable from './ScanTable';
+import SpreadChart from './SpreadChart';
+import PremiumChart from './PremiumChart';
+import DiscoveryScatter from './DiscoveryScatter';
+import ArbitrageCard from '../chat/ArbitrageCard';
+import {
+  useArbitrageScan,
+  useSpreadHistory,
+  usePremiumHistory,
+  useDiscovery,
+} from '../../hooks/useArbitrage';
+
+function PairDetail({ security, kind }: { security: string; kind: string }) {
+  const spread = useSpreadHistory(security);
+  const premium = usePremiumHistory(security);
+  const isNav = kind === 'nav_vehicle';
+
+  return (
+    <Stack spacing={2}>
+      <ArbitrageCard ticker={security} />
+      <Divider />
+      {spread.isLoading && <CircularProgress size={18} />}
+      {spread.data && !spread.data.error && <SpreadChart data={spread.data} />}
+      {spread.data?.error && <Alert severity="info">{spread.data.error}</Alert>}
+      {isNav && (
+        <>
+          {premium.isLoading && <CircularProgress size={18} />}
+          {premium.data && !premium.data.error && <PremiumChart data={premium.data} />}
+          {premium.data?.error && <Alert severity="info">{premium.data.error}</Alert>}
+        </>
+      )}
+    </Stack>
+  );
+}
+
+export default function ArbitragePage() {
+  const { data, isLoading, error } = useArbitrageScan();
+  const [selected, setSelected] = useState<string | null>(null);
+  const [discoveryOpen, setDiscoveryOpen] = useState(false);
+  const [symbolsInput, setSymbolsInput] = useState('');
+  const [sweepFor, setSweepFor] = useState('');
+  const discovery = useDiscovery(sweepFor, !!sweepFor);
+
+  const rows = data?.candidates ?? [];
+  const selectedRow = rows.find((r) => r.security === selected);
+
+  return (
+    <Box>
+      <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2 }}>
+        <Typography variant="h4">Arbitrage</Typography>
+        <Button
+          size="small"
+          startIcon={<ScienceIcon />}
+          variant={discoveryOpen ? 'contained' : 'outlined'}
+          onClick={() => setDiscoveryOpen((o) => !o)}
+        >
+          Discovery
+        </Button>
+      </Stack>
+
+      <Collapse in={discoveryOpen}>
+        <Paper sx={{ p: 2, mb: 2 }}>
+          <Typography variant="subtitle2" gutterBottom>
+            Cointegration sweep against the commodity/crypto/FX panel
+          </Typography>
+          <Stack direction="row" spacing={1} sx={{ mb: 1 }}>
+            <TextField
+              size="small"
+              label="Symbols"
+              placeholder="NEM, AEM, FCX"
+              value={symbolsInput}
+              onChange={(e) => setSymbolsInput(e.target.value)}
+              sx={{ minWidth: 260 }}
+            />
+            <Button
+              variant="contained"
+              size="small"
+              disabled={!symbolsInput.trim()}
+              onClick={() => setSweepFor(symbolsInput.trim())}
+            >
+              Sweep
+            </Button>
+          </Stack>
+          {discovery.isLoading && (
+            <Stack direction="row" spacing={1} alignItems="center">
+              <CircularProgress size={16} />
+              <Typography variant="body2" color="text.secondary">
+                Testing each symbol against six references…
+              </Typography>
+            </Stack>
+          )}
+          {discovery.error && <Alert severity="error">Sweep failed.</Alert>}
+          {discovery.data && (
+            <DiscoveryScatter
+              tested={discovery.data.tested ?? []}
+              criticalValues={discovery.data.critical_values}
+            />
+          )}
+        </Paper>
+      </Collapse>
+
+      {isLoading && (
+        <Stack direction="row" spacing={1} alignItems="center" sx={{ py: 3 }}>
+          <CircularProgress size={20} />
+          <Typography variant="body2" color="text.secondary">
+            Scanning the curated universe — each pair is a full workup, so this
+            takes a moment.
+          </Typography>
+        </Stack>
+      )}
+      {error && <Alert severity="error">{(error as Error).message}</Alert>}
+
+      {data && (
+        <>
+          <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 1 }}>
+            <Typography variant="body2" color="text.secondary">
+              {data.returned} of {data.scanned} pairs
+            </Typography>
+            {data.errors.length > 0 && (
+              <Chip size="small" color="warning" variant="outlined"
+                label={`${data.errors.length} errored`} />
+            )}
+          </Stack>
+          <ScanTable rows={rows} onSelect={setSelected} />
+        </>
+      )}
+
+      {selectedRow && (
+        <Paper sx={{ p: 2, mt: 2 }}>
+          <PairDetail security={selectedRow.security} kind={selectedRow.kind} />
+        </Paper>
+      )}
+    </Box>
+  );
+}

--- a/frontend/src/components/arbitrage/DiscoveryScatter.test.tsx
+++ b/frontend/src/components/arbitrage/DiscoveryScatter.test.tsx
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { screen } from '@testing-library/react';
+
+import DiscoveryScatter from './DiscoveryScatter';
+import { renderWithProviders } from '../../testUtils';
+import type { TestedPair } from '../../api/arbitrage';
+
+const CRITICALS = { '0.01': -3.9, '0.05': -3.34, '0.1': -3.04 };
+
+function pair(overrides: Partial<TestedPair> = {}): TestedPair {
+  return {
+    security: 'NEM',
+    underlying: 'GC=F',
+    economic_link: true,
+    correlation: 0.733,
+    statistic: -2.87,
+    reject_at: null,
+    half_life_days: 6.4,
+    passed: false,
+    failed_because: 'not cointegrated',
+    ...overrides,
+  };
+}
+
+describe('DiscoveryScatter', () => {
+  it('summarises how many pairs passed', () => {
+    renderWithProviders(
+      <DiscoveryScatter
+        tested={[pair(), pair({ security: 'AEM', statistic: -4.2, passed: true, failed_because: null })]}
+        criticalValues={CRITICALS}
+      />,
+    );
+    expect(screen.getByText(/1 of 2 pairs passed/)).toBeInTheDocument();
+    expect(screen.getByText(/filled = passed, hollow = rejected/)).toBeInTheDocument();
+  });
+
+  it('draws rejected points hollow and passed points filled', () => {
+    const { container } = renderWithProviders(
+      <DiscoveryScatter
+        tested={[pair(), pair({ security: 'AEM', statistic: -4.2, passed: true, failed_because: null })]}
+        criticalValues={CRITICALS}
+      />,
+    );
+    const circles = Array.from(
+      container.querySelectorAll('[data-testid="discovery-scatter"] circle'),
+    );
+    expect(circles).toHaveLength(2);
+    const fills = circles.map((c) => c.getAttribute('fill'));
+    expect(fills).toContain('none'); // the rejected near-miss
+    expect(fills.filter((f) => f !== 'none')).toHaveLength(1);
+  });
+
+  it('renders a critical-value line per level', () => {
+    const { container } = renderWithProviders(
+      <DiscoveryScatter tested={[pair()]} criticalValues={CRITICALS} />,
+    );
+    const svg = container.querySelector('[data-testid="discovery-scatter"]')!;
+    // Scoped by class — d3 axis ticks are <line> elements too.
+    expect(svg.querySelectorAll('line.critical-line')).toHaveLength(3);
+    expect(svg.textContent).toContain('5%');
+  });
+
+  it('explains a rejected point in its tooltip', () => {
+    const { container } = renderWithProviders(
+      <DiscoveryScatter tested={[pair()]} criticalValues={CRITICALS} />,
+    );
+    const title = container.querySelector('[data-testid="discovery-scatter"] title')!;
+    expect(title.textContent).toContain('NEM ~ GC=F');
+    expect(title.textContent).toContain('-2.87');
+    expect(title.textContent).toContain('rejected: not cointegrated');
+  });
+
+  it('skips pairs with no measurable statistic', () => {
+    const { container } = renderWithProviders(
+      <DiscoveryScatter
+        tested={[pair(), pair({ security: 'GHOST', statistic: null, correlation: null })]}
+        criticalValues={CRITICALS}
+      />,
+    );
+    expect(
+      container.querySelectorAll('[data-testid="discovery-scatter"] circle'),
+    ).toHaveLength(1);
+    expect(screen.getByText(/0 of 1 pairs passed/)).toBeInTheDocument();
+  });
+
+  it('degrades when nothing was testable', () => {
+    renderWithProviders(<DiscoveryScatter tested={[]} criticalValues={CRITICALS} />);
+    expect(screen.getByText(/Nothing testable in this sweep/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/arbitrage/DiscoveryScatter.tsx
+++ b/frontend/src/components/arbitrage/DiscoveryScatter.tsx
@@ -1,0 +1,138 @@
+/**
+ * DiscoveryScatter — every tested pair from a cointegration sweep, plotted
+ * against the critical value that decides it.
+ *
+ * Built for the near-misses. A pass/fail list said "0 found" for NEM/AEM/FCX;
+ * the scatter shows NEM sitting at −2.87 against a −3.04 threshold with 0.73
+ * correlation — one tick from qualifying. Points left of the line passed,
+ * hollow points did not.
+ */
+import { useEffect, useRef } from 'react';
+import * as d3 from 'd3';
+import { Box, Stack, Typography, useTheme } from '@mui/material';
+import type { TestedPair } from '../../api/arbitrage';
+
+interface Props {
+  tested: TestedPair[];
+  /** Engle-Granger critical values by level, e.g. {"0.05": -3.34}. */
+  criticalValues?: Record<string, number>;
+  height?: number;
+}
+
+const MARGIN = { top: 16, right: 20, bottom: 34, left: 46 };
+
+export default function DiscoveryScatter({ tested, criticalValues, height = 260 }: Props) {
+  const ref = useRef<SVGSVGElement>(null);
+  const theme = useTheme();
+
+  const plottable = tested.filter((t) => t.statistic != null && t.correlation != null);
+
+  useEffect(() => {
+    if (!ref.current || plottable.length === 0) return;
+    const svg = d3.select(ref.current);
+    svg.selectAll('*').remove();
+
+    const width = ref.current.parentElement?.clientWidth || 640;
+    const W = Math.max(120, width - MARGIN.left - MARGIN.right);
+    const H = height - MARGIN.top - MARGIN.bottom;
+    const muted = theme.palette.text.secondary;
+
+    const crits = Object.values(criticalValues ?? {});
+    const stats = plottable.map((t) => t.statistic as number);
+    const xLo = Math.min(...stats, ...crits) - 0.4;
+    const xHi = Math.max(...stats, ...crits) + 0.4;
+
+    const xScale = d3.scaleLinear().domain([xLo, xHi]).range([0, W]);
+    const yScale = d3.scaleLinear().domain([0, 1]).range([H, 0]);
+
+    const g = svg
+      .attr('width', width)
+      .attr('height', height)
+      .append('g')
+      .attr('transform', `translate(${MARGIN.left},${MARGIN.top})`);
+
+    // Critical-value lines: everything left of one clears that level.
+    Object.entries(criticalValues ?? {}).forEach(([level, value]) => {
+      g.append('line')
+        .attr('class', 'critical-line')
+        .attr('x1', xScale(value))
+        .attr('x2', xScale(value))
+        .attr('y1', 0)
+        .attr('y2', H)
+        .attr('stroke', theme.palette.warning.main)
+        .attr('stroke-width', 1)
+        .attr('stroke-dasharray', '3,3')
+        .attr('opacity', 0.7);
+      g.append('text')
+        .attr('x', xScale(value))
+        .attr('y', -4)
+        .attr('text-anchor', 'middle')
+        .attr('fill', muted)
+        .attr('font-size', 9)
+        .text(`${(Number(level) * 100).toFixed(0)}%`);
+    });
+
+    g.selectAll('circle')
+      .data(plottable)
+      .enter()
+      .append('circle')
+      .attr('cx', (t) => xScale(t.statistic as number))
+      .attr('cy', (t) => yScale(Math.abs(t.correlation as number)))
+      .attr('r', 5)
+      .attr('fill', (t) => (t.passed ? theme.palette.success.main : 'none'))
+      .attr('stroke', (t) =>
+        t.passed ? theme.palette.success.main : theme.palette.text.secondary,
+      )
+      .attr('stroke-width', 1.5)
+      .append('title')
+      .text(
+        (t) =>
+          `${t.security} ~ ${t.underlying}\n` +
+          `statistic ${(t.statistic as number).toFixed(2)} · ` +
+          `|corr| ${Math.abs(t.correlation as number).toFixed(2)}` +
+          (t.half_life_days != null ? ` · half-life ${t.half_life_days.toFixed(1)}d` : '') +
+          (t.passed ? '' : `\nrejected: ${t.failed_because}`),
+      );
+
+    g.append('g')
+      .attr('transform', `translate(0,${H})`)
+      .call(d3.axisBottom(xScale).ticks(5))
+      .attr('color', muted)
+      .attr('font-size', 9);
+
+    g.append('g')
+      .call(d3.axisLeft(yScale).ticks(4))
+      .attr('color', muted)
+      .attr('font-size', 9);
+
+    g.append('text')
+      .attr('x', W / 2)
+      .attr('y', H + 28)
+      .attr('text-anchor', 'middle')
+      .attr('fill', muted)
+      .attr('font-size', 9)
+      .text('Engle-Granger statistic (more negative = stronger)');
+  }, [plottable, criticalValues, height, theme]);
+
+  if (plottable.length === 0) {
+    return (
+      <Typography variant="body2" color="text.secondary">
+        Nothing testable in this sweep — the symbols had no usable price history.
+      </Typography>
+    );
+  }
+
+  const passed = plottable.filter((t) => t.passed).length;
+
+  return (
+    <Box>
+      <Stack direction="row" spacing={2} alignItems="baseline" sx={{ mb: 0.5 }}>
+        <Typography variant="subtitle2">Cointegration sweep</Typography>
+        <Typography variant="caption" color="text.secondary">
+          {passed} of {plottable.length} pairs passed · filled = passed, hollow = rejected
+        </Typography>
+      </Stack>
+      <svg ref={ref} data-testid="discovery-scatter" />
+    </Box>
+  );
+}

--- a/frontend/src/components/arbitrage/PremiumChart.test.tsx
+++ b/frontend/src/components/arbitrage/PremiumChart.test.tsx
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { screen } from '@testing-library/react';
+
+import PremiumChart from './PremiumChart';
+import { renderWithProviders } from '../../testUtils';
+import type { PremiumHistoryResponse } from '../../api/arbitrage';
+
+const NOTE =
+  "Approximation: today's holdings and senior claims are applied to past " +
+  'prices, so this is not a record of the discount as it stood.';
+
+function premiumData(overrides: Partial<PremiumHistoryResponse> = {}): PremiumHistoryResponse {
+  const points = Array.from({ length: 40 }, (_, i) => ({
+    date: `2026-06-${String((i % 28) + 1).padStart(2, '0')}`,
+    premium_discount_pct: -10 - i * 0.2,
+    nav_per_share: 108.86,
+    price: 96.99,
+  }));
+  return {
+    security: 'MSTR',
+    underlying: 'BTC-USD',
+    points,
+    latest: points[points.length - 1],
+    holdings_as_of: '2026-07-14',
+    holdings_age_days: 12,
+    holdings_stale: false,
+    method: 'current_capital_structure',
+    note: NOTE,
+    ...overrides,
+  };
+}
+
+describe('PremiumChart', () => {
+  it('renders the heading and latest discount', () => {
+    renderWithProviders(<PremiumChart data={premiumData()} />);
+    expect(screen.getByText('MSTR discount to NAV')).toBeInTheDocument();
+    expect(screen.getByText(/latest -17\.80%/)).toBeInTheDocument();
+  });
+
+  it('always shows the approximation caveat', () => {
+    // The series is not history; a reader who misses that misreads the chart.
+    renderWithProviders(<PremiumChart data={premiumData()} />);
+    expect(screen.getByText(/Approximation/)).toBeInTheDocument();
+    expect(screen.getByText(/not a record of the discount/)).toBeInTheDocument();
+  });
+
+  it('draws the series with a parity line at zero', () => {
+    const { container } = renderWithProviders(<PremiumChart data={premiumData()} />);
+    const svg = container.querySelector('[data-testid="premium-chart"]')!;
+    expect(svg.querySelectorAll('line').length).toBeGreaterThanOrEqual(1);
+    expect(svg.querySelectorAll('path').length).toBeGreaterThan(0);
+    expect(svg.querySelectorAll('circle').length).toBe(1);
+  });
+
+  it('degrades to a message when there are no points', () => {
+    renderWithProviders(<PremiumChart data={premiumData({ points: [], latest: null })} />);
+    expect(screen.getByText(/No premium history for MSTR/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/arbitrage/PremiumChart.tsx
+++ b/frontend/src/components/arbitrage/PremiumChart.tsx
@@ -1,0 +1,127 @@
+/**
+ * PremiumChart — a NAV vehicle's discount to net asset value over time.
+ *
+ * The approximation label is not decoration. Only the current capital
+ * structure is known, so every point applies today's holdings and senior
+ * claims to that date's prices. A reader who takes this for a record of the
+ * historical discount would draw exactly the wrong conclusion about how the
+ * gap has behaved, so the caveat renders with the chart, always.
+ */
+import { useEffect, useRef } from 'react';
+import * as d3 from 'd3';
+import { Alert, Box, Stack, Typography, useTheme } from '@mui/material';
+import type { PremiumHistoryResponse } from '../../api/arbitrage';
+
+interface Props {
+  data: PremiumHistoryResponse;
+  height?: number;
+}
+
+const MARGIN = { top: 14, right: 20, bottom: 26, left: 46 };
+
+export default function PremiumChart({ data, height = 220 }: Props) {
+  const ref = useRef<SVGSVGElement>(null);
+  const theme = useTheme();
+
+  useEffect(() => {
+    if (!ref.current || data.points.length === 0) return;
+    const svg = d3.select(ref.current);
+    svg.selectAll('*').remove();
+
+    const width = ref.current.parentElement?.clientWidth || 640;
+    const W = Math.max(120, width - MARGIN.left - MARGIN.right);
+    const H = height - MARGIN.top - MARGIN.bottom;
+    const muted = theme.palette.text.secondary;
+
+    const points = data.points.map((p) => ({
+      date: new Date(p.date),
+      pct: p.premium_discount_pct,
+    }));
+
+    const xScale = d3
+      .scaleTime()
+      .domain(d3.extent(points, (p) => p.date) as [Date, Date])
+      .range([0, W]);
+
+    // Always include zero: premium vs discount is the meaningful boundary.
+    const lo = Math.min(0, d3.min(points, (p) => p.pct) ?? 0);
+    const hi = Math.max(0, d3.max(points, (p) => p.pct) ?? 0);
+    const pad = (hi - lo) * 0.1 || 1;
+    const yScale = d3.scaleLinear().domain([lo - pad, hi + pad]).range([H, 0]);
+
+    const g = svg
+      .attr('width', width)
+      .attr('height', height)
+      .append('g')
+      .attr('transform', `translate(${MARGIN.left},${MARGIN.top})`);
+
+    // Parity line — above it the vehicle trades at a premium.
+    g.append('line')
+      .attr('x1', 0)
+      .attr('x2', W)
+      .attr('y1', yScale(0))
+      .attr('y2', yScale(0))
+      .attr('stroke', muted)
+      .attr('stroke-width', 1)
+      .attr('stroke-dasharray', '4,3')
+      .attr('opacity', 0.8);
+
+    g.append('path')
+      .datum(points)
+      .attr('fill', 'none')
+      .attr('stroke', theme.palette.primary.main)
+      .attr('stroke-width', 1.5)
+      .attr(
+        'd',
+        d3
+          .line<{ date: Date; pct: number }>()
+          .x((p) => xScale(p.date))
+          .y((p) => yScale(p.pct))
+          .curve(d3.curveMonotoneX),
+      );
+
+    const last = points[points.length - 1];
+    g.append('circle')
+      .attr('cx', xScale(last.date))
+      .attr('cy', yScale(last.pct))
+      .attr('r', 4)
+      .attr('fill', theme.palette.secondary.main);
+
+    g.append('g')
+      .attr('transform', `translate(0,${H})`)
+      .call(d3.axisBottom(xScale).ticks(5).tickFormat(d3.timeFormat('%b %d') as never))
+      .attr('color', muted)
+      .attr('font-size', 9);
+
+    g.append('g')
+      .call(d3.axisLeft(yScale).ticks(4).tickFormat((v) => `${v}%`))
+      .attr('color', muted)
+      .attr('font-size', 9);
+  }, [data, height, theme]);
+
+  if (data.points.length === 0) {
+    return (
+      <Typography variant="body2" color="text.secondary">
+        No premium history for {data.security}.
+      </Typography>
+    );
+  }
+
+  return (
+    <Box>
+      <Stack direction="row" spacing={2} alignItems="baseline" sx={{ mb: 0.5 }}>
+        <Typography variant="subtitle2">
+          {data.security} discount to NAV
+        </Typography>
+        <Typography variant="caption" color="text.secondary">
+          latest{' '}
+          {data.latest ? `${data.latest.premium_discount_pct.toFixed(2)}%` : '—'}
+        </Typography>
+      </Stack>
+      <svg ref={ref} data-testid="premium-chart" />
+      <Alert severity="info" icon={false} sx={{ mt: 1, py: 0, fontSize: 12 }}>
+        {data.note}
+      </Alert>
+    </Box>
+  );
+}

--- a/frontend/src/components/arbitrage/ScanTable.test.tsx
+++ b/frontend/src/components/arbitrage/ScanTable.test.tsx
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen } from '@testing-library/react';
+
+import ScanTable from './ScanTable';
+import { renderWithProviders } from '../../testUtils';
+import type { ScanRow } from '../../api/arbitrage';
+
+function row(overrides: Partial<ScanRow> = {}): ScanRow {
+  return {
+    security: 'MSTR',
+    name: 'Strategy',
+    kind: 'nav_vehicle',
+    underlying: 'BTC-USD',
+    score: 9.7,
+    verdict: 'reject',
+    basis: 'nav_discount',
+    discount_pct: -16.92,
+    spread_zscore: -1.35,
+    half_life_days: 66.4,
+    cointegrated: false,
+    convergence: 'buyback',
+    hedge_instrument: 'IBIT',
+    hedge_available: true,
+    breaks_on: ['Negative carry (senior claims serviced out of NAV)'],
+    ...overrides,
+  };
+}
+
+describe('ScanTable', () => {
+  it('renders score, verdict and the net discount', () => {
+    renderWithProviders(<ScanTable rows={[row()]} />);
+    expect(screen.getByText('MSTR')).toBeInTheDocument();
+    expect(screen.getByText('9.7')).toBeInTheDocument();
+    expect(screen.getByText('reject')).toBeInTheDocument();
+    expect(screen.getByText('-16.92%')).toBeInTheDocument();
+    expect(screen.getByText('nav vehicle')).toBeInTheDocument();
+  });
+
+  it('marks an unhedgeable leg instead of naming a futures contract', () => {
+    renderWithProviders(
+      <ScanTable
+        rows={[row({ security: 'GLD', hedge_available: false, hedge_instrument: null })]}
+      />,
+    );
+    expect(screen.getByText('futures only')).toBeInTheDocument();
+  });
+
+  it('shows the first risk with an overflow count', () => {
+    renderWithProviders(
+      <ScanTable rows={[row({ breaks_on: ['Negative carry', 'Spread trending wider'] })]} />,
+    );
+    expect(screen.getByText('Negative carry')).toBeInTheDocument();
+    expect(screen.getByText('+1')).toBeInTheDocument();
+  });
+
+  it('dashes out a row with no discount and no risks', () => {
+    renderWithProviders(
+      <ScanTable rows={[row({ discount_pct: null, breaks_on: [], score: null })]} />,
+    );
+    expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('reports the clicked security', () => {
+    const onSelect = vi.fn();
+    renderWithProviders(<ScanTable rows={[row()]} onSelect={onSelect} />);
+    fireEvent.click(screen.getByText('MSTR'));
+    expect(onSelect).toHaveBeenCalledWith('MSTR');
+  });
+
+  it('is inert without a select handler', () => {
+    renderWithProviders(<ScanTable rows={[row()]} />);
+    fireEvent.click(screen.getByText('MSTR'));
+    expect(screen.getByText('MSTR')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/arbitrage/ScanTable.tsx
+++ b/frontend/src/components/arbitrage/ScanTable.tsx
@@ -1,0 +1,106 @@
+/**
+ * ScanTable — the ranked scan, one row per curated pair.
+ *
+ * Columns are chosen so a `reject` is legible at a glance: the score alone
+ * says little, but score + convergence + hedgeability + what breaks it says
+ * why. `discount_pct` is the NET figure; the gross number never reaches this
+ * projection.
+ */
+import { Box, Chip, Stack, Tooltip, Typography } from '@mui/material';
+import { DataGrid, GridColDef, GridRenderCellParams } from '@mui/x-data-grid';
+import type { ScanRow } from '../../api/arbitrage';
+
+const VERDICT_COLOR: Record<string, 'success' | 'warning' | 'default'> = {
+  candidate: 'success',
+  watch: 'warning',
+  reject: 'default',
+};
+
+interface Props {
+  rows: ScanRow[];
+  onSelect?: (security: string) => void;
+}
+
+export default function ScanTable({ rows, onSelect }: Props) {
+  const columns: GridColDef<ScanRow>[] = [
+    { field: 'security', headerName: 'Symbol', width: 90 },
+    { field: 'underlying', headerName: 'Underlying', width: 100 },
+    {
+      field: 'kind',
+      headerName: 'Family',
+      width: 130,
+      valueFormatter: (value: string) => value?.replace('_', ' '),
+    },
+    {
+      field: 'score',
+      headerName: 'Score',
+      width: 80,
+      type: 'number',
+      valueFormatter: (value: number | null) => (value == null ? '—' : value.toFixed(1)),
+    },
+    {
+      field: 'verdict',
+      headerName: 'Verdict',
+      width: 110,
+      renderCell: (p: GridRenderCellParams<ScanRow, string>) => (
+        <Chip size="small" label={p.value} color={VERDICT_COLOR[p.value ?? ''] ?? 'default'} />
+      ),
+    },
+    {
+      field: 'discount_pct',
+      headerName: 'Net discount',
+      width: 120,
+      type: 'number',
+      valueFormatter: (value: number | null) =>
+        value == null ? '—' : `${value.toFixed(2)}%`,
+    },
+    { field: 'convergence', headerName: 'Convergence', width: 130 },
+    {
+      field: 'hedge_available',
+      headerName: 'Hedge',
+      width: 120,
+      renderCell: (p: GridRenderCellParams<ScanRow, boolean>) =>
+        p.value ? (
+          <Typography variant="body2">{p.row.hedge_instrument ?? '—'}</Typography>
+        ) : (
+          <Chip size="small" label="futures only" color="warning" variant="outlined" />
+        ),
+    },
+    {
+      field: 'breaks_on',
+      headerName: 'What breaks it',
+      flex: 1,
+      minWidth: 180,
+      sortable: false,
+      renderCell: (p: GridRenderCellParams<ScanRow, string[]>) => {
+        const risks = p.value ?? [];
+        if (risks.length === 0) return <Typography variant="body2">—</Typography>;
+        return (
+          <Tooltip title={risks.join(' · ')}>
+            <Stack direction="row" spacing={0.5} alignItems="center" sx={{ height: '100%' }}>
+              <Typography variant="caption" noWrap>
+                {risks[0]}
+              </Typography>
+              {risks.length > 1 && <Chip size="small" label={`+${risks.length - 1}`} />}
+            </Stack>
+          </Tooltip>
+        );
+      },
+    },
+  ];
+
+  return (
+    <Box data-testid="scan-table">
+      <DataGrid
+        rows={rows}
+        columns={columns}
+        getRowId={(row) => row.security}
+        autoHeight
+        disableRowSelectionOnClick
+        hideFooter={rows.length <= 25}
+        onRowClick={(params) => onSelect?.(String(params.id))}
+        sx={{ cursor: onSelect ? 'pointer' : 'default' }}
+      />
+    </Box>
+  );
+}

--- a/frontend/src/components/arbitrage/SpreadChart.test.tsx
+++ b/frontend/src/components/arbitrage/SpreadChart.test.tsx
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { screen } from '@testing-library/react';
+
+import SpreadChart from './SpreadChart';
+import { renderWithProviders } from '../../testUtils';
+import type { SpreadHistoryResponse } from '../../api/arbitrage';
+
+function spreadData(overrides: Partial<SpreadHistoryResponse> = {}): SpreadHistoryResponse {
+  const points = Array.from({ length: 60 }, (_, i) => ({
+    date: `2026-05-${String((i % 28) + 1).padStart(2, '0')}`,
+    spread: Math.sin(i / 6) * 0.1,
+  }));
+  return {
+    security: 'MSTR',
+    kind: 'nav_vehicle',
+    underlying: 'BTC-USD',
+    points,
+    mean: 0,
+    std: 0.12,
+    bands: { plus_one: 0.12, minus_one: -0.12, plus_two: 0.24, minus_two: -0.24 },
+    latest: { date: '2026-05-28', spread: -0.1686, z: -1.35 },
+    hedge_ratio: { beta: 1.44, alpha: 0.1 },
+    half_life: { half_life_days: 66.4 },
+    cointegration: { cointegrated: false, statistic: -2.87 },
+    trend: { slope_per_day: -0.0001, intercept: 0.013, slope_tstat: -1.0, widening: false },
+    ...overrides,
+  };
+}
+
+describe('SpreadChart', () => {
+  it('renders the pair heading and the latest z-score', () => {
+    renderWithProviders(<SpreadChart data={spreadData()} />);
+    expect(screen.getByText('MSTR − BTC-USD spread')).toBeInTheDocument();
+    expect(screen.getByText(/latest -1\.35σ/)).toBeInTheDocument();
+  });
+
+  it('draws the series, bands and trend line', () => {
+    const { container } = renderWithProviders(<SpreadChart data={spreadData()} />);
+    const svg = container.querySelector('[data-testid="spread-chart"]')!;
+    // Scoped by class: d3 axes emit their own <line> elements for tick marks.
+    expect(svg.querySelectorAll('line.level-line')).toHaveLength(3); // ±2σ, mean
+    expect(svg.querySelectorAll('line.trend-line')).toHaveLength(1);
+    expect(svg.querySelectorAll('path').length).toBeGreaterThan(0);
+    // Latest point marker.
+    expect(svg.querySelectorAll('circle').length).toBe(1);
+    expect(svg.textContent).toContain('+2σ');
+    expect(svg.textContent).toContain('mean');
+  });
+
+  it('reports half-life when the spread reverts', () => {
+    renderWithProviders(<SpreadChart data={spreadData()} />);
+    expect(screen.getByText(/half-life 66\.4d/)).toBeInTheDocument();
+  });
+
+  it('flags a widening spread in the caption', () => {
+    renderWithProviders(
+      <SpreadChart
+        data={spreadData({
+          trend: { slope_per_day: -0.01, intercept: 0.2, slope_tstat: -9, widening: true },
+        })}
+      />,
+    );
+    expect(screen.getByText(/widening/)).toBeInTheDocument();
+  });
+
+  it('degrades to a message when there are no points', () => {
+    renderWithProviders(<SpreadChart data={spreadData({ points: [] })} />);
+    expect(screen.getByText(/No spread history for MSTR/)).toBeInTheDocument();
+  });
+
+  it('omits the trend line when the fit produced no intercept', () => {
+    const { container } = renderWithProviders(
+      <SpreadChart
+        data={spreadData({
+          trend: { slope_per_day: null, intercept: null, slope_tstat: null, widening: null },
+        })}
+      />,
+    );
+    const svg = container.querySelector('[data-testid="spread-chart"]')!;
+    expect(svg.querySelectorAll('line.trend-line')).toHaveLength(0);
+    expect(svg.querySelectorAll('line.level-line')).toHaveLength(3);
+  });
+});

--- a/frontend/src/components/arbitrage/SpreadChart.tsx
+++ b/frontend/src/components/arbitrage/SpreadChart.tsx
@@ -1,0 +1,165 @@
+/**
+ * SpreadChart — the residual spread over time with its mean, ±1σ/±2σ bands,
+ * fitted trend line, and the latest point called out.
+ *
+ * This is the object every arbitrage number describes and the one thing that
+ * was never visible: `analyze_pair` computes the series and discards it. A
+ * z-score of −1.35 tells you the gap is stretched; this shows whether it has
+ * been oscillating around the mean or walking away from it.
+ *
+ * All levels arrive precomputed from the service (arch-v2 Rule 8) — this file
+ * scales and draws, it never derives a statistic.
+ */
+import { useEffect, useRef } from 'react';
+import * as d3 from 'd3';
+import { Box, Stack, Typography, useTheme } from '@mui/material';
+import type { SpreadHistoryResponse } from '../../api/arbitrage';
+
+interface Props {
+  data: SpreadHistoryResponse;
+  height?: number;
+}
+
+const MARGIN = { top: 14, right: 58, bottom: 26, left: 52 };
+
+export default function SpreadChart({ data, height = 240 }: Props) {
+  const ref = useRef<SVGSVGElement>(null);
+  const theme = useTheme();
+
+  useEffect(() => {
+    if (!ref.current || data.points.length === 0) return;
+    const svg = d3.select(ref.current);
+    svg.selectAll('*').remove();
+
+    const width = ref.current.parentElement?.clientWidth || 640;
+    const W = Math.max(120, width - MARGIN.left - MARGIN.right);
+    const H = height - MARGIN.top - MARGIN.bottom;
+    const muted = theme.palette.text.secondary;
+
+    const points = data.points.map((p) => ({ date: new Date(p.date), spread: p.spread }));
+    const { bands, mean } = data;
+
+    const xScale = d3
+      .scaleTime()
+      .domain(d3.extent(points, (p) => p.date) as [Date, Date])
+      .range([0, W]);
+
+    // Domain spans the data AND the outer bands so a 2σ line is never clipped.
+    const lo = Math.min(d3.min(points, (p) => p.spread) ?? 0, bands.minus_two);
+    const hi = Math.max(d3.max(points, (p) => p.spread) ?? 0, bands.plus_two);
+    const pad = (hi - lo) * 0.08 || 0.01;
+    const yScale = d3.scaleLinear().domain([lo - pad, hi + pad]).range([H, 0]);
+
+    const g = svg
+      .attr('width', width)
+      .attr('height', height)
+      .append('g')
+      .attr('transform', `translate(${MARGIN.left},${MARGIN.top})`);
+
+    // ±1σ shaded channel, then the ±2σ outer lines.
+    g.append('rect')
+      .attr('x', 0)
+      .attr('y', yScale(bands.plus_one))
+      .attr('width', W)
+      .attr('height', Math.max(0, yScale(bands.minus_one) - yScale(bands.plus_one)))
+      .attr('fill', theme.palette.primary.main)
+      .attr('fill-opacity', 0.07);
+
+    const level = (value: number, label: string, dash: string, colour: string) => {
+      g.append('line')
+        .attr('class', 'level-line')
+        .attr('x1', 0)
+        .attr('x2', W)
+        .attr('y1', yScale(value))
+        .attr('y2', yScale(value))
+        .attr('stroke', colour)
+        .attr('stroke-width', 1)
+        .attr('stroke-dasharray', dash)
+        .attr('opacity', 0.7);
+      g.append('text')
+        .attr('x', W + 4)
+        .attr('y', yScale(value))
+        .attr('dy', '0.35em')
+        .attr('fill', muted)
+        .attr('font-size', 9)
+        .text(label);
+    };
+
+    level(bands.plus_two, '+2σ', '2,3', theme.palette.warning.main);
+    level(bands.minus_two, '−2σ', '2,3', theme.palette.warning.main);
+    level(mean, 'mean', '4,3', muted);
+
+    // Fitted trend: y = intercept + slope * barIndex (both from the service).
+    const { intercept, slope_per_day: slope } = data.trend;
+    if (intercept != null && slope != null) {
+      g.append('line')
+        .attr('class', 'trend-line')
+        .attr('x1', xScale(points[0].date))
+        .attr('x2', xScale(points[points.length - 1].date))
+        .attr('y1', yScale(intercept))
+        .attr('y2', yScale(intercept + slope * (points.length - 1)))
+        .attr('stroke', data.trend.widening ? theme.palette.error.main : muted)
+        .attr('stroke-width', 1.5)
+        .attr('stroke-dasharray', '6,4')
+        .attr('opacity', 0.8);
+    }
+
+    g.append('path')
+      .datum(points)
+      .attr('fill', 'none')
+      .attr('stroke', theme.palette.primary.main)
+      .attr('stroke-width', 1.5)
+      .attr(
+        'd',
+        d3
+          .line<{ date: Date; spread: number }>()
+          .x((p) => xScale(p.date))
+          .y((p) => yScale(p.spread))
+          .curve(d3.curveMonotoneX),
+      );
+
+    const last = points[points.length - 1];
+    g.append('circle')
+      .attr('cx', xScale(last.date))
+      .attr('cy', yScale(last.spread))
+      .attr('r', 4)
+      .attr('fill', theme.palette.secondary.main);
+
+    g.append('g')
+      .attr('transform', `translate(0,${H})`)
+      .call(d3.axisBottom(xScale).ticks(5).tickFormat(d3.timeFormat('%b %d') as never))
+      .attr('color', muted)
+      .attr('font-size', 9);
+
+    g.append('g')
+      .call(d3.axisLeft(yScale).ticks(4))
+      .attr('color', muted)
+      .attr('font-size', 9);
+  }, [data, height, theme]);
+
+  if (data.points.length === 0) {
+    return (
+      <Typography variant="body2" color="text.secondary">
+        No spread history for {data.security}.
+      </Typography>
+    );
+  }
+
+  return (
+    <Box>
+      <Stack direction="row" spacing={2} alignItems="baseline" sx={{ mb: 0.5 }}>
+        <Typography variant="subtitle2">
+          {data.security} − {data.underlying} spread
+        </Typography>
+        <Typography variant="caption" color="text.secondary">
+          latest {data.latest.z == null ? '—' : `${data.latest.z.toFixed(2)}σ`}
+          {data.trend.widening ? ' · widening' : ''}
+          {data.half_life.half_life_days != null
+            ? ` · half-life ${data.half_life.half_life_days.toFixed(1)}d`
+            : ''}
+        </Typography>
+      </Stack>
+      <svg ref={ref} data-testid="spread-chart" />
+    </Box>
+  );
+}

--- a/frontend/src/components/chat/ArbitrageChartCards.test.tsx
+++ b/frontend/src/components/chat/ArbitrageChartCards.test.tsx
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+
+import {
+  SpreadHistoryCard,
+  PremiumHistoryCard,
+  ArbScanCard,
+  DiscoveryCard,
+} from './ArbitrageChartCards';
+import { mockApi, renderWithProviders } from '../../testUtils';
+
+afterEach(() => vi.unstubAllGlobals());
+
+const SPREAD = {
+  security: 'MSTR', kind: 'nav_vehicle', underlying: 'BTC-USD',
+  points: [{ date: '2026-05-01', spread: 0.1 }, { date: '2026-05-02', spread: -0.1 }],
+  mean: 0, std: 0.12,
+  bands: { plus_one: 0.12, minus_one: -0.12, plus_two: 0.24, minus_two: -0.24 },
+  latest: { date: '2026-05-02', spread: -0.1, z: -0.8 },
+  hedge_ratio: { beta: 1.4, alpha: 0.1 },
+  half_life: { half_life_days: 20 },
+  cointegration: { cointegrated: false, statistic: -2.8 },
+  trend: { slope_per_day: -0.001, intercept: 0.05, slope_tstat: -1, widening: false },
+};
+
+describe('SpreadHistoryCard', () => {
+  it('fetches and renders the chart from a ticker alone', async () => {
+    mockApi([['/spread-history', SPREAD]]);
+    renderWithProviders(<SpreadHistoryCard ticker="MSTR" />);
+    expect(screen.getByText(/Loading MSTR spread history/i)).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByTestId('spread-chart')).toBeInTheDocument());
+  });
+
+  it('shows an error alert when the request fails', async () => {
+    mockApi([['/spread-history', () => ({ __status: 500, error: 'boom' })]]);
+    renderWithProviders(<SpreadHistoryCard ticker="MSTR" />);
+    await waitFor(() =>
+      expect(screen.getByText(/Couldn't load MSTR spread history/i)).toBeInTheDocument(),
+    );
+  });
+
+  it('passes a structured service refusal through as guidance', async () => {
+    mockApi([['/spread-history', { security: 'ZZ', error: 'ZZ is not in the curated universe.' }]]);
+    renderWithProviders(<SpreadHistoryCard ticker="ZZ" />);
+    await waitFor(() =>
+      expect(screen.getByText(/not in the curated universe/i)).toBeInTheDocument(),
+    );
+  });
+});
+
+describe('PremiumHistoryCard', () => {
+  it('renders the premium chart with its caveat', async () => {
+    mockApi([
+      ['/premium-history', {
+        security: 'MSTR', underlying: 'BTC-USD',
+        points: [{ date: '2026-05-01', premium_discount_pct: -12, nav_per_share: 110, price: 96 }],
+        latest: { date: '2026-05-01', premium_discount_pct: -12, nav_per_share: 110, price: 96 },
+        method: 'current_capital_structure',
+        note: 'Approximation: today’s holdings applied to past prices.',
+      }],
+    ]);
+    renderWithProviders(<PremiumHistoryCard ticker="MSTR" />);
+    await waitFor(() => expect(screen.getByTestId('premium-chart')).toBeInTheDocument());
+    expect(screen.getByText(/Approximation/)).toBeInTheDocument();
+  });
+
+  it('explains why a non-NAV security has no premium chart', async () => {
+    // Routine for producers/ETFs — the service reason beats a generic failure.
+    mockApi([['/premium-history', {
+      security: 'GDX', kind: 'producer',
+      error: 'GDX is a producer, not a NAV vehicle — there is no net asset value.',
+    }]]);
+    renderWithProviders(<PremiumHistoryCard ticker="GDX" />);
+    await waitFor(() =>
+      expect(screen.getByText(/not a NAV vehicle/i)).toBeInTheDocument(),
+    );
+  });
+});
+
+describe('ArbScanCard', () => {
+  it('renders the scan table', async () => {
+    mockApi([['/api/arbitrage/scan', {
+      scanned: 1, returned: 1, errors: [],
+      candidates: [{
+        security: 'MSTR', kind: 'nav_vehicle', underlying: 'BTC-USD', score: 9.7,
+        verdict: 'reject', basis: 'nav_discount', discount_pct: -16.92,
+        spread_zscore: -1.35, half_life_days: 66.4, cointegrated: false,
+        convergence: 'buyback', hedge_instrument: 'IBIT', hedge_available: true,
+        breaks_on: [],
+      }],
+    }]]);
+    renderWithProviders(<ArbScanCard />);
+    expect(screen.getByText(/Scanning the curated universe/i)).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByTestId('scan-table')).toBeInTheDocument());
+    expect(screen.getByText('MSTR')).toBeInTheDocument();
+  });
+});
+
+describe('DiscoveryCard', () => {
+  it('plots the tested pairs from a symbols string', async () => {
+    mockApi([['/api/arbitrage/discover', {
+      count: 0, pairs: [], skipped: [], references: ['GC=F'],
+      tested: [{
+        security: 'NEM', underlying: 'GC=F', economic_link: true, correlation: 0.73,
+        statistic: -2.87, reject_at: null, half_life_days: 6.4, passed: false,
+        failed_because: 'not cointegrated',
+      }],
+      critical_values: { '0.05': -3.34 },
+    }]]);
+    renderWithProviders(<DiscoveryCard symbols="NEM" />);
+    await waitFor(() => expect(screen.getByTestId('discovery-scatter')).toBeInTheDocument());
+    expect(screen.getByText(/0 of 1 pairs passed/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/chat/ArbitrageChartCards.tsx
+++ b/frontend/src/components/chat/ArbitrageChartCards.tsx
@@ -1,0 +1,68 @@
+/**
+ * Self-fetching chat wrappers for the arbitrage visuals.
+ *
+ * The registry needs components that render from scalar props alone, while the
+ * charts themselves take fetched data — these adapt one to the other, exactly
+ * as PriceChartCard does for PriceChart. Keeping all four together makes the
+ * shared loading/error shape obvious and hard to diverge.
+ */
+import { Alert, Box, CircularProgress, Typography } from '@mui/material';
+import SpreadChart from '../arbitrage/SpreadChart';
+import PremiumChart from '../arbitrage/PremiumChart';
+import ScanTable from '../arbitrage/ScanTable';
+import DiscoveryScatter from '../arbitrage/DiscoveryScatter';
+import {
+  useSpreadHistory,
+  usePremiumHistory,
+  useArbitrageScan,
+  useDiscovery,
+} from '../../hooks/useArbitrage';
+
+function Loading({ label }: { label: string }) {
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 2 }}>
+      <CircularProgress size={18} />
+      <Typography variant="body2" color="text.secondary">
+        {label}
+      </Typography>
+    </Box>
+  );
+}
+
+export function SpreadHistoryCard({ ticker }: { ticker: string }) {
+  const { data, isLoading, error } = useSpreadHistory(ticker);
+  if (isLoading) return <Loading label={`Loading ${ticker} spread history…`} />;
+  if (error) return <Alert severity="error">Couldn&apos;t load {ticker} spread history.</Alert>;
+  if (!data) return null;
+  if (data.error) return <Alert severity="info">{data.error}</Alert>;
+  return <SpreadChart data={data} />;
+}
+
+export function PremiumHistoryCard({ ticker }: { ticker: string }) {
+  const { data, isLoading, error } = usePremiumHistory(ticker);
+  if (isLoading) return <Loading label={`Loading ${ticker} NAV premium history…`} />;
+  if (error) return <Alert severity="error">Couldn&apos;t load {ticker} premium history.</Alert>;
+  if (!data) return null;
+  // Non-NAV securities land here routinely — the service explains why, and
+  // that explanation is more useful than a generic failure.
+  if (data.error) return <Alert severity="info">{data.error}</Alert>;
+  return <PremiumChart data={data} />;
+}
+
+export function ArbScanCard() {
+  const { data, isLoading, error } = useArbitrageScan();
+  if (isLoading) return <Loading label="Scanning the curated universe…" />;
+  if (error) return <Alert severity="error">Couldn&apos;t run the arbitrage scan.</Alert>;
+  if (!data) return null;
+  return <ScanTable rows={data.candidates} />;
+}
+
+export function DiscoveryCard({ symbols }: { symbols: string }) {
+  const { data, isLoading, error } = useDiscovery(symbols, true);
+  if (isLoading) return <Loading label={`Sweeping ${symbols} against the panel…`} />;
+  if (error) return <Alert severity="error">Couldn&apos;t run the discovery sweep.</Alert>;
+  if (!data) return null;
+  return (
+    <DiscoveryScatter tested={data.tested ?? []} criticalValues={data.critical_values} />
+  );
+}

--- a/frontend/src/hooks/useArbitrage.ts
+++ b/frontend/src/hooks/useArbitrage.ts
@@ -11,3 +11,43 @@ export function useArbitragePair(security: string, days = 365) {
     staleTime: 10 * 60 * 1000,
   });
 }
+
+export function useSpreadHistory(security: string, days = 365) {
+  return useQuery({
+    queryKey: ['arbitrage-spread', security, days],
+    queryFn: () => arbitrageApi.getSpreadHistory(security, days),
+    enabled: !!security,
+    staleTime: 10 * 60 * 1000,
+  });
+}
+
+export function usePremiumHistory(security: string, days = 365) {
+  return useQuery({
+    queryKey: ['arbitrage-premium', security, days],
+    queryFn: () => arbitrageApi.getPremiumHistory(security, days),
+    enabled: !!security,
+    staleTime: 10 * 60 * 1000,
+  });
+}
+
+export function useArbitrageScan(topN = 20, days = 365) {
+  return useQuery({
+    queryKey: ['arbitrage-scan', topN, days],
+    queryFn: () => arbitrageApi.scan(topN, days),
+    // A cold scan is ten full pair workups — tens of seconds. Cache it hard;
+    // the underlying data is daily bars, so a stale window costs nothing.
+    staleTime: 30 * 60 * 1000,
+    retry: false,
+  });
+}
+
+/** Discovery is explicitly user-triggered — `enabled` gates the sweep. */
+export function useDiscovery(symbols: string, enabled: boolean, requireLink = true) {
+  return useQuery({
+    queryKey: ['arbitrage-discovery', symbols, requireLink],
+    queryFn: () => arbitrageApi.discover(symbols, requireLink),
+    enabled: enabled && !!symbols.trim(),
+    staleTime: 30 * 60 * 1000,
+    retry: false,
+  });
+}

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -25,14 +25,14 @@ export default defineConfig({
       // Ratchet floors: pinned ~1pt under the measured baseline; only ever
       // raised (see deploy.yml frontend-gate). Not aspirations — regressions.
       thresholds: {
-        // Measured 2026-07-26 after the statements/functions campaign:
-        // lines 88.4, statements 86.6, funcs 85.7, branches 69.4.
-        // (Previous baseline 2026-07-24: 85.4 / 83.4 / 78.7 / 65.8.)
+        // Measured 2026-07-27 after the arbitrage visualization suite:
+        // lines 89.2, statements 87.4, funcs 86.8, branches 70.5.
+        // (Previous 2026-07-26: 88.4 / 86.6 / 85.7 / 69.4.)
         // Floors pinned ~1pt under; ratchet only up.
-        lines: 87,
-        statements: 85,
-        functions: 84,
-        branches: 68,
+        lines: 88,
+        statements: 86,
+        functions: 85,
+        branches: 69,
       },
     },
   },

--- a/quantcore/analytics/nav.py
+++ b/quantcore/analytics/nav.py
@@ -146,6 +146,43 @@ def exposure_ratio(gross_nav_value: float, market_cap: float) -> Optional[float]
     return _clean(gross / cap)
 
 
+def premium_history(prices, spots, units: float, diluted_shares: float,
+                    senior_claims: float = 0.0,
+                    other_assets: float = 0.0) -> list[dict]:
+    """Per-date premium/discount series from aligned price and spot sequences.
+
+    ``prices`` and ``spots`` are parallel sequences of (date, value) pairs — the
+    caller aligns them; this function only does arithmetic, and reuses
+    ``net_nav_per_share``/``premium_discount`` so a historical point can never
+    drift from what the point-in-time workup would report.
+
+    IMPORTANT — the capital structure is treated as CONSTANT across the whole
+    series, because a single holdings snapshot is all that is usually
+    available. Every point therefore answers "what would the discount have been
+    on that date, if the entity had held today's units against today's senior
+    claims", which is an approximation, not history. Callers must label it as
+    such; ``ArbitrageService.get_premium_history`` carries a ``method`` field
+    and a note for exactly this reason.
+
+    Dates whose inputs are unusable (non-positive spot, insolvent structure)
+    are dropped rather than emitted as null holes.
+    """
+    out: list[dict] = []
+    for (date_str, price), (_, spot) in zip(prices, spots):
+        nav_ps = net_nav_per_share(units, spot, diluted_shares, senior_claims,
+                                   other_assets)
+        discount = premium_discount(price, nav_ps)
+        if discount is None:
+            continue
+        out.append({
+            "date": date_str,
+            "premium_discount_pct": discount,
+            "nav_per_share": nav_ps,
+            "price": _clean(price),
+        })
+    return out
+
+
 def analyze_nav_vehicle(price: float, units: float, spot: float,
                         diluted_shares: float, senior_claims: float = 0.0,
                         annual_senior_cost: float = 0.0,

--- a/quantcore/analytics/pairs.py
+++ b/quantcore/analytics/pairs.py
@@ -381,7 +381,7 @@ def spread_trend(spread) -> dict:
     s = pd.Series(spread).astype(float).replace([np.inf, -np.inf], np.nan).dropna()
     arr = np.asarray(s.values, dtype=float)
     empty = {"slope_per_day": None, "drift_total": None, "slope_tstat": None,
-             "widening": None, "n": int(arr.size)}
+             "intercept": None, "widening": None, "n": int(arr.size)}
     if arr.size < 10:
         return empty
 
@@ -398,6 +398,9 @@ def spread_trend(spread) -> dict:
         "slope_per_day": _clean(slope),
         "drift_total": _clean(slope * (arr.size - 1)),
         "slope_tstat": _clean(tstat),
+        # Fitted value at t=0, so a caller can draw the trend line without
+        # refitting: y = intercept + slope * bar_index.
+        "intercept": _clean(float(fit["beta"][0])),
         "widening": bool(significant and slope * deviation > 0),
         "n": int(arr.size),
     }

--- a/quantcore/services/arbitrage.py
+++ b/quantcore/services/arbitrage.py
@@ -273,21 +273,193 @@ class ArbitrageService:
         }
 
     # ------------------------------------------------------------------ #
+    # Chartable histories
+    # ------------------------------------------------------------------ #
+    def get_spread_history(self, security: str, underlying: Optional[str] = None,
+                           days: int = 365) -> dict:
+        """The spread series itself, with the bands and trend line to draw it.
+
+        ``analyze_pair`` computes this series and then discards it — a payload
+        of a thousand floats is noise to an LLM and a test pins that it never
+        leaks there. A chart is the one caller that genuinely needs it, so it
+        gets its own endpoint rather than fattening the workup.
+        """
+        security = (security or "").strip().upper()
+        if not security:
+            return {"error": "security is required"}
+
+        entry = self._repo.get_entry(security)
+        if entry is None:
+            if not underlying:
+                return {
+                    "security": security,
+                    "error": f"{security} is not in the curated universe and no "
+                             "underlying was supplied.",
+                    "hint": "Pass underlying= to chart an ad-hoc pair.",
+                }
+            resolved = underlying.strip()
+            kind = "producer"
+        else:
+            resolved = (underlying or entry["underlying"]).strip()
+            kind = entry["kind"]
+
+        sec_closes = self._closes(security, days)
+        und_closes = self._closes(resolved, days)
+        if sec_closes is None or und_closes is None:
+            missing = security if sec_closes is None else resolved
+            return {"security": security, "underlying": resolved,
+                    "error": f"No price history available for {missing}."}
+
+        ys, xs = pairs.align(sec_closes, und_closes)
+        hr = pairs.hedge_ratio(ys, xs)
+        if hr["beta"] is None:
+            return {"security": security, "underlying": resolved,
+                    "error": "Could not fit a hedge ratio for this pair."}
+
+        spread = pairs.spread_series(ys, xs, hr["beta"], hr["alpha"])
+        stats = pairs.zscore(spread)
+        mean = stats["mean"] or 0.0
+        std = stats["std"] or 0.0
+
+        points = [
+            {"date": pd.Timestamp(idx).date().isoformat(), "spread": _round(value, 6)}
+            for idx, value in spread.items()
+        ]
+        return {
+            "security": security,
+            "name": (entry or {}).get("name", security),
+            "kind": kind,
+            "underlying": resolved,
+            "points": points,
+            "mean": _round(mean, 6),
+            "std": _round(std, 6),
+            # Precomputed so the chart draws bands without doing arithmetic
+            # (arch-v2 Rule 8 — displayed math stays in the backend).
+            "bands": {
+                "plus_one": _round(mean + std, 6),
+                "minus_one": _round(mean - std, 6),
+                "plus_two": _round(mean + 2 * std, 6),
+                "minus_two": _round(mean - 2 * std, 6),
+            },
+            "latest": {
+                "date": points[-1]["date"] if points else None,
+                "spread": points[-1]["spread"] if points else None,
+                "z": stats["z"],
+            },
+            "hedge_ratio": hr,
+            "half_life": pairs.half_life(spread),
+            "cointegration": {
+                k: v for k, v in pairs.engle_granger(ys, xs).items() if k != "spread"
+            },
+            "trend": pairs.spread_trend(spread),
+        }
+
+    def get_premium_history(self, security: str, days: int = 365) -> dict:
+        """Discount-to-NAV over time for a NAV vehicle.
+
+        Only the current capital structure is known (one curated snapshot, or
+        the YAML bootstrap), so every point applies TODAY's holdings and senior
+        claims to that date's prices. That is an approximation, not history —
+        the payload says so in ``method`` and ``note``, and the chart is
+        required to show it. It converges on the truth as ``arb_nav_snapshots``
+        accumulates daily rows.
+        """
+        security = (security or "").strip().upper()
+        entry = self._repo.get_entry(security)
+        if entry is None:
+            return {"security": security,
+                    "error": f"{security} is not in the curated universe."}
+        if entry["kind"] != "nav_vehicle":
+            return {
+                "security": security,
+                "kind": entry["kind"],
+                "error": f"{security} is a {entry['kind']}, not a NAV vehicle — "
+                         "there is no net asset value to discount against.",
+            }
+
+        snapshot = None
+        try:
+            snapshot = self._repo.latest_nav_snapshot(security)
+        except Exception:
+            snapshot = None
+        source = snapshot or {}
+        units = source.get("units") or entry.get("holdings_units")
+        as_of = source.get("as_of") or entry.get("holdings_as_of")
+        senior = source.get("senior_claims", entry.get("senior_claims_usd")) or 0.0
+        other = source.get("other_assets", entry.get("other_assets_usd")) or 0.0
+        shares = source.get("diluted_shares") or entry.get("diluted_shares")
+        if shares is None:
+            shares = self._shares_outstanding(security)
+        if not units or not shares:
+            return {
+                "security": security,
+                "error": "No curated holdings or share count — add "
+                         "holdings_units and diluted_shares to arb_universe.yaml, "
+                         "or record a NAV snapshot.",
+                "holdings_as_of": as_of,
+            }
+
+        sec_closes = self._closes(security, days)
+        und_closes = self._closes(entry["underlying"], days)
+        if sec_closes is None or und_closes is None:
+            missing = security if sec_closes is None else entry["underlying"]
+            return {"security": security,
+                    "error": f"No price history available for {missing}."}
+
+        ys, xs = pairs.align(sec_closes, und_closes)
+        dated = [(pd.Timestamp(i).date().isoformat(), float(v)) for i, v in ys.items()]
+        spots = [(pd.Timestamp(i).date().isoformat(), float(v)) for i, v in xs.items()]
+        series = nav_math.premium_history(
+            prices=dated, spots=spots, units=float(units),
+            diluted_shares=float(shares), senior_claims=float(senior),
+            other_assets=float(other),
+        )
+        age = self._age_days(as_of, datetime.date.today())
+        return {
+            "security": security,
+            "name": entry.get("name", security),
+            "underlying": entry["underlying"],
+            "points": series,
+            "latest": series[-1] if series else None,
+            "units": float(units),
+            "diluted_shares": float(shares),
+            "senior_claims": float(senior),
+            "holdings_as_of": as_of,
+            "holdings_age_days": age,
+            "holdings_stale": age is not None and age > STALE_HOLDINGS_DAYS,
+            "method": "current_capital_structure",
+            "note": (
+                "Approximation: today's holdings and senior claims are applied to "
+                "past prices, so this is not a record of the discount as it stood. "
+                "It becomes exact as daily NAV snapshots accumulate."
+            ),
+        }
+
+    # ------------------------------------------------------------------ #
     # Statistical discovery
     # ------------------------------------------------------------------ #
     def discover_pairs(self, symbols: list[str],
                        references: Optional[list[str]] = None,
                        days: int = 365, min_abs_correlation: float = 0.4,
-                       require_economic_link: bool = True) -> dict:
+                       require_economic_link: bool = True,
+                       include_all: bool = False) -> dict:
         """Sweep symbols against commodity/crypto/FX references for cointegration.
 
         The economic-link gate is not optional decoration: over a wide enough
         sweep, cointegration tests will find statistically significant pairs
         with no causal relationship at all. Candidates whose sector/industry
         does not plausibly connect to the reference are dropped by default.
+
+        ``include_all`` additionally returns every pair that was *tested*, each
+        carrying ``passed`` and the reason it failed. A bare pass/fail list
+        hides the near-misses, and those are the interesting cases: NEM vs gold
+        correlates 0.73 with a 6.4-day half-life and still fails, its
+        Engle-Granger statistic landing 0.17 short of the loosest critical
+        value. ``pairs`` stays passes-only either way, so existing callers are
+        unaffected.
         """
         refs = [r.strip() for r in (references or list(REFERENCE_PANEL))]
-        found, skipped = [], []
+        found, skipped, tested = [], [], []
 
         ref_closes: dict[str, pd.Series] = {}
         for ref in refs:
@@ -308,13 +480,26 @@ class ArbitrageService:
             for ref, ref_series in ref_closes.items():
                 linked = self._economic_link(ref, profile)
                 if require_economic_link and not linked:
+                    if include_all:
+                        tested.append(self._tested_row(
+                            symbol, ref, linked, None, "no economic link"))
                     continue
                 stats = pairs.analyze_pair(sec_closes, ref_series)
                 corr = stats.get("correlation")
+                cointegrated = stats["cointegration"]["cointegrated"]
                 if corr is None or abs(corr) < min_abs_correlation:
+                    if include_all:
+                        tested.append(self._tested_row(
+                            symbol, ref, linked, stats,
+                            f"correlation below the {min_abs_correlation} floor"))
                     continue
-                if not stats["cointegration"]["cointegrated"]:
+                if not cointegrated:
+                    if include_all:
+                        tested.append(self._tested_row(
+                            symbol, ref, linked, stats, "not cointegrated"))
                     continue
+                if include_all:
+                    tested.append(self._tested_row(symbol, ref, linked, stats, None))
                 found.append({
                     "security": symbol,
                     "underlying": ref,
@@ -330,8 +515,33 @@ class ArbitrageService:
                 })
 
         found.sort(key=lambda f: abs(f["zscore"] or 0), reverse=True)
-        return {"count": len(found), "pairs": found, "skipped": skipped,
-                "references": list(ref_closes)}
+        result = {"count": len(found), "pairs": found, "skipped": skipped,
+                  "references": list(ref_closes)}
+        if include_all:
+            # Most negative statistic first — the order a reader scans for
+            # near-misses against the critical value.
+            tested.sort(key=lambda t: (t["statistic"] is None,
+                                       t["statistic"] if t["statistic"] is not None else 0))
+            result["tested"] = tested
+            result["critical_values"] = dict(pairs._EG_CRIT_2VAR)
+        return result
+
+    @staticmethod
+    def _tested_row(symbol: str, reference: str, linked: bool,
+                    stats: Optional[dict], failed_because: Optional[str]) -> dict:
+        """One row of the include_all sweep: what was measured and why it fell out."""
+        coint = (stats or {}).get("cointegration") or {}
+        return {
+            "security": symbol,
+            "underlying": reference,
+            "economic_link": linked,
+            "correlation": (stats or {}).get("correlation"),
+            "statistic": coint.get("statistic"),
+            "reject_at": coint.get("reject_at"),
+            "half_life_days": ((stats or {}).get("half_life") or {}).get("half_life_days"),
+            "passed": failed_because is None,
+            "failed_because": failed_because,
+        }
 
     def _sector_text(self, symbol: str) -> str:
         try:

--- a/quantcore/services/chat_tools.py
+++ b/quantcore/services/chat_tools.py
@@ -30,6 +30,11 @@ BACKEND_COMPONENT_REGISTRY: dict[str, dict[str, object]] = {
     # `underlying`) have no card — every prop here is required, so there is no
     # way to make `underlying` optional without weakening the validator.
     "arbitrage_pair": {"ticker": str},
+    "arbitrage_spread": {"ticker": str},
+    "arbitrage_premium": {"ticker": str},
+    # No props: the scan covers the whole curated universe.
+    "arbitrage_scan": {},
+    "arbitrage_discovery": {"symbols": str},
 }
 
 
@@ -344,7 +349,17 @@ TOOL_SCHEMAS: list[dict] = [
             "'arbitrage_pair' shows the structural-spread card for a curated "
             "pair: net discount, the score's factor breakdown, and what breaks "
             "the trade (requires ticker; curated securities only — check "
-            "list_arbitrage_universe if unsure)."
+            "list_arbitrage_universe if unsure), "
+            "'arbitrage_spread' charts that pair's spread over time with its "
+            "mean and standard-deviation bands, so the user can see how "
+            "stretched it is rather than reading a z-score (requires ticker), "
+            "'arbitrage_premium' charts a NAV vehicle's discount to net asset "
+            "value over time (requires ticker; nav_vehicle securities only), "
+            "'arbitrage_scan' shows the ranked scan table for the whole curated "
+            "universe (no props), "
+            "'arbitrage_discovery' plots a cointegration sweep — correlation "
+            "against test statistic, with near-misses visible against the "
+            "critical-value line (requires symbols, comma-separated)."
         ),
         "input_schema": {
             "type": "object",
@@ -375,8 +390,20 @@ TOOL_SCHEMAS: list[dict] = [
                             "enum": ["call", "put"],
                             "description": "spread_payoff only: option type",
                         },
+                        "symbols": {
+                            "type": "string",
+                            "description": (
+                                "arbitrage_discovery only: comma-separated "
+                                "tickers to sweep"
+                            ),
+                        },
                     },
-                    "required": ["ticker"],
+                    # No schema-level required list: which props are mandatory
+                    # depends on the component (arbitrage_scan takes none,
+                    # arbitrage_discovery takes symbols rather than ticker), and
+                    # JSON Schema cannot express that without oneOf. The
+                    # per-component registry is the enforcement point and
+                    # rejects both missing and extra props.
                 },
             },
             "required": ["component", "props"],

--- a/tests/test_arbitrage_api.py
+++ b/tests/test_arbitrage_api.py
@@ -109,6 +109,31 @@ class ArbitrageRouterTest(unittest.TestCase):
         resp = self.client.get("/api/arbitrage/discover")
         self.assertEqual(resp.status_code, 422)
 
+    def test_spread_history_route_uppercases_and_forwards(self):
+        resp = self.client.get(
+            "/api/arbitrage/pairs/mstr/spread-history?underlying=BTC-USD&days=180"
+        )
+        self.assertEqual(resp.status_code, 200)
+        name, args, kwargs = self.last_call()
+        self.assertEqual(name, "get_spread_history")
+        self.assertEqual(args[0], "MSTR")
+        self.assertEqual(kwargs["underlying"], "BTC-USD")
+        self.assertEqual(kwargs["days"], 180)
+
+    def test_premium_history_route_uppercases_and_forwards(self):
+        resp = self.client.get("/api/arbitrage/pairs/mstr/premium-history?days=90")
+        self.assertEqual(resp.status_code, 200)
+        name, args, kwargs = self.last_call()
+        self.assertEqual(name, "get_premium_history")
+        self.assertEqual(args[0], "MSTR")
+        self.assertEqual(kwargs["days"], 90)
+
+    def test_discover_forwards_include_all(self):
+        self.client.get("/api/arbitrage/discover?symbols=NEM&include_all=true")
+        self.assertTrue(self.last_call()[2]["include_all"])
+        self.client.get("/api/arbitrage/discover?symbols=NEM")
+        self.assertFalse(self.last_call()[2]["include_all"])
+
 
 class QueryParameterBoundsTest(ArbitrageRouterTest):
     """Expensive/lossy numeric inputs must be rejected at the edge.
@@ -164,6 +189,12 @@ class QueryParameterBoundsTest(ArbitrageRouterTest):
     def test_blank_symbols_is_rejected(self):
         self.assert_rejected("/api/arbitrage/discover?symbols=%20")
         self.assert_rejected("/api/arbitrage/discover?symbols=,,,")
+
+    def test_history_routes_enforce_the_same_day_bounds(self):
+        for path in ("/api/arbitrage/pairs/MSTR/spread-history?days=%s",
+                     "/api/arbitrage/pairs/MSTR/premium-history?days=%s"):
+            self.assert_rejected(path % 29)
+            self.assert_rejected(path % 99999)
 
     def test_values_inside_the_bounds_still_pass_through(self):
         for path in ("/api/arbitrage/scan?top_n=1&days=30",

--- a/tests/test_arbitrage_nav.py
+++ b/tests/test_arbitrage_nav.py
@@ -129,6 +129,41 @@ class ExposureRatioTest(unittest.TestCase):
         self.assertIsNone(nav.exposure_ratio(160, 0))
 
 
+class PremiumHistoryTest(unittest.TestCase):
+    """Per-date series; capital structure held constant by design."""
+
+    PRICES = [('2026-07-01', 96.99), ('2026-07-02', 90.0)]
+    SPOTS = [('2026-07-01', 64_709), ('2026-07-02', 64_709)]
+
+    def series(self, **overrides):
+        kwargs = {
+            "prices": self.PRICES, "spots": self.SPOTS, "units": 843_775,
+            "diluted_shares": 350_000_000, "senior_claims": 16_500_000_000,
+        }
+        kwargs.update(overrides)
+        return nav.premium_history(**kwargs)
+
+    def test_each_point_matches_the_point_in_time_workup(self):
+        rows = self.series()
+        self.assertEqual(len(rows), 2)
+        self.assertAlmostEqual(rows[0]["premium_discount_pct"], -10.9, delta=0.5)
+        # Same NAV per share throughout — only price moves.
+        self.assertEqual(rows[0]["nav_per_share"], rows[1]["nav_per_share"])
+        self.assertLess(rows[1]["premium_discount_pct"], rows[0]["premium_discount_pct"])
+
+    def test_dates_are_carried_through(self):
+        self.assertEqual([r["date"] for r in self.series()],
+                         ['2026-07-01', '2026-07-02'])
+
+    def test_unusable_points_are_dropped_not_nulled(self):
+        """An insolvent structure yields no per-share value; emitting a null
+        hole would draw a broken line."""
+        self.assertEqual(self.series(senior_claims=10**15), [])
+
+    def test_empty_input_yields_empty_series(self):
+        self.assertEqual(nav.premium_history([], [], 100, 100), [])
+
+
 class AnalyzeNavVehicleTest(unittest.TestCase):
     def test_zero_senior_claims_makes_gross_and_net_agree(self):
         result = nav.analyze_nav_vehicle(price=95, units=100, spot=10,

--- a/tests/test_arbitrage_service.py
+++ b/tests/test_arbitrage_service.py
@@ -359,6 +359,157 @@ class ScanSummaryTest(unittest.TestCase):
         self.assertIn("NET", summary["note"])
 
 
+class SpreadHistoryTest(unittest.TestCase):
+    """The series analyze_pair discards, plus the levels needed to draw it."""
+
+    def setUp(self):
+        y, x = cointegrated_pair()
+        self.frames = {"AAA": price_frame(y), "ZZZ": price_frame(x)}
+        self.entries = [entry(security="AAA")]
+
+    def test_returns_dated_points_and_band_levels(self):
+        result = build(self.entries, self.frames).get_spread_history("AAA")
+        self.assertGreater(len(result["points"]), 100)
+        self.assertIn("date", result["points"][0])
+        self.assertIn("spread", result["points"][0])
+        # Bands are precomputed so the chart never does arithmetic.
+        mean, std = result["mean"], result["std"]
+        self.assertAlmostEqual(result["bands"]["plus_one"], mean + std, places=5)
+        self.assertAlmostEqual(result["bands"]["minus_one"], mean - std, places=5)
+        self.assertAlmostEqual(result["bands"]["plus_two"], mean + 2 * std, places=5)
+        self.assertAlmostEqual(result["bands"]["minus_two"], mean - 2 * std, places=5)
+
+    def test_latest_matches_the_final_point(self):
+        result = build(self.entries, self.frames).get_spread_history("AAA")
+        self.assertEqual(result["latest"]["spread"], result["points"][-1]["spread"])
+        self.assertEqual(result["latest"]["date"], result["points"][-1]["date"])
+        self.assertIsNotNone(result["latest"]["z"])
+
+    def test_trend_carries_an_intercept_so_the_line_can_be_drawn(self):
+        result = build(self.entries, self.frames).get_spread_history("AAA")
+        self.assertIn("intercept", result["trend"])
+        self.assertIsNotNone(result["trend"]["intercept"])
+
+    def test_cointegration_block_never_leaks_the_series(self):
+        """engle_granger returns the spread; it must not ride along twice."""
+        result = build(self.entries, self.frames).get_spread_history("AAA")
+        self.assertNotIn("spread", result["cointegration"])
+
+    def test_ad_hoc_pair_needs_an_underlying(self):
+        svc = build([], self.frames)
+        self.assertIn("not in the curated universe",
+                      svc.get_spread_history("AAA")["error"])
+        self.assertIsNone(
+            svc.get_spread_history("AAA", underlying="ZZZ").get("error")
+        )
+
+    def test_missing_history_is_reported_cleanly(self):
+        result = build(self.entries, {"ZZZ": price_frame([1.0] * 40)}).get_spread_history("AAA")
+        self.assertIn("No price history", result["error"])
+
+
+class PremiumHistoryTest(unittest.TestCase):
+    def setUp(self):
+        n = 120
+        self.frames = {
+            "MSTR": price_frame([100.0] * n),
+            "BTC-USD": price_frame([50_000.0] * n),
+        }
+        self.entry = entry(
+            security="MSTR", kind="nav_vehicle", underlying="BTC-USD", hedge="IBIT",
+            mechanism="buyback", holdings_units=1_000, holdings_as_of="2026-07-14",
+            senior_claims_usd=10_000_000, diluted_shares=1_000_000,
+        )
+
+    def test_series_values_are_exact(self):
+        # 1,000 units x $50,000 = $50M gross, less $10M senior = $40M over 1M
+        # shares = $40/share; price 100 => +150% premium.
+        result = build([self.entry], self.frames).get_premium_history("MSTR")
+        self.assertEqual(len(result["points"]), 120)
+        point = result["points"][-1]
+        self.assertAlmostEqual(point["nav_per_share"], 40.0, places=4)
+        self.assertAlmostEqual(point["premium_discount_pct"], 150.0, places=4)
+        self.assertEqual(result["latest"], point)
+
+    def test_approximation_is_declared_not_implied(self):
+        """The series applies today's capital structure to past prices; a
+        reader who misses that would misread how the gap behaved."""
+        result = build([self.entry], self.frames).get_premium_history("MSTR")
+        self.assertEqual(result["method"], "current_capital_structure")
+        self.assertIn("Approximation", result["note"])
+        self.assertIn("not a record", result["note"])
+
+    def test_db_snapshot_supersedes_the_yaml_bootstrap(self):
+        snapshot = {"units": 2_000, "as_of": "2026-07-20", "senior_claims": 0.0,
+                    "annual_senior_cost": 0.0, "other_assets": 0.0,
+                    "diluted_shares": 1_000_000, "source": "db"}
+        result = build([self.entry], self.frames, snapshot=snapshot).get_premium_history("MSTR")
+        self.assertEqual(result["units"], 2_000)
+        # 2,000 x 50,000 / 1M shares = $100/share, price 100 => flat.
+        self.assertAlmostEqual(result["points"][-1]["premium_discount_pct"], 0.0, places=4)
+
+    def test_non_nav_vehicle_is_refused_with_a_reason(self):
+        producer = entry(security="GDX", kind="producer", underlying="GC=F")
+        frames = {"GDX": price_frame([30.0] * 60), "GC=F": price_frame([2000.0] * 60)}
+        result = build([producer], frames).get_premium_history("GDX")
+        self.assertIn("not a NAV vehicle", result["error"])
+        self.assertEqual(result["kind"], "producer")
+
+    def test_uncurated_security_is_refused(self):
+        result = build([], self.frames).get_premium_history("NOPE")
+        self.assertIn("not in the curated universe", result["error"])
+
+    def test_missing_holdings_explains_what_to_add(self):
+        bare = {**self.entry, "holdings_units": None, "diluted_shares": None}
+        result = build([bare], self.frames).get_premium_history("MSTR")
+        self.assertIn("arb_universe.yaml", result["error"])
+
+
+class DiscoveryIncludeAllTest(unittest.TestCase):
+    """Near-misses are the point of the scatter — they must survive the sweep."""
+
+    def setUp(self):
+        y, x = cointegrated_pair(seed=12)
+        self.frames = {"MINER": price_frame(y), "GC=F": price_frame(x)}
+        self.info = {"MINER": {"sector": "Basic Materials", "industry": "Gold Mining"}}
+
+    def test_default_omits_the_tested_list(self):
+        svc = build([], self.frames, info=self.info)
+        result = svc.discover_pairs(["MINER"], references=["GC=F"])
+        self.assertNotIn("tested", result)
+
+    def test_include_all_reports_passes_and_failures_alike(self):
+        svc = build([], self.frames, info=self.info)
+        result = svc.discover_pairs(["MINER"], references=["GC=F"], include_all=True)
+        self.assertEqual(len(result["tested"]), 1)
+        row = result["tested"][0]
+        for field in ("correlation", "statistic", "half_life_days", "passed",
+                      "failed_because", "economic_link"):
+            self.assertIn(field, row)
+        self.assertIn("critical_values", result)
+
+    def test_a_rejected_pair_keeps_its_measurements(self):
+        """A correlation floor of 1.0 rejects everything — the row must still
+        carry the numbers so the scatter can plot the near-miss."""
+        svc = build([], self.frames, info=self.info)
+        result = svc.discover_pairs(["MINER"], references=["GC=F"],
+                                    min_abs_correlation=1.0, include_all=True)
+        self.assertEqual(result["count"], 0)
+        row = result["tested"][0]
+        self.assertFalse(row["passed"])
+        self.assertIn("correlation below", row["failed_because"])
+        self.assertIsNotNone(row["correlation"])
+        self.assertIsNotNone(row["statistic"])
+
+    def test_gate_rejections_are_recorded_too(self):
+        svc = build([], self.frames, info={"MINER": {"sector": "Consumer Staples"}})
+        result = svc.discover_pairs(["MINER"], references=["GC=F"], include_all=True)
+        row = result["tested"][0]
+        self.assertFalse(row["passed"])
+        self.assertEqual(row["failed_because"], "no economic link")
+        self.assertFalse(row["economic_link"])
+
+
 class UniverseTest(unittest.TestCase):
     def test_flags_stale_holdings_and_hedge_availability(self):
         entries = [

--- a/tests/test_chat_protocol.py
+++ b/tests/test_chat_protocol.py
@@ -109,9 +109,21 @@ class TestEventStream(unittest.TestCase):
 
 class TestValidateDirective(unittest.TestCase):
     def test_valid_components_accept_ticker(self):
-        for component in ("signals", "live_price", "price_chart", "arbitrage_pair"):
+        for component in ("signals", "live_price", "price_chart", "arbitrage_pair",
+                          "arbitrage_spread", "arbitrage_premium"):
             ok, reason = validate_directive(component, {"ticker": "INTC"})
             self.assertTrue(ok, f"{component} should accept ticker prop: {reason}")
+
+    def test_scan_component_takes_no_props(self):
+        """Universe-wide, so a ticker is meaningless and must be rejected."""
+        self.assertTrue(validate_directive("arbitrage_scan", {})[0])
+        ok, reason = validate_directive("arbitrage_scan", {"ticker": "MSTR"})
+        self.assertFalse(ok)
+        self.assertIn("ticker", reason)
+
+    def test_discovery_component_takes_symbols_not_ticker(self):
+        self.assertTrue(validate_directive("arbitrage_discovery", {"symbols": "NEM,AEM"})[0])
+        self.assertFalse(validate_directive("arbitrage_discovery", {"ticker": "NEM"})[0])
 
     def test_arbitrage_pair_rejects_an_underlying_prop(self):
         """Curated pairs only — the card resolves the underlying itself. Every
@@ -334,6 +346,21 @@ class TestToolSchemas(unittest.TestCase):
         show = next(t for t in TOOL_SCHEMAS if t["name"] == "show_component")
         enum = show["input_schema"]["properties"]["component"]["enum"]
         self.assertEqual(set(enum), set(BACKEND_COMPONENT_REGISTRY))
+
+    def test_show_component_declares_every_prop_the_registry_uses(self):
+        """A prop the registry accepts but the schema omits is unreachable —
+        the model has no way to know it may send it."""
+        show = next(t for t in TOOL_SCHEMAS if t["name"] == "show_component")
+        declared = set(show["input_schema"]["properties"]["props"]["properties"])
+        used = {p for spec in BACKEND_COMPONENT_REGISTRY.values() for p in spec}
+        self.assertTrue(used <= declared, f"undeclared props: {sorted(used - declared)}")
+
+    def test_show_component_has_no_schema_level_required_props(self):
+        """Which props are mandatory depends on the component (arbitrage_scan
+        takes none), and JSON Schema can't express that — the registry is the
+        enforcement point. A `required` list here would contradict it."""
+        show = next(t for t in TOOL_SCHEMAS if t["name"] == "show_component")
+        self.assertNotIn("required", show["input_schema"]["properties"]["props"])
 
     def test_arbitrage_tool_steers_the_model_to_the_net_discount(self):
         """Safety contract, not prose polish.


### PR DESCRIPTION
Four visualization gaps, all closed, on **both** surfaces: each visual is a GenUI-compliant component the sidekick can render, and the new `/arbitrage` page composes the *same* components so the two can't drift.

## 1. The spread was invisible

`pairs.py` computes the residual series and `analyze_pair` **deliberately discards it** — a test pins that it never leaks into a payload, because a thousand floats is noise to an LLM. But it's the object every arbitrage number describes: a z-score of −1.35 tells you the gap is stretched; only the chart tells you whether it's been oscillating or walking away.

New `GET /pairs/{security}/spread-history` returns points plus mean, ±1σ/±2σ levels and the fitted trend line — **all precomputed**, so the chart draws without deriving (Rule 8). `spread_trend` now also returns `intercept`, letting the trend line be drawn without refitting in the browser.

## 2. Premium history is an approximation, and says so

Only the current capital structure is known, so every point applies *today's* holdings and senior claims to that date's prices. A reader taking that for real history would draw the wrong conclusion about how the gap behaved. So:

- payload carries `method: "current_capital_structure"` + an explicit note
- the chart renders the caveat inline, always
- tests assert both

It converges on truth as `arb_nav_snapshots` accumulates daily rows. Non-NAV securities get a structured refusal naming their family (*"GLD is a commodity_etf, not a NAV vehicle"*), which the card surfaces instead of a generic error.

## 3. Discovery needed its failures

A pass/fail list reported **"0 found"** for the obvious miner names and hid why. `discover_pairs(include_all=True)` now returns every tested pair with `passed` and `failed_because`, plotted against the critical-value lines — filled passed, hollow rejected.

Run live against NEM, it immediately shows **two different near-misses that the old output flattened into a single zero**:

| Pair | Correlation | Statistic | Rejected because |
|---|---|---|---|
| NEM ~ GC=F | **0.73** | −2.88 (vs −3.04) | not cointegrated |
| NEM ~ HG=F | 0.35 | **−3.80** (clears 5%) | correlation below the 0.4 floor |

The second is strongly cointegrated and thrown out purely by the correlation gate — visible for the first time.

## 4. Scan table + `/arbitrage` page

Route, nav entry, ranked table (score, verdict, net discount, convergence, hedge, what-breaks-it). Row click opens the pair detail composing the existing card + spread chart + premium chart for NAV vehicles. Collapsible discovery panel.

## Fixed while wiring the registry

`show_component` hard-required `ticker` — which would have **contradicted the registry** for `arbitrage_scan` (no props) and `arbitrage_discovery` (`symbols`), setting the model up to send a prop the validator then rejects. JSON Schema can't express per-component requirements without `oneOf`, so the required list is gone and the registry stays the single enforcement point. Two new tests: every registry prop must be declared in the schema, and no schema-level `required` list may return.

## Verification

| | Before | After |
|---|---|---|
| Backend tests | 987 | **1018** |
| Frontend tests | 344 | **382** |
| Statements | 86.68% | **87.35%** |
| Functions | 85.85% | **86.82%** |
| Branches | 69.67% | **70.51%** |
| Lines | 88.49% | **89.24%** |

Every frontend metric rose; floors ratcheted 88/86/85/69. Backend coverage 86.2%, typecheck clean, architecture guards pass, OpenAPI regenerated (99 routes).

Live-checked against the local API on the test DB: bands equal mean±σ exactly, trend intercept present, premium method label present, GLD correctly refused, and the NEM sweep returns all six tested rows with reasons.

**Note:** needs a `prod-rollout.yml` dispatch after merge, as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)