### PR TITLE
PR 1: QuantUI rebrand, /harvester move, Portfolio route shell

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Harvest Ladder Dashboard</title>
+    <title>QuantUI</title>
     <!-- Fonts are self-hosted (@fontsource, imported in main.tsx) so the strict
          CSP (default-src 'self') holds with no external origins. -->
   </head>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import {
   IconButton, Tooltip,
 } from '@mui/material';
 import DashboardIcon from '@mui/icons-material/Dashboard';
+import AccountBalanceWalletIcon from '@mui/icons-material/AccountBalanceWallet';
 import ListAltIcon from '@mui/icons-material/ListAlt';
 import ShowChartIcon from '@mui/icons-material/ShowChart';
 import BarChartIcon from '@mui/icons-material/BarChart';
@@ -15,6 +16,7 @@ import ChatIcon from '@mui/icons-material/Chat';
 import ChatRail from './components/chat/ChatRail';
 import { useChat } from './chat/ChatContext';
 import DashboardPage from './components/dashboard/DashboardPage';
+import PortfolioPage from './components/portfolio/PortfolioPage';
 import PlansPage from './components/plans/PlansPage';
 import PlanDetailPage from './components/plans/PlanDetailPage';
 import SymbolsPage from './components/symbols/SymbolsPage';
@@ -32,7 +34,8 @@ function Layout() {
   const isLight = themeName === 'light';
 
   const navItems = [
-    { label: 'Dashboard', path: '/', icon: <DashboardIcon /> },
+    { label: 'Portfolio', path: '/', icon: <AccountBalanceWalletIcon /> },
+    { label: 'Harvester', path: '/harvester', icon: <DashboardIcon /> },
     { label: 'Securities', path: '/securities', icon: <BarChartIcon /> },
     { label: 'Arbitrage', path: '/arbitrage', icon: <CompareArrowsIcon /> },
     { label: 'Plans', path: '/plans', icon: <ListAltIcon /> },
@@ -57,7 +60,7 @@ function Layout() {
               letterSpacing: '0.05em',
             }}
           >
-            Harvest Ladder
+            QuantUI
           </Typography>
 
           <Stack direction="row" spacing={1}>
@@ -167,7 +170,8 @@ export default function App() {
   return (
     <Routes>
       <Route element={<Layout />}>
-        <Route path="/" element={<DashboardPage />} />
+        <Route path="/" element={<PortfolioPage />} />
+        <Route path="/harvester" element={<DashboardPage />} />
         <Route path="/securities" element={<SecuritiesPage />} />
         <Route path="/securities/:symbol" element={<SecurityDetailPage />} />
         <Route path="/arbitrage" element={<ArbitragePage />} />

--- a/frontend/src/components/dashboard/DashboardPage.tsx
+++ b/frontend/src/components/dashboard/DashboardPage.tsx
@@ -25,7 +25,7 @@ export default function DashboardPage() {
 
   return (
     <Box>
-      <Typography variant="h4" gutterBottom>Dashboard</Typography>
+      <Typography variant="h4" gutterBottom>Harvester Dashboard</Typography>
       <Grid container spacing={3} sx={{ mb: 4 }}>
         {cards.map((c) => (
           <Grid item xs={12} sm={6} md={3} key={c.label}>

--- a/frontend/src/components/portfolio/PortfolioPage.test.tsx
+++ b/frontend/src/components/portfolio/PortfolioPage.test.tsx
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { screen } from '@testing-library/react';
+import PortfolioPage from './PortfolioPage';
+import { renderWithProviders } from '../../testUtils';
+
+describe('PortfolioPage', () => {
+  it('renders the Portfolio heading', () => {
+    renderWithProviders(<PortfolioPage />);
+    expect(screen.getByText('Portfolio')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/portfolio/PortfolioPage.tsx
+++ b/frontend/src/components/portfolio/PortfolioPage.tsx
@@ -1,0 +1,10 @@
+import { Box, Typography } from '@mui/material';
+
+export default function PortfolioPage() {
+  return (
+    <Box>
+      <Typography variant="h4" gutterBottom>Portfolio</Typography>
+      <Typography color="text.secondary">Coming soon.</Typography>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- PR 1 of the portfolio-lots plan ([docs/proposals/portfolio-lots-plan.md](docs/proposals/portfolio-lots-plan.md)) for #126.
- Rebrands the app to **QuantUI** (header, page title).
- Moves the harvester dashboard from `/` to `/harvester`, heading updated to "Harvester Dashboard".
- Adds a placeholder **Portfolio** page at `/` (nav positioned first) — intentionally no data yet, since making `/` a live portfolio view before per-owner scoping (PR 2) would leak one user's holdings to every logged-in user.

## Test plan
- [x] `cd frontend && npx vitest run --coverage` — 383/383 passing, coverage above ratchet floor (89.25%/87.35%/86.83%/70.51% vs 88/86/85/69)
- [x] `cd frontend && npx tsc --noEmit` — clean
- [x] `grep -rn "Harvest Ladder" frontend/src frontend/index.html` — no matches
- [x] Manually verified in browser: `/` shows Portfolio placeholder with correct nav order, `/harvester` shows "Harvester Dashboard" with nav highlighting
- [x] `python -m unittest discover -s tests -t .` — 1018/1018 passing (no backend changes in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)