### PR TITLE
feat: owner-scope the API from the authenticated principal (issue #126, PR 2)

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -48,15 +48,22 @@ as its HMAC secret) fails closed.
 
 from __future__ import annotations
 
+import logging
 import os
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import Any, Optional
 
 import jwt
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
+from quantcore.services.identity import UnknownIdentityError
+from quantcore.services.registry import get_services
+
 _TRUTHY = {"1", "true", "yes", "on"}
+
+_security_logger = logging.getLogger("quantcore.security")
 
 # auto_error=False so a missing/blank header reaches our dependency (which then either
 # bypasses, when AUTH_DISABLED, or raises a uniform 401) rather than FastAPI's generic 403.
@@ -122,6 +129,11 @@ class Principal:
 
     @property
     def owner(self) -> str:
+        """The raw authenticated identity (IAP email or MCP token ``sub``).
+
+        This is *not* the canonical short-handle owner used in ``positions.owner``
+        etc. — that resolution happens in ``require_owner``, via ``IdentityService``.
+        """
         return self.subject or (self.email or "unknown")
 
     @classmethod
@@ -223,3 +235,31 @@ def require_principal(
 
     claims = _decode(credentials.credentials)
     return Principal.from_claims(claims, credentials.credentials)
+
+
+def require_owner(principal: Principal = Depends(require_principal)) -> str:
+    """FastAPI dependency: resolve the authenticated principal to its canonical owner.
+
+    Every owner-scoped route depends on this instead of accepting an ``?owner=``
+    query param (issue #126 decision #1) — there is no legitimate cross-user read
+    path on this endpoint. An identity with no ``owner_identities`` mapping is
+    never auto-provisioned (decision #2): it logs a security event and 403s,
+    identically for ES256 UI tokens and HS256 MCP tokens (decision #4).
+
+    ``Principal.local()`` (auth inactive — local/compose, no key configured) is
+    exempt: it resolves straight to ``"john"``, preserving the same open-by-default
+    local contract ``require_principal`` already grants ``Principal.local()``.
+    """
+    if principal.is_local:
+        return "john"
+
+    try:
+        return get_services().identity.resolve_owner(principal.owner)
+    except UnknownIdentityError:
+        # Identity only — never the token, header, or raw claims.
+        _security_logger.warning(
+            "SECURITY unmapped_principal identity=%s at=%s",
+            principal.owner,
+            datetime.now(timezone.utc).isoformat(),
+        )
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="not_provisioned")

--- a/api/deps.py
+++ b/api/deps.py
@@ -45,7 +45,7 @@ def route_error_plain(message: str, status: int) -> QuantCoreJSONResponse:
     return QuantCoreJSONResponse({"error": message}, status_code=status)
 
 
-def load_portfolio(owner: str = "john") -> list[dict]:
+def load_portfolio(owner: str) -> list[dict]:
     """Load an owner's positions from the DB-backed positions table."""
     return get_services().portfolio.list_positions(owner)
 

--- a/api/routers/options.py
+++ b/api/routers/options.py
@@ -18,8 +18,9 @@ from __future__ import annotations
 
 from typing import List, Optional
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Depends, Query
 
+from ..auth import require_owner
 from ..deps import load_portfolio, load_watchlist, route_error_plain, services
 from ..json_response import QuantCoreJSONResponse
 from ..schemas.options import VerticalSpreadRequest
@@ -121,10 +122,10 @@ def get_signals_options_flow(ticker: str) -> QuantCoreJSONResponse:
 # Portfolio delta exposure
 # --------------------------------------------------------------------------- #
 @router.get("/portfolio/delta-exposure")
-def get_portfolio_delta_exposure() -> QuantCoreJSONResponse:
+def get_portfolio_delta_exposure(owner: str = Depends(require_owner)) -> QuantCoreJSONResponse:
     try:
         return QuantCoreJSONResponse(
-            services().options.get_portfolio_delta_exposure(load_portfolio())
+            services().options.get_portfolio_delta_exposure(load_portfolio(owner))
         )
     except Exception as exc:  # noqa: BLE001
         return route_error_plain(str(exc), 500)
