### PR TITLE
feat: lot-granular positions schema and multi-lot loss alerts (#126 PR 3)

### DIFF
--- a/db/migrations/V4__portfolio_lots.sql
+++ b/db/migrations/V4__portfolio_lots.sql
@@ -1,0 +1,50 @@
+-- V4: Portfolio lots (issue #126, PR 3)
+--
+-- The `positions` table becomes lot-granular: multiple open lots per symbol,
+-- partial sales via `lot_sales`, and parent/child lineage for splits. V2's
+-- (owner, symbol_id, purchase_date) UNIQUE index forbade exactly the split
+-- rule this PR introduces (a partial sale creates a second lot with the SAME
+-- owner/symbol/trade_date as its parent), so it is dropped here.
+
+-- Drop the index that forbids #126's own split rule. A partial sale creates a
+-- second lot with the SAME (owner, symbol, trade_date) as its parent.
+DROP INDEX IF EXISTS idx_positions_owner_symbol_date;
+
+ALTER TABLE positions
+  ADD COLUMN IF NOT EXISTS status            TEXT NOT NULL DEFAULT 'OPEN',
+  ADD COLUMN IF NOT EXISTS parent_lot_id     INTEGER REFERENCES positions(position_id) ON DELETE SET NULL,
+  -- 'trade_date', not 'purchase_date': cost basis and holding period run from
+  -- the TRADE date, not the settlement date, and "days held" counts from it.
+  ADD COLUMN IF NOT EXISTS trade_date        DATE,
+  ADD COLUMN IF NOT EXISTS fees              NUMERIC(18,6),
+  ADD COLUMN IF NOT EXISTS acquisition_type  TEXT NOT NULL DEFAULT 'BUY',
+  ADD COLUMN IF NOT EXISTS covered           BOOLEAN,
+  ADD COLUMN IF NOT EXISTS fx_rate_at_purchase NUMERIC(18,8),
+  -- Nullable now, populated when tax work lands (#126 decision 10).
+  ADD COLUMN IF NOT EXISTS basis_adjustment      NUMERIC(18,6),
+  ADD COLUMN IF NOT EXISTS wash_sale_disallowed  NUMERIC(18,6);
+
+-- Fractional shares: Schwab Stock Slices = 4dp, E*TRADE = 3dp on the ticket.
+ALTER TABLE positions ALTER COLUMN quantity TYPE NUMERIC(18,6);
+
+-- Backfill (#126 decision 11).
+UPDATE positions SET status = 'OPEN'          WHERE status IS NULL;
+UPDATE positions SET acquisition_type = 'BUY' WHERE acquisition_type IS NULL;
+UPDATE positions SET trade_date = purchase_date::date
+  WHERE trade_date IS NULL AND purchase_date IS NOT NULL AND purchase_date <> '';
+
+CREATE INDEX IF NOT EXISTS idx_positions_owner_status ON positions(owner, status);
+CREATE INDEX IF NOT EXISTS idx_positions_parent       ON positions(parent_lot_id);
+
+CREATE TABLE IF NOT EXISTS lot_sales (
+    sale_id        SERIAL PRIMARY KEY,
+    lot_id         INTEGER NOT NULL REFERENCES positions(position_id) ON DELETE CASCADE,
+    shares_sold    NUMERIC(18,6) NOT NULL,
+    sale_price     NUMERIC(18,6) NOT NULL,
+    sale_trade_date DATE NOT NULL,
+    fees           NUMERIC(18,6),
+    allocation_method TEXT,      -- FIFO | LIFO | HIFO | MANUAL
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    notes          TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_lot_sales_lot ON lot_sales(lot_id);

--- a/notifier.py
+++ b/notifier.py
@@ -93,16 +93,36 @@ class Notifier:
                 }
                 self.send_notifications(embed)
 
-            # Keep separate notification for price below purchase price
-            if stock.current_price.amount < stock.purchase_price.amount:
+            # Keep separate notification for price below purchase price,
+            # evaluated per lot so a symbol with multiple purchase lots
+            # doesn't hide an underwater lot behind a profitable one
+            # (issue #126 Step 3.4). One alert per symbol either way — the
+            # dedup key in send_notifications() is the embed title, which is
+            # symbol + alert type, not lot.
+            lots = self.portfolio.lots.get(stock.symbol) or [stock]
+            underwater_lots = []
+            for lot in lots:
+                lot.current_price = stock.current_price
+                if (
+                    lot.purchase_price is not None
+                    and stock.current_price is not None
+                    and stock.current_price.amount < lot.purchase_price.amount
+                ):
+                    underwater_lots.append(lot)
+
+            if underwater_lots:
+                lot_lines = [
+                    f"Purchased {lot.purchase_date} @ {lot.purchase_price} x {lot.quantity}: "
+                    f"{lot.calculate_gain_loss_percentage():.1f}% or {lot.calculate_gain_loss()} Loss"
+                    for lot in underwater_lots
+                ]
                 embed = {
                     "content": f"Stock Warning: {datetime.now():%Y-%m-%d %H:%M:%S} {stock.symbol}",
                     "embeds": [
                         {
                             "title": f"{stock.name} ({stock.symbol}) Loss Alert",
-                            "description": f"Current Price: {stock.current_price}\n"
-                                           f"Purchase Price: {stock.purchase_price}\n"
-                                           f"{stock.calculate_gain_loss_percentage():.1f}% or {stock.calculate_gain_loss()} Loss",
+                            "description": f"Current Price: {stock.current_price}\n\n"
+                                           + "\n".join(lot_lines),
                             "color": 16711680  # Red color for alert
                         }
                     ]

--- a/portfolio/portfolio.py
+++ b/portfolio/portfolio.py
@@ -208,8 +208,11 @@ class Portfolio:
             stock = Stock(
                 name=row.get('name'),
                 symbol=row['symbol'],
-                purchase_price=float(row['purchase_price']),
-                quantity=int(row['quantity']),
+                # Repository rows carry Decimal quantity/price (issue #126 Step
+                # 3.3's fractional shares) — int()/float() here would truncate
+                # a fractional lot like 0.0625 to zero shares.
+                purchase_price=row['purchase_price'],
+                quantity=row['quantity'],
                 purchase_date=purchase_date,
                 currency=row.get('currency', 'USD'),
                 sale_price=row.get('sale_price'),

--- a/portfolio/portfolio.py
+++ b/portfolio/portfolio.py
@@ -11,16 +11,24 @@ from portfolio.yfinance_gateway import get_descriptive_info
 class Portfolio:
     def __init__(self, default_currency: str = "USD"):
         self.stocks: Dict[str, Stock] = {}
+        # All lots per symbol, in insertion order. `self.stocks` stays
+        # symbol-keyed (last lot wins) for the many symbol-level consumers
+        # (MA/harvester/sentiment/options alerts, metrics, pricing); `self.lots`
+        # is the only place every lot survives, for lot-dependent consumers
+        # (issue #126 Step 3.4).
+        self.lots: Dict[str, List[Stock]] = {}
         self.default_currency = default_currency
 
     def add_stock(self, stock: Stock) -> None:
         """Add a stock to the portfolio"""
         self.stocks[stock.symbol] = stock
+        self.lots.setdefault(stock.symbol, []).append(stock)
 
     def remove_stock(self, symbol: str) -> None:
         """Remove a stock from the portfolio"""
         if symbol in self.stocks:
             del self.stocks[symbol]
+        self.lots.pop(symbol, None)
 
     def get_stock(self, symbol: str) -> Optional[Stock]:
         """Get a stock by its symbol"""

--- a/portfolio/stock.py
+++ b/portfolio/stock.py
@@ -1,15 +1,18 @@
-from typing import Optional, Dict, List
+from decimal import Decimal
+from typing import Optional, Dict, List, Union
 
 from datetime import date
 from portfolio.metrics import Metrics
 from portfolio.money import Money
 from portfolio.yfinance_gateway import get_latest_prices
 
+Number = Union[int, float, Decimal]
+
 
 class Stock:
     name: str
     symbol: str
-    quantity: int
+    quantity: Number
     purchase_price: Optional[Money] = None
     purchase_date: Optional[date] = None
     sale_price: Optional[Money] = None
@@ -22,13 +25,13 @@ class Stock:
         self,
         name: str,
         symbol: str,
-        quantity: Optional[int],
-        purchase_price: Optional[float],
+        quantity: Optional[Number],
+        purchase_price: Optional[Number],
         purchase_date: Optional[date],
         currency: str = "USD",
-        sale_price: Optional[float] = None,
+        sale_price: Optional[Number] = None,
         sale_date: Optional[date] = None,
-        current_price: Optional[float] = None,
+        current_price: Optional[Number] = None,
         tags: Optional[List[str]] = None
     ):
         self.name = name

--- a/quantcore/db.py
+++ b/quantcore/db.py
@@ -110,6 +110,47 @@ ALTER TABLE positions ADD COLUMN IF NOT EXISTS sale_date TEXT;
 CREATE UNIQUE INDEX IF NOT EXISTS idx_positions_owner_symbol_date
     ON positions(owner, symbol_id, purchase_date);
 
+-- V4 (issue #126, PR 3): lot-granular positions. Mirrors
+-- db/migrations/V4__portfolio_lots.sql. Drops the V2 unique index (it forbids
+-- the split rule: a partial sale creates a second lot with the SAME
+-- owner/symbol/trade_date as its parent) and adds lot status/lineage columns
+-- plus the lot_sales table.
+DROP INDEX IF EXISTS idx_positions_owner_symbol_date;
+
+ALTER TABLE positions
+  ADD COLUMN IF NOT EXISTS status            TEXT NOT NULL DEFAULT 'OPEN',
+  ADD COLUMN IF NOT EXISTS parent_lot_id     INTEGER REFERENCES positions(position_id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS trade_date        DATE,
+  ADD COLUMN IF NOT EXISTS fees              NUMERIC(18,6),
+  ADD COLUMN IF NOT EXISTS acquisition_type  TEXT NOT NULL DEFAULT 'BUY',
+  ADD COLUMN IF NOT EXISTS covered           BOOLEAN,
+  ADD COLUMN IF NOT EXISTS fx_rate_at_purchase NUMERIC(18,8),
+  ADD COLUMN IF NOT EXISTS basis_adjustment      NUMERIC(18,6),
+  ADD COLUMN IF NOT EXISTS wash_sale_disallowed  NUMERIC(18,6);
+
+ALTER TABLE positions ALTER COLUMN quantity TYPE NUMERIC(18,6);
+
+UPDATE positions SET status = 'OPEN'          WHERE status IS NULL;
+UPDATE positions SET acquisition_type = 'BUY' WHERE acquisition_type IS NULL;
+UPDATE positions SET trade_date = purchase_date::date
+  WHERE trade_date IS NULL AND purchase_date IS NOT NULL AND purchase_date <> '';
+
+CREATE INDEX IF NOT EXISTS idx_positions_owner_status ON positions(owner, status);
+CREATE INDEX IF NOT EXISTS idx_positions_parent       ON positions(parent_lot_id);
+
+CREATE TABLE IF NOT EXISTS lot_sales (
+    sale_id        SERIAL PRIMARY KEY,
+    lot_id         INTEGER NOT NULL REFERENCES positions(position_id) ON DELETE CASCADE,
+    shares_sold    NUMERIC(18,6) NOT NULL,
+    sale_price     NUMERIC(18,6) NOT NULL,
+    sale_trade_date DATE NOT NULL,
+    fees           NUMERIC(18,6),
+    allocation_method TEXT,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    notes          TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_lot_sales_lot ON lot_sales(lot_id);
+
 CREATE TABLE IF NOT EXISTS plan_instances (
     instance_id SERIAL PRIMARY KEY,
     template_id INTEGER NOT NULL,

--- a/quantcore/repositories/portfolio_repository.py
+++ b/quantcore/repositories/portfolio_repository.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from contextlib import closing
 from datetime import datetime, timezone
+from decimal import Decimal
 from typing import Any, Dict, List, Optional
 
 from quantcore.db import get_connection
@@ -32,6 +33,7 @@ SELECT symbol_id FROM symbols WHERE ticker = :ticker;
 
 SQL_LIST_POSITIONS = """
 SELECT
+    p.position_id    AS position_id,
     p.name           AS name,
     s.ticker         AS symbol,
     p.purchase_price AS purchase_price,
@@ -39,10 +41,18 @@ SELECT
     p.purchase_date  AS purchase_date,
     p.currency       AS currency,
     p.sale_price     AS sale_price,
-    p.sale_date      AS sale_date
+    p.sale_date      AS sale_date,
+    p.status         AS status,
+    p.parent_lot_id  AS parent_lot_id,
+    p.trade_date     AS trade_date,
+    p.fees           AS fees,
+    p.acquisition_type AS acquisition_type,
+    p.account        AS account,
+    p.notes          AS notes
 FROM positions p
 JOIN symbols s ON s.symbol_id = p.symbol_id
 WHERE p.owner = :owner
+  AND p.status = :status
 ORDER BY s.ticker, p.purchase_date;
 """
 
@@ -71,23 +81,77 @@ SQL_INSERT_POSITION = """
 INSERT INTO positions (
     owner, symbol_id, name,
     purchase_price, quantity, purchase_date, currency, sale_price, sale_date,
-    opened_at, entry_price, shares, cost_basis_total
+    opened_at, entry_price, shares, cost_basis_total,
+    status, parent_lot_id, trade_date, fees, acquisition_type, account, notes
 ) VALUES (
     :owner, :symbol_id, :name,
     :purchase_price, :quantity, :purchase_date, :currency, :sale_price, :sale_date,
-    :opened_at, :entry_price, :shares, :cost_basis_total
+    :opened_at, :entry_price, :shares, :cost_basis_total,
+    :status, :parent_lot_id, :trade_date, :fees, :acquisition_type, :account, :notes
 )
-ON CONFLICT(owner, symbol_id, purchase_date) DO UPDATE SET
-    name           = excluded.name,
-    purchase_price = excluded.purchase_price,
-    quantity       = excluded.quantity,
-    currency       = excluded.currency,
-    sale_price     = excluded.sale_price,
-    sale_date      = excluded.sale_date,
-    opened_at      = excluded.opened_at,
-    entry_price    = excluded.entry_price,
-    shares         = excluded.shares,
-    cost_basis_total = excluded.cost_basis_total;
+RETURNING position_id;
+"""
+
+SQL_GET_LOT = """
+SELECT
+    p.position_id    AS position_id,
+    p.name           AS name,
+    s.ticker         AS symbol,
+    p.purchase_price AS purchase_price,
+    p.quantity       AS quantity,
+    p.purchase_date  AS purchase_date,
+    p.currency       AS currency,
+    p.sale_price     AS sale_price,
+    p.sale_date      AS sale_date,
+    p.status         AS status,
+    p.parent_lot_id  AS parent_lot_id,
+    p.trade_date     AS trade_date,
+    p.fees           AS fees,
+    p.acquisition_type AS acquisition_type,
+    p.account        AS account,
+    p.notes          AS notes
+FROM positions p
+JOIN symbols s ON s.symbol_id = p.symbol_id
+WHERE p.owner = :owner
+  AND p.position_id = :lot_id;
+"""
+
+SQL_DELETE_LOT = """
+DELETE FROM positions WHERE owner = :owner AND position_id = :lot_id;
+"""
+
+SQL_LIST_LOTS_FOR_SYMBOL = """
+SELECT
+    p.position_id    AS position_id,
+    p.name           AS name,
+    s.ticker         AS symbol,
+    p.purchase_price AS purchase_price,
+    p.quantity       AS quantity,
+    p.purchase_date  AS purchase_date,
+    p.currency       AS currency,
+    p.sale_price     AS sale_price,
+    p.sale_date      AS sale_date,
+    p.status         AS status,
+    p.parent_lot_id  AS parent_lot_id,
+    p.trade_date     AS trade_date,
+    p.fees           AS fees,
+    p.acquisition_type AS acquisition_type,
+    p.account        AS account,
+    p.notes          AS notes
+FROM positions p
+JOIN symbols s ON s.symbol_id = p.symbol_id
+WHERE p.owner = :owner
+  AND s.ticker = :ticker{status_clause}
+ORDER BY p.trade_date, p.position_id;
+"""
+
+SQL_INSERT_SALE = """
+INSERT INTO lot_sales (
+    lot_id, shares_sold, sale_price, sale_trade_date, fees, allocation_method, notes
+) VALUES (
+    :lot_id, :shares_sold, :sale_price, :sale_trade_date, :fees, :allocation_method, :notes
+)
+RETURNING sale_id;
 """
 
 
@@ -95,19 +159,35 @@ def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+def _dec(v) -> Optional[Decimal]:
+    return Decimal(str(v)) if v is not None else None
+
+
 def _row_to_dict(row) -> Dict[str, Any]:
-    """Map a positions row to the CSV-parity dict shape the REST layer expects."""
+    """Map a positions row to the CSV-parity dict shape the REST layer expects.
+
+    Keeps every historical key (CSV parity, frontend dependency) and adds the
+    lot-identity fields from V4 (issue #126 Step 3.2).
+    """
     return {
         "name": (row["name"] or "").strip() if row["name"] is not None else "",
         "symbol": (row["symbol"] or "").strip().upper(),
-        "purchase_price": float(row["purchase_price"]) if row["purchase_price"] is not None else None,
-        "quantity": int(row["quantity"]) if row["quantity"] is not None else None,
+        "purchase_price": _dec(row["purchase_price"]),
+        "quantity": _dec(row["quantity"]),
         "purchase_date": row["purchase_date"] or None,
         "currency": (row["currency"] or "USD").strip().upper(),
-        "sale_price": float(row["sale_price"]) if row["sale_price"] is not None else None,
+        "sale_price": _dec(row["sale_price"]),
         "sale_date": row["sale_date"] or None,
         "source": "portfolio",
         "tags": [],
+        "lot_id": int(row["position_id"]) if row["position_id"] is not None else None,
+        "status": row["status"] or None,
+        "parent_lot_id": int(row["parent_lot_id"]) if row["parent_lot_id"] is not None else None,
+        "trade_date": row["trade_date"] or None,
+        "fees": _dec(row["fees"]),
+        "acquisition_type": row["acquisition_type"] or None,
+        "account": row["account"] or None,
+        "notes": row["notes"] or None,
     }
 
 
@@ -125,21 +205,28 @@ class PortfolioRepository:
 
     @staticmethod
     def _legacy_values(row: Dict[str, Any]) -> Dict[str, Any]:
-        """Derive the (now-nullable) legacy columns from CSV-parity fields."""
+        """Derive the (now-nullable) legacy columns from CSV-parity fields.
+
+        `shares` is a legacy INTEGER column with no reader left in the
+        codebase (grep-confirmed) — it cannot hold the fractional quantities
+        Step 3.3 introduces, so it's left NULL for those rather than raising.
+        """
         pp = row.get("purchase_price")
         qty = row.get("quantity")
         cost = (pp * qty) if (pp is not None and qty is not None) else None
+        whole_qty = qty if (qty is not None and qty == int(qty)) else None
         return {
             "opened_at": row.get("purchase_date"),
             "entry_price": pp,
-            "shares": qty,
+            "shares": whole_qty,
             "cost_basis_total": cost,
         }
 
-    def _insert_position(self, conn, owner: str, row: Dict[str, Any]) -> None:
+    def _insert_position(self, conn, owner: str, row: Dict[str, Any]) -> int:
+        """Insert one lot. Returns the new `position_id` (lot_id)."""
         symbol_id = self._resolve_symbol_id(conn, row["symbol"])
         legacy = self._legacy_values(row)
-        conn.execute(SQL_INSERT_POSITION, {
+        cur = conn.execute(SQL_INSERT_POSITION, {
             "owner": owner,
             "symbol_id": symbol_id,
             "name": row.get("name"),
@@ -149,15 +236,26 @@ class PortfolioRepository:
             "currency": row.get("currency"),
             "sale_price": row.get("sale_price"),
             "sale_date": row.get("sale_date"),
+            "status": row.get("status") or "OPEN",
+            "parent_lot_id": row.get("parent_lot_id"),
+            "trade_date": row.get("trade_date") or row.get("purchase_date"),
+            "fees": row.get("fees"),
+            "acquisition_type": row.get("acquisition_type") or "BUY",
+            "account": row.get("account"),
+            "notes": row.get("notes"),
             **legacy,
         })
+        return int(cur.fetchone()["position_id"])
 
     # ------------------------------------------------------------------
     # Reads
     # ------------------------------------------------------------------
-    def list_positions(self, owner: str) -> List[Dict[str, Any]]:
+    def list_positions(self, owner: str, status: str = "OPEN") -> List[Dict[str, Any]]:
+        """List `owner`'s lots. Defaults to open lots only (decision #12)."""
         with closing(get_connection()) as conn:
-            rows = conn.execute(SQL_LIST_POSITIONS, {"owner": owner}).fetchall()
+            rows = conn.execute(
+                SQL_LIST_POSITIONS, {"owner": owner, "status": status}
+            ).fetchall()
         return [_row_to_dict(r) for r in rows]
 
     def list_owners(self) -> List[str]:
@@ -171,6 +269,25 @@ class PortfolioRepository:
                 SQL_COUNT_OWNER_SYMBOL, {"owner": owner, "ticker": ticker.strip().upper()}
             ).fetchone()
         return int(row["n"]) if row else 0
+
+    def get_lot(self, owner: str, lot_id: int) -> Optional[Dict[str, Any]]:
+        with closing(get_connection()) as conn:
+            row = conn.execute(SQL_GET_LOT, {"owner": owner, "lot_id": lot_id}).fetchone()
+        return _row_to_dict(row) if row is not None else None
+
+    def list_lots_for_symbol(
+        self, owner: str, ticker: str, status: Optional[str] = "OPEN"
+    ) -> List[Dict[str, Any]]:
+        """List every lot of `ticker` for `owner`. `status=None` returns all statuses."""
+        sql = SQL_LIST_LOTS_FOR_SYMBOL.format(
+            status_clause="" if status is None else "\n  AND p.status = :status"
+        )
+        params = {"owner": owner, "ticker": ticker.strip().upper()}
+        if status is not None:
+            params["status"] = status
+        with closing(get_connection()) as conn:
+            rows = conn.execute(sql, params).fetchall()
+        return [_row_to_dict(r) for r in rows]
 
     # ------------------------------------------------------------------
     # Writes
@@ -191,15 +308,18 @@ class PortfolioRepository:
                 raise
         return len(rows)
 
-    def add_position(self, owner: str, row: Dict[str, Any]) -> None:
-        """Insert a single position (upsert on the owner/symbol/date key)."""
+    def add_position(self, owner: str, row: Dict[str, Any]) -> int:
+        """Insert a single lot. Every call creates a new lot (issue #126 Step 3.2)
+        — the old owner/symbol/date upsert is gone. Returns the new `lot_id`.
+        """
         with closing(get_connection()) as conn:
             try:
-                self._insert_position(conn, owner, row)
+                lot_id = self._insert_position(conn, owner, row)
                 conn.commit()
             except Exception:
                 conn.rollback()
                 raise
+        return lot_id
 
     def remove_position(self, owner: str, ticker: str) -> int:
         """Delete every lot of `ticker` for `owner`. Returns rows removed."""
@@ -214,3 +334,84 @@ class PortfolioRepository:
                 conn.rollback()
                 raise
         return int(removed)
+
+    def update_lot(self, owner: str, lot_id: int, fields: Dict[str, Any]) -> bool:
+        """Patch a single lot's mutable fields. Returns True if a row was updated.
+
+        `fields` keys must be a subset of the mutable lot columns; unknown keys
+        raise rather than being silently dropped.
+        """
+        mutable_columns = {
+            "name", "purchase_price", "quantity", "purchase_date", "currency",
+            "sale_price", "sale_date", "status", "parent_lot_id", "trade_date",
+            "fees", "acquisition_type", "account", "notes",
+        }
+        unknown = set(fields) - mutable_columns
+        if unknown:
+            raise ValueError(f"update_lot: unknown field(s) {sorted(unknown)}")
+        if not fields:
+            return False
+        set_clause = ", ".join(f"{col} = :{col}" for col in fields)
+        sql = (
+            f"UPDATE positions SET {set_clause} "
+            "WHERE owner = :owner AND position_id = :lot_id;"
+        )
+        params = {**fields, "owner": owner, "lot_id": lot_id}
+        with closing(get_connection()) as conn:
+            try:
+                cur = conn.execute(sql, params)
+                updated = cur.rowcount
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                raise
+        return updated > 0
+
+    def delete_lot(self, owner: str, lot_id: int) -> bool:
+        """Delete a single lot. Returns True if a row was deleted."""
+        with closing(get_connection()) as conn:
+            try:
+                cur = conn.execute(SQL_DELETE_LOT, {"owner": owner, "lot_id": lot_id})
+                deleted = cur.rowcount
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                raise
+        return deleted > 0
+
+    def insert_sale(
+        self,
+        owner: str,
+        lot_id: int,
+        shares_sold: Any,
+        sale_price: Any,
+        sale_trade_date: str,
+        fees: Any = None,
+        allocation_method: Optional[str] = None,
+        notes: Optional[str] = None,
+    ) -> int:
+        """Record a partial or full sale against `lot_id`. Returns the new `sale_id`.
+
+        Owner-scoped via an existence check — `lot_sales` itself has no owner
+        column, so a lot id alone must never be sufficient to write a row.
+        """
+        with closing(get_connection()) as conn:
+            try:
+                lot = conn.execute(SQL_GET_LOT, {"owner": owner, "lot_id": lot_id}).fetchone()
+                if lot is None:
+                    raise ValueError(f"lot {lot_id} not found for owner {owner!r}")
+                cur = conn.execute(SQL_INSERT_SALE, {
+                    "lot_id": lot_id,
+                    "shares_sold": shares_sold,
+                    "sale_price": sale_price,
+                    "sale_trade_date": sale_trade_date,
+                    "fees": fees,
+                    "allocation_method": allocation_method,
+                    "notes": notes,
+                })
+                sale_id = int(cur.fetchone()["sale_id"])
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                raise
+        return sale_id

--- a/quantcore/services/portfolio.py
+++ b/quantcore/services/portfolio.py
@@ -13,35 +13,48 @@ the CSV, so the WebUI and downstream callers are unaffected.
 from __future__ import annotations
 
 import csv
+import logging
+from decimal import Decimal
 from typing import Any, Dict, List, Optional
 
 from quantcore.repositories.portfolio_repository import PortfolioRepository
 
+logger = logging.getLogger(__name__)
+
 
 class DuplicateSymbolError(Exception):
-    """Raised by add_position when the owner already holds the symbol."""
+    """Kept for import-compatibility. No longer raised by add_position — a
+    symbol may have any number of open lots (issue #126 Step 3.3)."""
+
+
+def _money(v) -> Optional[Decimal]:
+    return Decimal(str(v)) if v not in (None, "") else None
+
+
+def _quantity(v) -> Optional[Decimal]:
+    return Decimal(str(v)).quantize(Decimal("0.000001")) if v not in (None, "") else None
 
 
 def _normalize_row(raw: Dict[str, Any]) -> Dict[str, Any]:
     """Coerce a raw CSV/body dict into the canonical position shape.
 
-    Mirrors the parsing api/app.py._load_portfolio() applied to portfolio.csv.
+    `trade_date` is the lot's real identity; `purchase_date` is a deprecated
+    alias accepted for backward compatibility (issue #126 Step 3.3).
     """
-    def _f(v):
-        return float(v) if v not in (None, "") else None
-
-    def _i(v):
-        return int(v) if v not in (None, "") else None
-
     return {
         "name": (raw.get("name") or "").strip(),
         "symbol": (raw.get("symbol") or "").strip().upper(),
-        "purchase_price": _f(raw.get("purchase_price")),
-        "quantity": _i(raw.get("quantity")),
+        "purchase_price": _money(raw.get("purchase_price")),
+        "quantity": _quantity(raw.get("quantity")),
         "purchase_date": (raw.get("purchase_date") or None),
+        "trade_date": (raw.get("trade_date") or raw.get("purchase_date") or None),
         "currency": (raw.get("currency") or "USD").strip().upper(),
-        "sale_price": _f(raw.get("sale_price")),
+        "sale_price": _money(raw.get("sale_price")),
         "sale_date": (raw.get("sale_date") or None),
+        "fees": _money(raw.get("fees")),
+        "acquisition_type": (raw.get("acquisition_type") or None),
+        "account": (raw.get("account") or None),
+        "notes": (raw.get("notes") or None),
     }
 
 
@@ -67,25 +80,29 @@ class PortfolioService:
         Returns the number of positions imported.
         """
         rows: List[Dict[str, Any]] = []
+        warned_deprecated_alias = False
         with open(path, newline="") as fh:
             for raw in csv.DictReader(fh):
                 row = _normalize_row(raw)
                 if not row["symbol"]:
                     continue
+                if not raw.get("trade_date") and raw.get("purchase_date") and not warned_deprecated_alias:
+                    logger.warning(
+                        "import_csv(owner=%s, path=%s): 'purchase_date' is a deprecated "
+                        "alias for 'trade_date' — update the CSV to include 'trade_date'",
+                        owner, path,
+                    )
+                    warned_deprecated_alias = True
                 rows.append(row)
         return self._repo.replace_owner_positions(owner, rows)
 
     def add_position(self, owner: str = "john", **fields: Any) -> Dict[str, Any]:
-        """Add a single position for `owner`.
-
-        Raises DuplicateSymbolError if the owner already holds the symbol —
-        preserving the REST 409-on-duplicate behaviour.
+        """Add a single lot for `owner`. Multiple lots per symbol are allowed —
+        each call creates a new lot rather than upserting (issue #126 Step 3.3).
         """
         row = _normalize_row(fields)
         if not row["symbol"]:
             raise ValueError("symbol is required")
-        if self._repo.count_for_symbol(owner, row["symbol"]) > 0:
-            raise DuplicateSymbolError(f"{row['symbol']} is already in the portfolio")
         self._repo.add_position(owner, row)
         return {"symbol": row["symbol"]}
 

--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -1,0 +1,133 @@
+import unittest
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+from notifier import Notifier
+from portfolio.metrics import Metrics
+from portfolio.portfolio import Portfolio
+from portfolio.stock import Stock
+
+
+def _lot(symbol, name, purchase_price, quantity, purchase_date, current_price):
+    stock = Stock(
+        name=name,
+        symbol=symbol,
+        quantity=quantity,
+        purchase_price=purchase_price,
+        purchase_date=purchase_date,
+        current_price=current_price,
+    )
+    # Non-None and below current_price so the moving-average checks in
+    # calculate_and_send_notifications() don't fire (or crash comparing
+    # against the Metrics() default of None).
+    stock.metrics = Metrics(
+        thirty_day_moving_average=1,
+        fifty_day_moving_average=1,
+        one_hundred_day_moving_average=1,
+        two_hundred_day_moving_average=1,
+    )
+    return stock
+
+
+class NotifierMultiLotLossAlertTest(unittest.TestCase):
+    """Two-lot fixture for issue #126 Step 3.4 — the loss alert must be
+    evaluated per lot, but still consolidated into one Discord notification
+    per symbol (dedup key is symbol + alert type, not lot)."""
+
+    def _make_notifier(self, portfolio: Portfolio) -> tuple[Notifier, list]:
+        harvester_stub = MagicMock()
+        harvester_stub.harvest_hit_for_symbol.return_value = []
+        services_stub = MagicMock()
+        services_stub.harvester = harvester_stub
+        patcher = patch("notifier.get_services", return_value=services_stub)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+        notifier = Notifier(portfolio)
+        notifier.check_options_alerts = MagicMock()
+        notifier.check_sentiment_flips = MagicMock()
+
+        sent_embeds: list = []
+        notifier.send_notifications = MagicMock(side_effect=sent_embeds.append)
+        return notifier, sent_embeds
+
+    def test_one_underwater_lot_and_one_profitable_lot_yields_one_alert(self):
+        portfolio = Portfolio()
+        losing_lot = _lot(
+            "ZZLOSSTEST", "ZZ Loss Test", purchase_price=50.0, quantity=10,
+            purchase_date=date(2026, 1, 2), current_price=40.0,
+        )
+        winning_lot = _lot(
+            "ZZLOSSTEST", "ZZ Loss Test", purchase_price=30.0, quantity=5,
+            purchase_date=date(2026, 2, 3), current_price=40.0,
+        )
+        portfolio.add_stock(losing_lot)
+        portfolio.add_stock(winning_lot)
+
+        notifier, sent_embeds = self._make_notifier(portfolio)
+        notifier.calculate_and_send_notifications()
+
+        loss_alerts = [
+            e for e in sent_embeds
+            if e["embeds"][0]["title"] == "ZZ Loss Test (ZZLOSSTEST) Loss Alert"
+        ]
+        self.assertEqual(
+            len(loss_alerts), 1,
+            "expected exactly one consolidated Loss Alert, not one per lot",
+        )
+
+        description = loss_alerts[0]["embeds"][0]["description"]
+        self.assertIn("2026-01-02", description)
+        self.assertNotIn("2026-02-03", description)
+
+    def test_no_lots_underwater_yields_no_loss_alert(self):
+        portfolio = Portfolio()
+        lot_a = _lot(
+            "ZZGAINTEST", "ZZ Gain Test", purchase_price=10.0, quantity=10,
+            purchase_date=date(2026, 1, 2), current_price=40.0,
+        )
+        lot_b = _lot(
+            "ZZGAINTEST", "ZZ Gain Test", purchase_price=20.0, quantity=5,
+            purchase_date=date(2026, 2, 3), current_price=40.0,
+        )
+        portfolio.add_stock(lot_a)
+        portfolio.add_stock(lot_b)
+
+        notifier, sent_embeds = self._make_notifier(portfolio)
+        notifier.calculate_and_send_notifications()
+
+        loss_alerts = [
+            e for e in sent_embeds
+            if e["embeds"][0]["title"] == "ZZ Gain Test (ZZGAINTEST) Loss Alert"
+        ]
+        self.assertEqual(loss_alerts, [])
+
+    def test_both_lots_underwater_yields_one_alert_listing_both(self):
+        portfolio = Portfolio()
+        lot_a = _lot(
+            "ZZBOTHLOSS", "ZZ Both Loss", purchase_price=50.0, quantity=10,
+            purchase_date=date(2026, 1, 2), current_price=40.0,
+        )
+        lot_b = _lot(
+            "ZZBOTHLOSS", "ZZ Both Loss", purchase_price=60.0, quantity=5,
+            purchase_date=date(2026, 2, 3), current_price=40.0,
+        )
+        portfolio.add_stock(lot_a)
+        portfolio.add_stock(lot_b)
+
+        notifier, sent_embeds = self._make_notifier(portfolio)
+        notifier.calculate_and_send_notifications()
+
+        loss_alerts = [
+            e for e in sent_embeds
+            if e["embeds"][0]["title"] == "ZZ Both Loss (ZZBOTHLOSS) Loss Alert"
+        ]
+        self.assertEqual(len(loss_alerts), 1)
+
+        description = loss_alerts[0]["embeds"][0]["description"]
+        self.assertIn("2026-01-02", description)
+        self.assertIn("2026-02-03", description)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_portfolio_repository.py
+++ b/tests/test_portfolio_repository.py
@@ -1,0 +1,145 @@
+import unittest
+from contextlib import closing
+from decimal import Decimal
+
+from quantcore.db_safety import assert_not_production  # noqa: E402
+
+assert_not_production()
+
+from quantcore.db import get_connection  # noqa: E402
+from quantcore.repositories.portfolio_repository import PortfolioRepository  # noqa: E402
+
+# Synthetic owner/symbol that won't collide with real positions in the
+# configured QuantCore database.
+OWNER = "zz_owner_lots"
+SYMBOL = "ZZLOT1"
+
+
+class PortfolioRepositoryLotsTest(unittest.TestCase):
+    """Issue #126 Step 3.2: the repository stops overwriting and starts
+    returning lot identity. These tests exercise PortfolioRepository directly
+    (bypassing PortfolioService's duplicate-symbol guard, which is Step 3.3's
+    concern) so multi-lot behavior can be verified now.
+    """
+
+    def setUp(self):
+        self._purge()
+        self.addCleanup(self._purge)
+        self.repo = PortfolioRepository()
+
+    def _purge(self):
+        with closing(get_connection()) as conn:
+            conn.execute("DELETE FROM positions WHERE owner = %s", (OWNER,))
+            conn.commit()
+
+    def _row(self, **overrides):
+        row = {
+            "name": "Test Lot",
+            "symbol": SYMBOL,
+            "purchase_price": 10.0,
+            "quantity": 5,
+            "purchase_date": "2026-01-02",
+            "currency": "USD",
+        }
+        row.update(overrides)
+        return row
+
+    # ------------------------------------------------------------------
+    def test_add_position_creates_a_new_lot_each_call(self):
+        lot_id_1 = self.repo.add_position(OWNER, self._row())
+        lot_id_2 = self.repo.add_position(OWNER, self._row())
+
+        self.assertIsInstance(lot_id_1, int)
+        self.assertIsInstance(lot_id_2, int)
+        self.assertNotEqual(lot_id_1, lot_id_2)
+
+        positions = self.repo.list_positions(OWNER)
+        self.assertEqual(len(positions), 2)
+        self.assertEqual(sorted(p["lot_id"] for p in positions), sorted([lot_id_1, lot_id_2]))
+
+    def test_row_to_dict_has_lot_identity_fields_and_keeps_existing_keys(self):
+        self.repo.add_position(OWNER, self._row())
+        positions = self.repo.list_positions(OWNER)
+        self.assertEqual(len(positions), 1)
+        row = positions[0]
+
+        # Existing CSV-parity keys, unchanged.
+        for key in (
+            "name", "symbol", "purchase_price", "quantity", "purchase_date",
+            "currency", "sale_price", "sale_date", "source", "tags",
+        ):
+            self.assertIn(key, row)
+        self.assertEqual(row["source"], "portfolio")
+        self.assertEqual(row["tags"], [])
+        self.assertEqual(row["purchase_price"], Decimal("10.0"))
+        self.assertEqual(row["quantity"], Decimal("5"))
+        self.assertIsInstance(row["purchase_price"], Decimal)
+        self.assertIsInstance(row["quantity"], Decimal)
+
+        # New lot-identity keys.
+        for key in (
+            "lot_id", "status", "parent_lot_id", "trade_date", "fees",
+            "acquisition_type", "account", "notes",
+        ):
+            self.assertIn(key, row)
+        self.assertEqual(row["status"], "OPEN")
+        self.assertEqual(row["acquisition_type"], "BUY")
+        self.assertIsNone(row["parent_lot_id"])
+        self.assertEqual(row["trade_date"].isoformat(), "2026-01-02")
+
+    def test_list_positions_defaults_to_open_lots_only(self):
+        open_lot = self.repo.add_position(OWNER, self._row())
+        closed_lot = self.repo.add_position(OWNER, self._row())
+        self.repo.update_lot(OWNER, closed_lot, {"status": "CLOSED"})
+
+        open_positions = self.repo.list_positions(OWNER)
+        self.assertEqual([p["lot_id"] for p in open_positions], [open_lot])
+
+        all_positions = self.repo.list_lots_for_symbol(OWNER, SYMBOL, status=None)
+        self.assertEqual(
+            sorted(p["lot_id"] for p in all_positions), sorted([open_lot, closed_lot])
+        )
+
+    def test_get_lot_is_owner_scoped(self):
+        lot_id = self.repo.add_position(OWNER, self._row())
+
+        self.assertIsNotNone(self.repo.get_lot(OWNER, lot_id))
+        self.assertIsNone(self.repo.get_lot("zz_someone_else", lot_id))
+
+    def test_update_lot_is_owner_scoped(self):
+        lot_id = self.repo.add_position(OWNER, self._row())
+
+        self.assertFalse(self.repo.update_lot("zz_someone_else", lot_id, {"notes": "x"}))
+        self.assertTrue(self.repo.update_lot(OWNER, lot_id, {"notes": "updated"}))
+        self.assertEqual(self.repo.get_lot(OWNER, lot_id)["notes"], "updated")
+
+    def test_update_lot_rejects_unknown_field(self):
+        lot_id = self.repo.add_position(OWNER, self._row())
+        with self.assertRaises(ValueError):
+            self.repo.update_lot(OWNER, lot_id, {"position_id": 999})
+
+    def test_delete_lot_is_owner_scoped(self):
+        lot_id = self.repo.add_position(OWNER, self._row())
+
+        self.assertFalse(self.repo.delete_lot("zz_someone_else", lot_id))
+        self.assertTrue(self.repo.delete_lot(OWNER, lot_id))
+        self.assertIsNone(self.repo.get_lot(OWNER, lot_id))
+
+    def test_insert_sale_requires_matching_owner(self):
+        lot_id = self.repo.add_position(OWNER, self._row(quantity=10))
+
+        with self.assertRaises(ValueError):
+            self.repo.insert_sale(
+                "zz_someone_else", lot_id, shares_sold=4, sale_price=12.0,
+                sale_trade_date="2026-02-01",
+            )
+
+        sale_id = self.repo.insert_sale(
+            OWNER, lot_id, shares_sold=4, sale_price=12.0,
+            sale_trade_date="2026-02-01", allocation_method="FIFO",
+        )
+        self.assertIsInstance(sale_id, int)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_portfolio_service.py
+++ b/tests/test_portfolio_service.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 import unittest
 from contextlib import closing
+from decimal import Decimal
 from pathlib import Path
 
 from quantcore.db_safety import assert_not_production  # noqa: E402
@@ -129,7 +130,7 @@ class PortfolioServiceTest(unittest.TestCase):
         self.assertIn(OWNER_A, owners)
         self.assertIn(OWNER_B, owners)
 
-    def test_add_position_then_duplicate_raises(self):
+    def test_add_position_allows_multiple_lots_of_same_symbol(self):
         result = self.service.add_position(
             OWNER_A, name="Added", symbol="zztest", purchase_price="12.5",
             quantity="4", purchase_date="2026-01-10", currency="usd",
@@ -141,11 +142,35 @@ class PortfolioServiceTest(unittest.TestCase):
         self.assertEqual(positions[0]["symbol"], "ZZTEST")
         self.assertEqual(positions[0]["currency"], "USD")
 
-        with self.assertRaises(DuplicateSymbolError):
-            self.service.add_position(
-                OWNER_A, name="Dup", symbol="ZZTEST", purchase_price="13",
-                quantity="1", purchase_date="2026-05-11",
-            )
+        # A second lot of the same symbol on the same date no longer raises —
+        # multiple lots per symbol is the feature (issue #126 Step 3.3).
+        second = self.service.add_position(
+            OWNER_A, name="Second Lot", symbol="ZZTEST", purchase_price="13",
+            quantity="1", purchase_date="2026-01-10",
+        )
+        self.assertEqual(second, {"symbol": "ZZTEST"})
+
+        positions = self.service.list_positions(OWNER_A)
+        self.assertEqual(len(positions), 2)
+        lot_ids = {p["lot_id"] for p in positions}
+        self.assertEqual(len(lot_ids), 2)
+
+    def test_add_position_fractional_quantity_round_trips_exactly(self):
+        self.service.add_position(
+            OWNER_A, name="Fractional", symbol="ZZTEST", purchase_price="100",
+            quantity="0.0625", purchase_date="2026-01-10",
+        )
+        positions = self.service.list_positions(OWNER_A)
+        self.assertEqual(len(positions), 1)
+        self.assertEqual(positions[0]["quantity"], Decimal("0.0625"))
+
+    def test_add_position_purchase_date_populates_trade_date(self):
+        self.service.add_position(
+            OWNER_A, name="Legacy Alias", symbol="ZZTEST", purchase_price="10",
+            quantity="1", purchase_date="2026-01-10",
+        )
+        positions = self.service.list_positions(OWNER_A)
+        self.assertEqual(positions[0]["trade_date"].isoformat(), "2026-01-10")
 
     def test_add_position_without_symbol_raises_value_error(self):
         with self.assertRaises(ValueError):

--- a/tests/test_stock_portfolio_manager.py
+++ b/tests/test_stock_portfolio_manager.py
@@ -223,5 +223,35 @@ class TestStockPortfolioManager(unittest.TestCase):
         self.assertEqual(total_current_eur.currency, "EUR")
 
 
+class TestReadStocksFromRecordsFractionalLots(unittest.TestCase):
+    """issue #126 Step 3.4: repository rows carry Decimal quantity/price
+    (fractional shares) — read_stocks_from_records() must not truncate
+    them via int()/float()."""
+
+    def test_fractional_quantity_and_decimal_price_round_trip_exactly(self):
+        portfolio = spm.Portfolio()
+        records = [{
+            "name": "Fractional Co",
+            "symbol": "ZZFRAC",
+            "purchase_price": Decimal("133.3300"),
+            "quantity": Decimal("0.0625"),
+            "purchase_date": "2026-01-10",
+            "currency": "USD",
+            "sale_price": None,
+            "sale_date": None,
+        }]
+
+        portfolio.read_stocks_from_records(records)
+        stock = portfolio.get_stock("ZZFRAC")
+
+        self.assertEqual(stock.quantity, Decimal("0.0625"))
+        self.assertEqual(stock.purchase_price.amount, Decimal("133.33"))
+
+        stock.current_price = Money("100.00", "USD")
+        gain_loss = stock.calculate_gain_loss()
+        # (100 - 133.33) * 0.0625 = -2.083125 -> quantized to cents by Money
+        self.assertEqual(gain_loss.amount, Decimal("-2.08"))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Part of issue #126 (portfolio-lots-plan), PR 3 of 4. Builds on PR 1 (merged) and PR 2/#150 (merged, shipped prod).
- `db/migrations/V4__portfolio_lots.sql` (+ mirrored inline in `quantcore/db.py`): makes `positions` lot-granular — drops the `(owner, symbol_id, purchase_date)` unique index (it forbids the split rule a partial sale needs: a partial sale creates a second lot with the *same* owner/symbol/trade_date as its parent), adds `status`/`parent_lot_id`/`trade_date`/`fees`/`acquisition_type`/`account`/`notes` and a new `lot_sales` table for partial-sale bookkeeping.
- `PortfolioRepository`/`PortfolioService.add_position` no longer upsert on owner/symbol/date — every call creates a new lot. `DuplicateSymbolError` is kept only for import compatibility and is no longer raised.
- `Portfolio` gains `self.lots: Dict[str, List[Stock]]` alongside the existing symbol-keyed `self.stocks` (last-lot-wins, unchanged for the many symbol-level consumers: MA checks, harvester, sentiment, options alerts, metrics, pricing).
- `notifier.py`'s loss-alert check now evaluates each lot independently (via `portfolio.lots`) instead of comparing only the last-loaded lot, so a profitable lot can no longer mask an underwater one — while still sending exactly one consolidated Discord embed per symbol.

## Test plan
- [x] Full backend suite: `coverage run -m unittest discover -s tests -t .` — 1038 tests, `OK (skipped=5)`.
- [x] Live acceptance run on the **test** database (per the plan's explicit acceptance criteria — not an HTML report diff): seeded a real two-lot symbol (KO, one underwater lot + one profitable lot) through the actual `Portfolio` → `Notifier` report path, with `notifier.requests.post` monkeypatched so nothing was sent to the real Discord webhook. Confirmed exactly one consolidated Loss Alert embed, listing only the underwater lot and correctly omitting the profitable one. Seeded rows cleaned up afterward.
- [x] New/updated unit tests: `tests/test_notifier.py` (multi-lot loss-alert scenarios), `tests/test_portfolio_repository.py` (lot identity), `tests/test_portfolio_service.py` (multi-lot + fractional quantity + trade_date alias).

🤖 Generated with [Claude Code](https://claude.com/claude-code)