@@ -270,10 +271,11 @@ def refresh_options_snapshots(
     batch_size: int = 10,
     max_workers: int = 4,
     batch_delay: float = 1.5,
+    owner: str = Depends(require_owner),
 ) -> QuantCoreJSONResponse:
     return QuantCoreJSONResponse(
         services().options.refresh_options_snapshots(
-            load_portfolio(),
+            load_portfolio(owner),
             load_watchlist(),
             source=source,
             chain_type=chain_type,

--- a/api/routers/portfolio.py
+++ b/api/routers/portfolio.py
@@ -1,12 +1,16 @@
 """Portfolio / watchlist / securities routes.
 
 Ports the Flask handlers (api/app.py) for:
-  GET/POST  /api/portfolio          (+ ?owner=, default "john")
+  GET/POST  /api/portfolio
   DELETE    /api/portfolio/{ticker}
   POST      /api/portfolio/import    (multipart file OR JSON path)
   GET/POST  /api/watchlist
   GET       /api/securities
   GET       /api/securities/lookup
+
+The owner is resolved from the authenticated principal via ``require_owner``
+(issue #126 decision #1) — there is no ``?owner=`` query param; there is no
+legitimate cross-user read path on this endpoint.
 
 These routes returned the bare ``{"error": message}`` body (no ``status`` key)
 on validation/not-found, so they use ``route_error_plain`` rather than the
@@ -20,8 +24,9 @@ from pathlib import Path
 from typing import Optional
 
 import yaml
-from fastapi import APIRouter, File, Request, UploadFile
+from fastapi import APIRouter, Depends, File, Request, UploadFile
 
+from ..auth import require_owner
 from ..deps import (
     PROJECT_ROOT,
     load_portfolio,
@@ -48,12 +53,14 @@ router = APIRouter(prefix="/api", tags=["securities"])
 # Portfolio
 # --------------------------------------------------------------------------- #
 @router.get("/portfolio", response_model=SecuritiesResponse)
-def get_portfolio(owner: str = "john") -> QuantCoreJSONResponse:
+def get_portfolio(owner: str = Depends(require_owner)) -> QuantCoreJSONResponse:
     return QuantCoreJSONResponse({"securities": load_portfolio(owner)})
 
 
 @router.post("/portfolio", response_model=AddSecurityResponse, status_code=201)
-def add_to_portfolio(body: AddPositionRequest, owner: str = "john") -> QuantCoreJSONResponse:
+def add_to_portfolio(
+    body: AddPositionRequest, owner: str = Depends(require_owner)
+) -> QuantCoreJSONResponse:
     symbol = (body.symbol or "").strip().upper()
     if not symbol:
         return route_error_plain("symbol is required", 400)
@@ -75,7 +82,9 @@ def add_to_portfolio(body: AddPositionRequest, owner: str = "john") -> QuantCore
 
 
 @router.delete("/portfolio/{ticker}", response_model=RemovePositionResponse)
-def remove_from_portfolio(ticker: str, owner: str = "john") -> QuantCoreJSONResponse:
+def remove_from_portfolio(
+    ticker: str, owner: str = Depends(require_owner)
+) -> QuantCoreJSONResponse:
     ticker = ticker.upper()
     removed = services().portfolio.remove_position(owner, ticker)
     if removed == 0:
@@ -86,7 +95,7 @@ def remove_from_portfolio(ticker: str, owner: str = "john") -> QuantCoreJSONResp
 @router.post("/portfolio/import", response_model=ImportResult)
 async def import_portfolio(
     request: Request,
-    owner: str = "john",
+    owner: str = Depends(require_owner),
     file: Optional[UploadFile] = File(default=None),
 ) -> QuantCoreJSONResponse:
     """Full-sync replace of the owner's positions from an uploaded CSV.
@@ -156,8 +165,8 @@ def add_to_watchlist(body: AddWatchlistRequest) -> QuantCoreJSONResponse:
 # Securities — combined portfolio + watchlist
 # --------------------------------------------------------------------------- #
 @router.get("/securities", response_model=SecuritiesResponse)
-def get_securities() -> QuantCoreJSONResponse:
-    portfolio = {s["symbol"]: s for s in load_portfolio()}
+def get_securities(owner: str = Depends(require_owner)) -> QuantCoreJSONResponse:
+    portfolio = {s["symbol"]: s for s in load_portfolio(owner)}
     watchlist = {s["symbol"]: s for s in load_watchlist()}
     combined: dict[str, dict] = {}
     for sym, s in portfolio.items():

--- a/api/routers/prices.py
+++ b/api/routers/prices.py
@@ -12,8 +12,9 @@ from __future__ import annotations
 
 from typing import Optional
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
+from ..auth import require_owner
 from ..deps import load_portfolio, load_watchlist, route_error_plain, services
 from ..json_response import QuantCoreJSONResponse
 
@@ -240,6 +241,7 @@ def screen_securities(
     macd_bearish: Optional[str] = None,
     news_sentiment: Optional[str] = None,
     source: str = "all",
+    owner: str = Depends(require_owner),
 ) -> QuantCoreJSONResponse:
     filters = {
         "rsi_max": rsi_max,
@@ -257,7 +259,7 @@ def screen_securities(
     }
     try:
         return QuantCoreJSONResponse(
-            services().prices.screen_securities(filters, load_portfolio(), load_watchlist())
+            services().prices.screen_securities(filters, load_portfolio(owner), load_watchlist())
         )
     except Exception as exc:  # noqa: BLE001
         return route_error_plain(str(exc), 500)

--- a/api/routers/sentiment.py
+++ b/api/routers/sentiment.py
@@ -14,8 +14,9 @@ by the /{ticker}/news template.
 
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
+from ..auth import require_owner
 from ..deps import load_portfolio, load_watchlist, services
 from ..json_response import QuantCoreJSONResponse
 
@@ -23,10 +24,12 @@ router = APIRouter(prefix="/api/securities", tags=["sentiment"])
 
 
 @router.get("/news/sentiment-summary")
-def get_sentiment_summary(source: str = "all") -> QuantCoreJSONResponse:
+def get_sentiment_summary(
+    source: str = "all", owner: str = Depends(require_owner)
+) -> QuantCoreJSONResponse:
     try:
         result = services().sentiment.get_sentiment_dashboard(
-            load_portfolio(), load_watchlist(), source_filter=source
+            load_portfolio(owner), load_watchlist(), source_filter=source
         )
     except Exception as exc:  # noqa: BLE001 — parity with Flask
         return QuantCoreJSONResponse({"error": str(exc), "items": []}, status_code=500)

--- a/db/migrations/V3__owner_identities.sql
+++ b/db/migrations/V3__owner_identities.sql
@@ -1,0 +1,32 @@
+-- V3: Owner identity mapping
+--
+-- Portfolio-lots plan (issue #126), PR 2, Step 2.1. Maps an authenticated
+-- identity (IAP email for ES256 UI tokens, or MCP token `sub` for HS256
+-- tokens) to the canonical short-handle `owner` value already used as the
+-- literal in `positions.owner` (e.g. 'john'). Additive only — no DROP.
+--
+-- Unknown identities are never auto-provisioned (issue #126 decision #2):
+-- rows are added by an admin, via scripts/grant_quantui_iap_access.sh going
+-- forward. The seed inserts below cover the users already granted IAP access
+-- as of this migration.
+CREATE TABLE IF NOT EXISTS owner_identities (
+    identity   TEXT PRIMARY KEY,      -- IAP email OR MCP token sub, lowercased
+    owner      TEXT NOT NULL,         -- canonical short handle, e.g. 'john'
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    notes      TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_owner_identities_owner ON owner_identities(owner);
+
+-- Seed: existing provisioned users (identity lowercased). ON CONFLICT DO
+-- NOTHING keeps this migration re-runnable and safe to apply after manual
+-- rows have already been added.
+INSERT INTO owner_identities (identity, owner, notes) VALUES
+    ('john', 'john', 'MCP token default sub'),
+    ('funkjohn@gmail.com', 'john', 'IAP email'),
+    ('john@johnfunk.com', 'john', 'IAP email'),
+    ('thomas@zoidbergfolio.com', 'thomas', 'IAP email'),
+    ('dr.sagerjl@gmail.com', 'sager', 'IAP email'),
+    ('musicalmacdonald@gmail.com', 'macdonald', 'IAP email'),
+    ('superdavidabrown@gmail.com', 'dabrown', 'IAP email')
+ON CONFLICT (identity) DO NOTHING;

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -53,4 +53,19 @@ describe('App routing', () => {
     renderApp('/nonexistent-path');
     expect(screen.getByText('Page not found')).toBeInTheDocument();
   });
+
+  it('renders RestrictedAccess with no Layout chrome when a call reports not_provisioned', async () => {
+    mockApi([
+      [/\/api\//, () => ({ __status: 403, error: 'not_provisioned', message: 'not_provisioned' })],
+    ]);
+    renderApp('/securities');
+    await waitFor(() =>
+      expect(
+        screen.getByText(/restricted to authorized users/i),
+      ).toBeInTheDocument(),
+    );
+    // No nav chrome (Layout's AppBar links) and no chat toggle survive.
+    expect(screen.queryAllByRole('link').length).toBe(0);
+    expect(screen.queryByTestId('chat-toggle')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { Routes, Route, Link, useLocation, Outlet } from 'react-router-dom';
 import {
   AppBar, Toolbar, Typography, Button, Container, Box, Stack, alpha,
@@ -24,7 +25,9 @@ import SecuritiesPage from './components/securities/SecuritiesPage';
 import SecurityDetailPage from './components/securities/SecurityDetailPage';
 import ArbitragePage from './components/arbitrage/ArbitragePage';
 import SettingsPage from './components/settings/SettingsPage';
+import RestrictedAccess from './components/access/RestrictedAccess';
 import { useAppTheme } from './ThemeContext';
+import { onNotProvisioned } from './api/client';
 
 function Layout() {
   const location = useLocation();
@@ -167,6 +170,16 @@ function Layout() {
 }
 
 export default function App() {
+  // Issue #126 decision #2/#4: an unmapped principal must land on a full-page
+  // restricted screen with no header/nav/ChatRail, never inside Layout.
+  const [restricted, setRestricted] = useState(false);
+
+  useEffect(() => onNotProvisioned(() => setRestricted(true)), []);
+
+  if (restricted) {
+    return <RestrictedAccess />;
+  }
+
   return (
     <Routes>
       <Route element={<Layout />}>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -11,6 +11,17 @@ export class ApiError extends Error {
   }
 }
 
+type NotProvisionedListener = () => void;
+const notProvisionedListeners = new Set<NotProvisionedListener>();
+
+/** Subscribe to the global "principal isn't provisioned" signal (issue #126
+ * decision #2/#4): fired whenever any apiRequest call comes back as a 403
+ * whose body resolves to "not_provisioned". Returns an unsubscribe function. */
+export function onNotProvisioned(listener: NotProvisionedListener): () => void {
+  notProvisionedListeners.add(listener);
+  return () => notProvisionedListeners.delete(listener);
+}
+
 export async function apiRequest<T>(
   endpoint: string,
   options?: RequestInit,
@@ -27,10 +38,11 @@ export async function apiRequest<T>(
   if (!response.ok) {
     const error = await response.json().catch(() => ({}));
     // `detail` is FastAPI's error field; `message`/`error` are legacy shapes.
-    throw new ApiError(
-      error.message || error.error || error.detail || response.statusText,
-      response.status,
-    );
+    const message = error.message || error.error || error.detail || response.statusText;
+    if (response.status === 403 && message === 'not_provisioned') {
+      notProvisionedListeners.forEach((listener) => listener());
+    }
+    throw new ApiError(message, response.status);
   }
 
   return response.json();

--- a/frontend/src/components/access/RestrictedAccess.test.tsx
+++ b/frontend/src/components/access/RestrictedAccess.test.tsx
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+
+import RestrictedAccess, {
+  RESTRICTED_ACCESS_REDIRECT_DELAY_MS,
+  RESTRICTED_ACCESS_REDIRECT_URL,
+} from './RestrictedAccess';
+
+const COPY =
+  'This system is restricted to authorized users. Individuals who attempt ' +
+  'unauthorized access will be prosecuted. If you are unauthorized, ' +
+  'terminate access now.';
+
+function stubLocation() {
+  const original = window.location;
+  // window.location isn't directly assignable; replace the whole property
+  // instead so `.href = ...` writes land on a throwaway stand-in object.
+  Object.defineProperty(window, 'location', {
+    value: { ...original, href: '' },
+    writable: true,
+    configurable: true,
+  });
+  return () => {
+    Object.defineProperty(window, 'location', {
+      value: original,
+      writable: true,
+      configurable: true,
+    });
+  };
+}
+
+describe('RestrictedAccess', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanup();
+  });
+
+  it('renders the exact restricted-access copy', () => {
+    render(<RestrictedAccess />);
+    expect(screen.getByText(COPY)).toBeInTheDocument();
+  });
+
+  it('does not display any identifying information', () => {
+    render(<RestrictedAccess />);
+    expect(screen.queryByText(/@/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/contact/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/email/i)).not.toBeInTheDocument();
+  });
+
+  it('does not redirect before 10 seconds', () => {
+    const restore = stubLocation();
+    render(<RestrictedAccess />);
+    vi.advanceTimersByTime(9_999);
+    expect(window.location.href).toBe('');
+    restore();
+  });
+
+  it('redirects to the FBI cyber crime page after 10 seconds', () => {
+    const restore = stubLocation();
+    render(<RestrictedAccess />);
+    vi.advanceTimersByTime(RESTRICTED_ACCESS_REDIRECT_DELAY_MS);
+    expect(window.location.href).toBe(RESTRICTED_ACCESS_REDIRECT_URL);
+    restore();
+  });
+});

--- a/frontend/src/components/access/RestrictedAccess.tsx
+++ b/frontend/src/components/access/RestrictedAccess.tsx
@@ -1,0 +1,38 @@
+import { useEffect } from 'react';
+import { Box, Typography } from '@mui/material';
+
+export const RESTRICTED_ACCESS_REDIRECT_URL = 'https://www.fbi.gov/investigate/cyber';
+export const RESTRICTED_ACCESS_REDIRECT_DELAY_MS = 10_000;
+
+/** Full-page terminal state for an unmapped principal (issue #126 decision
+ * #2/#4). Deliberately standalone — no Layout, no nav, no identifying
+ * information — and rendered outside the Layout-wrapped route tree in App.tsx. */
+export default function RestrictedAccess() {
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      window.location.href = RESTRICTED_ACCESS_REDIRECT_URL;
+    }, RESTRICTED_ACCESS_REDIRECT_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: '100vh',
+        width: '100vw',
+        bgcolor: 'background.default',
+        p: 4,
+        textAlign: 'center',
+      }}
+    >
+      <Typography variant="h6" component="p" sx={{ maxWidth: 600 }}>
+        This system is restricted to authorized users. Individuals who attempt
+        unauthorized access will be prosecuted. If you are unauthorized,
+        terminate access now.
+      </Typography>
+    </Box>
+  );
+}

--- a/frontend/src/components/portfolio/EmptyPortfolio.test.tsx
+++ b/frontend/src/components/portfolio/EmptyPortfolio.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { screen } from '@testing-library/react';
+
+import EmptyPortfolio from './EmptyPortfolio';
+import { renderWithProviders } from '../../testUtils';
+
+describe('EmptyPortfolio', () => {
+  it('renders friendly copy inviting the user to add a first position', () => {
+    renderWithProviders(<EmptyPortfolio />);
+    expect(screen.getByText('Your portfolio is empty')).toBeInTheDocument();
+    expect(screen.getByText(/add your first position/i)).toBeInTheDocument();
+  });
+
+  it('does not display any identifying information', () => {
+    renderWithProviders(<EmptyPortfolio />);
+    expect(screen.queryByText(/@/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/contact/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/email/i)).not.toBeInTheDocument();
+  });
+
+  it('does not use the restricted-access copy', () => {
+    renderWithProviders(<EmptyPortfolio />);
+    expect(screen.queryByText(/restricted to authorized users/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/prosecuted/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/portfolio/EmptyPortfolio.tsx
+++ b/frontend/src/components/portfolio/EmptyPortfolio.tsx
@@ -1,0 +1,18 @@
+import { Box, Typography } from '@mui/material';
+
+/** Friendly empty-state for a provisioned owner with zero positions — rendered
+ * inside the normal Layout, distinct from RestrictedAccess (a 403). Must never
+ * fire on a network error or 500; only on a successful, empty response. */
+export default function EmptyPortfolio() {
+  return (
+    <Box sx={{ textAlign: 'center', mt: 8 }}>
+      <Typography variant="h5" gutterBottom>
+        Your portfolio is empty
+      </Typography>
+      <Typography color="text.secondary" sx={{ maxWidth: 480, mx: 'auto' }}>
+        Add your first position to start tracking gains, losses, and Harvester
+        plans.
+      </Typography>
+    </Box>
+  );
+}

--- a/main.py
+++ b/main.py
@@ -648,6 +648,17 @@ if __name__ == "__main__":
     for stock in portfolio.list_stocks() + watchlist.list_stocks():
         if stock.symbol not in capture_symbols:
             capture_symbols.append(stock.symbol)
+
+    # Capture walks every owner's symbols, not just John's (issue #126 decision
+    # #5) — other owners' positions have no separate daily job of their own.
+    for other_owner in get_services().portfolio.list_owners():
+        if other_owner == "john":
+            continue
+        for row in get_services().portfolio.list_positions(other_owner):
+            sym = row.get("symbol")
+            if sym and sym not in capture_symbols:
+                capture_symbols.append(sym)
+
     print(f"Capturing options chains for {len(capture_symbols)} symbols...")
     for sym in capture_symbols:
         try:

--- a/quantcore/db.py
+++ b/quantcore/db.py
@@ -385,6 +385,19 @@ CREATE TABLE IF NOT EXISTS arb_nav_snapshots (
 
 CREATE INDEX IF NOT EXISTS idx_arb_nav_latest
     ON arb_nav_snapshots(security, as_of DESC);
+
+-- Maps an authenticated identity (IAP email or MCP token sub, lowercased) to
+-- the canonical short-handle owner value used elsewhere (e.g. positions.owner).
+-- Unknown identities are never auto-provisioned - rows are admin-managed (see
+-- db/migrations/V3__owner_identities.sql and scripts/grant_quantui_iap_access.sh).
+CREATE TABLE IF NOT EXISTS owner_identities (
+    identity   TEXT PRIMARY KEY,
+    owner      TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    notes      TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_owner_identities_owner ON owner_identities(owner);
 """
 
 

--- a/quantcore/repositories/owner_identity_repository.py
+++ b/quantcore/repositories/owner_identity_repository.py
@@ -1,0 +1,52 @@
+"""OwnerIdentityRepository — SQL-only CRUD over the `owner_identities` table.
+
+Maps an authenticated identity (IAP email or MCP token sub) to the canonical
+short-handle owner value. No auto-provisioning logic here — that policy lives
+in IdentityService (quantcore/services/identity.py).
+"""
+
+from __future__ import annotations
+
+from contextlib import closing
+from typing import List, Optional, Tuple
+
+from quantcore.db import get_connection
+
+SQL_RESOLVE = """
+SELECT owner FROM owner_identities WHERE identity = :identity;
+"""
+
+SQL_UPSERT = """
+INSERT INTO owner_identities (identity, owner, notes)
+VALUES (:identity, :owner, :notes)
+ON CONFLICT (identity) DO UPDATE SET
+    owner = excluded.owner,
+    notes = excluded.notes;
+"""
+
+SQL_LIST_ALL = """
+SELECT identity, owner, notes FROM owner_identities ORDER BY identity;
+"""
+
+
+class OwnerIdentityRepository:
+    """SQL persistence for the identity -> owner mapping."""
+
+    def resolve(self, identity: str) -> Optional[str]:
+        with closing(get_connection()) as conn:
+            row = conn.execute(SQL_RESOLVE, {"identity": identity}).fetchone()
+        return row["owner"] if row else None
+
+    def upsert(self, identity: str, owner: str, notes: Optional[str] = None) -> None:
+        with closing(get_connection()) as conn:
+            try:
+                conn.execute(SQL_UPSERT, {"identity": identity, "owner": owner, "notes": notes})
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                raise
+
+    def list_all(self) -> List[Tuple[str, str, Optional[str]]]:
+        with closing(get_connection()) as conn:
+            rows = conn.execute(SQL_LIST_ALL).fetchall()
+        return [(r["identity"], r["owner"], r["notes"]) for r in rows]

--- a/quantcore/services/identity.py
+++ b/quantcore/services/identity.py
@@ -1,0 +1,25 @@
+"""IdentityService — resolves an authenticated identity to its owner handle.
+
+Issue #126 decision #2: unknown identities are never auto-provisioned. A
+lookup miss raises UnknownIdentityError; the caller (api/auth.py's
+require_owner dependency) is responsible for the 403 + security-event log.
+"""
+
+from __future__ import annotations
+
+from quantcore.repositories.owner_identity_repository import OwnerIdentityRepository
+
+
+class UnknownIdentityError(Exception):
+    """Raised when an identity has no owner_identities mapping."""
+
+
+class IdentityService:
+    def __init__(self, owner_identity_repository: OwnerIdentityRepository) -> None:
+        self._repo = owner_identity_repository
+
+    def resolve_owner(self, identity: str) -> str:
+        owner = self._repo.resolve(identity.strip().lower())
+        if owner is None:
+            raise UnknownIdentityError(identity)
+        return owner

--- a/quantcore/services/portfolio.py
+++ b/quantcore/services/portfolio.py
@@ -52,7 +52,7 @@ class PortfolioService:
     # ------------------------------------------------------------------
     # Reads
     # ------------------------------------------------------------------
-    def list_positions(self, owner: str = "john") -> List[Dict[str, Any]]:
+    def list_positions(self, owner: str) -> List[Dict[str, Any]]:
         return self._repo.list_positions(owner)
 
     def list_owners(self) -> List[str]:

--- a/quantcore/services/registry.py
+++ b/quantcore/services/registry.py
@@ -27,6 +27,7 @@ from quantcore.repositories.news_repository import NewsStore
 from quantcore.repositories.ohlcv_repository import OhlcvRepository
 from quantcore.repositories.options_position_repository import OptionsPositionStore
 from quantcore.repositories.options_repository import OptionsStore
+from quantcore.repositories.owner_identity_repository import OwnerIdentityRepository
 from quantcore.repositories.portfolio_repository import PortfolioRepository
 from quantcore.repositories.sentiment_repository import SentimentStore
 from quantcore.repositories.user_settings_repository import UserSettingsRepository
@@ -40,6 +41,7 @@ from quantcore.services.chat import (
     TurnContext,
 )
 from quantcore.services.harvester import HarvesterService
+from quantcore.services.identity import IdentityService
 from quantcore.services.keyproxy import KeyProxyService
 from quantcore.services.microstructure import MicrostructureService
 from quantcore.services.options import OptionsService
@@ -71,6 +73,7 @@ class Services:
     portfolio_repository: PortfolioRepository
     user_settings_repository: UserSettingsRepository
     arbitrage_repository: ArbitrageRepository
+    owner_identity_repository: OwnerIdentityRepository
     # Services
     microstructure: MicrostructureService
     sentiment: SentimentService
@@ -85,6 +88,7 @@ class Services:
     chat: ChatService
     keyproxy: KeyProxyService
     settings: SettingsService
+    identity: IdentityService
 
 
 @lru_cache(maxsize=1)
@@ -100,6 +104,8 @@ def get_services() -> Services:
     portfolio_repository = PortfolioRepository()
     user_settings_repository = UserSettingsRepository()
     arbitrage_repository = ArbitrageRepository()
+    owner_identity_repository = OwnerIdentityRepository()
+    identity = IdentityService(owner_identity_repository=owner_identity_repository)
     settings = SettingsService(
         user_settings_repository,
         allowed=MODEL_IDS,
@@ -213,6 +219,7 @@ def get_services() -> Services:
         portfolio_repository=portfolio_repository,
         user_settings_repository=user_settings_repository,
         arbitrage_repository=arbitrage_repository,
+        owner_identity_repository=owner_identity_repository,
         microstructure=microstructure,
         sentiment=sentiment,
         fundamentals=fundamentals,
@@ -241,4 +248,5 @@ def get_services() -> Services:
         chat=chat,
         keyproxy=keyproxy,
         settings=settings,
+        identity=identity,
     )

--- a/scripts/grant_quantui_iap_access.sh
+++ b/scripts/grant_quantui_iap_access.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 #
 # Grant the dev team roles/iap.httpsResourceAccessor on the quantui Cloud Run
-# service (direct IAP integration) so they can log in through IAP.
+# service (direct IAP integration) so they can log in through IAP, AND write
+# the matching owner_identities row in the same run (issue #126 Step 2.7).
+# These two must never drift apart: a user with IAP access but no DB row (or
+# vice versa) is exactly the state that lands a legitimate user on the harsh
+# RestrictedAccess screen. See db/migrations/V3__owner_identities.sql.
 #
 # Each account ALSO needs to be a test user on the OAuth consent screen
 # (Console -> APIs & Services -> OAuth consent screen -> Audience -> Add users)
@@ -11,24 +15,60 @@
 #   Defaults to the TEST project; pass quantcore-prod-20260606 to grant in prod.
 #   e.g.  ./scripts/grant_quantui_iap_access.sh quantcore-prod-20260606
 #
+# The owner_identities write targets QUANTCORE_TEST_DB_DSN for the test
+# project, or QUANTCORE_DB_DSN (the default DSN) for prod — both read from
+# .env, same convention as .claude/with-test-db.sh. The corresponding Cloud
+# SQL Auth Proxy tunnel must already be running locally (5433=prod, 5434=test).
+#
 set -euo pipefail
+
+cd "$(dirname "$0")/.."
 
 PROJECT="${1:-quantcore-test-20260606}"
 REGION="${2:-us-central1}"
 SERVICE="${3:-quantui}"
 ROLE="roles/iap.httpsResourceAccessor"
 
+# email:owner pairs. The owner handle is the canonical short value already
+# used as positions.owner (e.g. 'john') — see db/migrations/V3__owner_identities.sql
+# for the seed this list must stay in sync with.
+#
+# jlsager@csuchico.edu and thomasdfowler@gmail.com are deliberately absent:
+# thomasdfowler@gmail.com is not a valid/active Google account, so IAM
+# silently drops the `user:` binding even though gcloud reports success —
+# no admin action fixes this. jlsager@csuchico.edu is the wrong identity for
+# J.L. Sager (fails to authenticate for secret access); dr.sagerjl@gmail.com
+# is the one that actually works. Both are known, don't re-add without a
+# fresh working account.
 USERS=(
-  "funkjohn@gmail.com"
-  "jlsager@csuchico.edu"
-  "john@johnfunk.com"
-  "musicalmacdonald@gmail.com"
-  "superdavidabrown@gmail.com"
-  "thomasdfowler@gmail.com"
-  "thomas@zoidbergfolio.com"
+  "funkjohn@gmail.com:john"
+  "john@johnfunk.com:john"
+  "musicalmacdonald@gmail.com:macdonald"
+  "superdavidabrown@gmail.com:dabrown"
+  "thomas@zoidbergfolio.com:thomas"
+  "dr.sagerjl@gmail.com:sager"
 )
 
-for u in "${USERS[@]}"; do
+# --- DB DSN selection --------------------------------------------------------
+if [[ "${PROJECT}" == *prod* ]]; then
+  DSN_VAR="QUANTCORE_DB_DSN"
+else
+  DSN_VAR="QUANTCORE_TEST_DB_DSN"
+fi
+DB_DSN=$(grep -E "^${DSN_VAR}=" .env | head -1 | cut -d= -f2-)
+if [ -z "${DB_DSN}" ]; then
+  echo "${DSN_VAR} not found in .env — cannot write owner_identities rows." >&2
+  exit 1
+fi
+export QUANTCORE_DB_DSN="${DB_DSN}"
+export PYTHONPATH=.
+
+FAILED_DB=()
+
+for pair in "${USERS[@]}"; do
+  u="${pair%%:*}"
+  owner="${pair##*:}"
+
   echo "==> Granting ${ROLE} to ${u} on ${SERVICE} (${PROJECT}/${REGION})"
   gcloud iap web add-iam-policy-binding \
     --resource-type=cloud-run \
@@ -37,7 +77,38 @@ for u in "${USERS[@]}"; do
     --project="${PROJECT}" \
     --member="user:${u}" \
     --role="${ROLE}"
+
+  echo "==> Recording ${u} -> ${owner} in owner_identities (${DSN_VAR})"
+  if ! OWNER_IDENTITY="${u}" OWNER_HANDLE="${owner}" python -c "
+import os
+from quantcore.db import get_connection
+
+conn = get_connection()
+conn.execute(
+    'INSERT INTO owner_identities (identity, owner, notes) '
+    'VALUES (:identity, :owner, :notes) '
+    'ON CONFLICT (identity) DO NOTHING',
+    {
+        'identity': os.environ['OWNER_IDENTITY'],
+        'owner': os.environ['OWNER_HANDLE'],
+        'notes': 'scripts/grant_quantui_iap_access.sh',
+    },
+)
+conn.commit()
+conn.close()
+"; then
+    echo "!! IAP grant for ${u} succeeded but the owner_identities write FAILED." >&2
+    FAILED_DB+=("${u}")
+  fi
 done
+
+if [ "${#FAILED_DB[@]}" -gt 0 ]; then
+  echo
+  echo "FAILED: owner_identities write did not complete for: ${FAILED_DB[*]}" >&2
+  echo "IAP access was granted for these accounts, but until the DB row is" >&2
+  echo "fixed by hand they will still hit the restricted-access screen." >&2
+  exit 1
+fi
 
 echo
 echo "Done. Current IAP IAM policy for ${SERVICE}:"

--- a/scripts/grant_quantui_iap_access.sh
+++ b/scripts/grant_quantui_iap_access.sh
@@ -81,7 +81,11 @@ for pair in "${USERS[@]}"; do
   echo "==> Recording ${u} -> ${owner} in owner_identities (${DSN_VAR})"
   if ! OWNER_IDENTITY="${u}" OWNER_HANDLE="${owner}" python -c "
 import os
+import sys
 from quantcore.db import get_connection
+
+identity = os.environ['OWNER_IDENTITY']
+owner = os.environ['OWNER_HANDLE']
 
 conn = get_connection()
 conn.execute(
@@ -89,15 +93,41 @@ conn.execute(
     'VALUES (:identity, :owner, :notes) '
     'ON CONFLICT (identity) DO NOTHING',
     {
-        'identity': os.environ['OWNER_IDENTITY'],
-        'owner': os.environ['OWNER_HANDLE'],
+        'identity': identity,
+        'owner': owner,
         'notes': 'scripts/grant_quantui_iap_access.sh',
     },
 )
 conn.commit()
+
+# ON CONFLICT DO NOTHING means a pre-existing row for this identity is left
+# untouched. Verify what actually landed rather than trusting the insert:
+# a rerun after fixing a typo in USERS, or granting an identity that was
+# already (mis)mapped to someone else, must not report success while the
+# identity stays mapped to the wrong owner.
+row = conn.execute(
+    'SELECT owner FROM owner_identities WHERE identity = :identity',
+    {'identity': identity},
+).fetchone()
 conn.close()
+
+if row is None:
+    print(f'{identity}: no owner_identities row found after insert', file=sys.stderr)
+    sys.exit(1)
+
+stored_owner = row['owner']
+if stored_owner != owner:
+    print(
+        f'{identity}: already mapped to owner={stored_owner!r}, not the '
+        f'requested {owner!r} — ON CONFLICT DO NOTHING left it untouched. '
+        'Fix the USERS array (if this was a typo) or update the row by hand '
+        '(if the existing mapping is the mistake); this script will not '
+        'overwrite an existing mapping automatically.',
+        file=sys.stderr,
+    )
+    sys.exit(1)
 "; then
-    echo "!! IAP grant for ${u} succeeded but the owner_identities write FAILED." >&2
+    echo "!! IAP grant for ${u} succeeded but the owner_identities write/verify FAILED." >&2
     FAILED_DB+=("${u}")
   fi
 done

--- a/tests/test_api_smoke.py
+++ b/tests/test_api_smoke.py
@@ -23,22 +23,35 @@ from fastapi.testclient import TestClient  # noqa: E402
 
 from quantcore.db import get_connection  # noqa: E402
 from quantcore.repositories.harvester_repository import _utc_now_iso  # noqa: E402
+from quantcore.repositories.owner_identity_repository import (  # noqa: E402
+    OwnerIdentityRepository,
+)
 from quantcore.services.registry import get_services  # noqa: E402
 
+from api.auth import Principal, require_principal  # noqa: E402
 from api.main import create_app  # noqa: E402
 
 TEST_SYMBOL = "ZZAPISMOKE"
 TEST_TEMPLATE = "zz_api_smoke_template"
 
+# Owner-scoping (issue #126 PR 2): a principal must resolve through
+# IdentityService.resolve_owner, so tests map a fake identity to the owner
+# handle rather than passing ?owner= directly.
+TEST_IDENTITY = "zz_api_smoke_identity@example.com"
+TEST_OWNER = "zz_api_import_test"
+UNMAPPED_IDENTITY = "zz_api_smoke_unmapped@example.com"
+
 
 class ApiSmokeTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.client = TestClient(create_app())
+        cls.app = create_app()
+        cls.client = TestClient(cls.app)
 
     def setUp(self):
         self._purge()
         self.addCleanup(self._purge)
+        OwnerIdentityRepository().upsert(TEST_IDENTITY, TEST_OWNER)
 
     def _purge(self):
         with closing(get_connection()) as conn:
@@ -49,7 +62,18 @@ class ApiSmokeTest(unittest.TestCase):
             )
             conn.execute("DELETE FROM symbols WHERE ticker = %s", (TEST_SYMBOL,))
             conn.execute("DELETE FROM plan_templates WHERE name = %s", (TEST_TEMPLATE,))
+            conn.execute("DELETE FROM owner_identities WHERE identity = %s", (TEST_IDENTITY,))
+            conn.execute(
+                "DELETE FROM owner_identities WHERE identity = %s", (UNMAPPED_IDENTITY,)
+            )
             conn.commit()
+
+    def _override_principal(self, identity):
+        """Swap in a non-local principal for one test, resolved for real through
+        IdentityService via require_owner (only require_principal is stubbed)."""
+        principal = Principal(subject=identity, is_local=False)
+        self.app.dependency_overrides[require_principal] = lambda: principal
+        self.addCleanup(self.app.dependency_overrides.pop, require_principal, None)
 
     def _seed_plan(self, status="ACTIVE", rungs=((1, 110.0, 10), (2, 120.0, 10))):
         now = _utc_now_iso()
@@ -230,7 +254,8 @@ class ApiSmokeTest(unittest.TestCase):
         self.assertEqual(resp.json(), {"error": "symbol is required"})
 
     def test_remove_missing_position_returns_404(self):
-        resp = self.client.delete("/api/portfolio/ZZNOSUCH?owner=zz_api_import_test")
+        self._override_principal(TEST_IDENTITY)
+        resp = self.client.delete("/api/portfolio/ZZNOSUCH")
         self.assertEqual(resp.status_code, 404)
         self.assertEqual(resp.json(), {"error": "ZZNOSUCH not found in portfolio"})
 
@@ -240,7 +265,7 @@ class ApiSmokeTest(unittest.TestCase):
         self.assertEqual(resp.json(), {"error": "a CSV file upload or 'path' is required"})
 
     def test_import_multipart_round_trip(self):
-        owner = "zz_api_import_test"
+        self._override_principal(TEST_IDENTITY)
         csv = (
             "name,symbol,purchase_price,quantity,purchase_date,currency,"
             "sale_price,sale_date,current_price\n"
@@ -248,16 +273,41 @@ class ApiSmokeTest(unittest.TestCase):
         )
         try:
             resp = self.client.post(
-                f"/api/portfolio/import?owner={owner}",
+                "/api/portfolio/import",
                 files={"file": ("p.csv", csv, "text/csv")},
             )
             self.assertEqual(resp.status_code, 200)
-            self.assertEqual(resp.json(), {"owner": owner, "imported": 1})
+            self.assertEqual(resp.json(), {"owner": TEST_OWNER, "imported": 1})
 
-            got = self.client.get(f"/api/portfolio?owner={owner}").json()["securities"]
+            got = self.client.get("/api/portfolio").json()["securities"]
             self.assertEqual([s["symbol"] for s in got], ["ZZSMOKE"])
         finally:
-            self.client.delete(f"/api/portfolio/ZZSMOKE?owner={owner}")
+            self.client.delete("/api/portfolio/ZZSMOKE")
+
+    def test_unmapped_principal_returns_403_not_provisioned(self):
+        # No owner_identities row exists for this identity (issue #126 decision
+        # #2) — it must 403, not fall back to using the identity as the owner.
+        self._override_principal(UNMAPPED_IDENTITY)
+        resp = self.client.get("/api/portfolio")
+        self.assertEqual(resp.status_code, 403)
+        self.assertEqual(
+            resp.json(),
+            {"error": "not_provisioned", "message": "not_provisioned", "status": 403},
+        )
+
+    def test_unmapped_principal_403_is_identical_for_all_owner_scoped_routes(self):
+        # decision #4 — the same 403/not_provisioned shape regardless of route.
+        self._override_principal(UNMAPPED_IDENTITY)
+        for resp in (
+            self.client.get("/api/portfolio"),
+            self.client.get("/api/securities"),
+            self.client.get("/api/portfolio/delta-exposure"),
+        ):
+            self.assertEqual(resp.status_code, 403)
+            self.assertEqual(
+                resp.json(),
+                {"error": "not_provisioned", "message": "not_provisioned", "status": 403},
+            )
 
 
 class Phase3SurfaceGapRouteTest(unittest.TestCase):

--- a/tests/test_identity_service.py
+++ b/tests/test_identity_service.py
@@ -1,0 +1,54 @@
+import unittest
+from contextlib import closing
+
+from quantcore.db_safety import assert_not_production  # noqa: E402
+
+assert_not_production()
+
+from quantcore.db import get_connection  # noqa: E402
+from quantcore.repositories.owner_identity_repository import (  # noqa: E402
+    OwnerIdentityRepository,
+)
+from quantcore.services.identity import IdentityService, UnknownIdentityError  # noqa: E402
+
+IDENTITY = "zz_identity_test@example.com"
+OWNER = "zz_identity_owner"
+
+
+class IdentityServiceTest(unittest.TestCase):
+    def setUp(self):
+        self._purge()
+        self.addCleanup(self._purge)
+        self.repo = OwnerIdentityRepository()
+        self.service = IdentityService(owner_identity_repository=self.repo)
+
+    def _purge(self):
+        with closing(get_connection()) as conn:
+            conn.execute("DELETE FROM owner_identities WHERE identity = %s", (IDENTITY,))
+            conn.commit()
+
+    def test_resolve_owner_raises_for_unmapped_identity(self):
+        with self.assertRaises(UnknownIdentityError):
+            self.service.resolve_owner(IDENTITY)
+
+    def test_resolve_owner_returns_mapped_owner(self):
+        self.repo.upsert(IDENTITY, OWNER)
+        self.assertEqual(self.service.resolve_owner(IDENTITY), OWNER)
+
+    def test_resolve_owner_lowercases_identity(self):
+        self.repo.upsert(IDENTITY, OWNER)
+        self.assertEqual(self.service.resolve_owner(IDENTITY.upper()), OWNER)
+
+    def test_upsert_updates_existing_mapping(self):
+        self.repo.upsert(IDENTITY, OWNER)
+        self.repo.upsert(IDENTITY, "zz_identity_owner2")
+        self.assertEqual(self.service.resolve_owner(IDENTITY), "zz_identity_owner2")
+
+    def test_list_all_includes_seeded_mapping(self):
+        self.repo.upsert(IDENTITY, OWNER, notes="test note")
+        rows = self.repo.list_all()
+        self.assertIn((IDENTITY, OWNER, "test note"), rows)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Part of [issue #126](https://github.com/JohnFunkCode/StockPortfolioManager/issues/126)'s portfolio-lots plan (PR 2 of the [plan](docs/proposals/portfolio-lots-plan.md)). Follows PR #149 (QuantUI shell / Portfolio route).

- Adds an `owner_identities` mapping table (`db/migrations/V3__owner_identities.sql`, mirrored in `quantcore/db.py`'s schema DDL) plus `OwnerIdentityRepository` + `IdentityService` to resolve an authenticated identity (IAP email or MCP token `sub`) to its canonical short-handle owner.
- Adds a `require_owner` FastAPI dependency (`api/auth.py`) that every owner-scoped route now depends on instead of accepting an `?owner=` query param — there's no legitimate cross-user read path on this endpoint. An unmapped identity is **never auto-provisioned**: it logs a `SECURITY unmapped_principal` event and returns 403 `not_provisioned`, identically for ES256 UI tokens and HS256 MCP tokens.
- Frontend: a full-page `RestrictedAccess` screen (no header/nav/ChatRail) renders when a call reports `not_provisioned`, wired through a small pub-sub in `api/client.ts` so `App.tsx` can early-return before the route tree mounts. A provisioned owner with zero positions sees a friendly `EmptyPortfolio` state instead of a bare empty table.
- Ops: `scripts/grant_quantui_iap_access.sh` now writes the matching `owner_identities` row in the same run as each IAP grant, and fails loudly (naming which half succeeded) if the DB write doesn't land — so IAP access and the DB mapping can't drift apart, which is exactly the state that would land a legitimate user on the restricted screen.

## Test plan
- [x] `python -m unittest discover -s tests -t .` — 1025 tests, `OK (skipped=5)`
- [x] OpenAPI route surface diff — 99 routes, matched
- [x] `cd frontend && npx tsc --noEmit` — clean
- [x] `cd frontend && npx vitest run --coverage` — 391/391 passing, coverage above thresholds
- [x] `scripts/grant_quantui_iap_access.sh` DB-write logic verified directly against the test database (idempotent conflict path + fresh-insert path); the live `gcloud iap` IAM calls were intentionally not executed here
- [ ] After deploy to test: verify with two identities — one provisioned (sees their own data) and one deliberately unmapped (sees `RestrictedAccess`, security event appears in Cloud Run logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)