### PR TITLE
PR 4 follow-up: Sidekick registry parity + portfolio-server MCP wrapper (Steps 4.7-4.8)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -227,6 +227,20 @@ jobs:
             gcloud run deploy "quantcore-$s" --project "$PROJECT_ID" --region "$REGION" \
               --image "$REGION-docker.pkg.dev/$PROJECT_ID/$AR_REPO/quantcore-mcp:${GITHUB_SHA::7}"
           done
+      - name: Deploy quantcore-portfolio (image-only; env preserved)
+        # quantcore-portfolio's FIRST deploy is a manual one-time step (create
+        # the service with --allow-unauthenticated + SERVER_MODULE/PORT/
+        # QUANTCORE_REST_URL env, mirroring the other 5 wrappers — see
+        # portfolio-lots-plan.md Step 4.8). That config persists across
+        # image-only redeploys. Until that one-time deploy exists, skip rather
+        # than fail (a fresh service can't be image-only deployed).
+        run: |
+          if gcloud run services describe quantcore-portfolio --project "$PROJECT_ID" --region "$REGION" >/dev/null 2>&1; then
+            gcloud run deploy quantcore-portfolio --project "$PROJECT_ID" --region "$REGION" \
+              --image "$REGION-docker.pkg.dev/$PROJECT_ID/$AR_REPO/quantcore-mcp:${GITHUB_SHA::7}"
+          else
+            echo "quantcore-portfolio service not found — first deploy is a manual one-time step; skipping image roll-out."
+          fi
       - name: Update report Job image
         run: |
           gcloud run jobs update quantcore-report --project "$PROJECT_ID" --region "$REGION" \

--- a/.mcp.json
+++ b/.mcp.json
@@ -35,6 +35,13 @@
         "Authorization": "Bearer ${QUANTCORE_MCP_TOKEN}"
       }
     },
+    "portfolio-server": {
+      "type": "http",
+      "url": "https://quantcore-portfolio-swgixldxzq-uc.a.run.app/mcp",
+      "headers": {
+        "Authorization": "Bearer ${QUANTCORE_MCP_TOKEN}"
+      }
+    },
     "stock-price-server-local": {
       "type": "http",
       "url": "http://localhost:6001/mcp"
@@ -54,6 +61,10 @@
     "market-analysis-server-local": {
       "type": "http",
       "url": "http://localhost:6005/mcp"
+    },
+    "portfolio-server-local": {
+      "type": "http",
+      "url": "http://localhost:6006/mcp"
     }
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -158,6 +158,19 @@ services:
     restart: on-failure
     networks: [quantcore]
 
+  portfolio:
+    build: { context: ., dockerfile: Dockerfile.mcp }
+    environment:
+      SERVER_MODULE: fastMCPTest.portfolio_server
+      PORT: "6006"
+      QUANTCORE_REST_URL: "http://quantcore-api:5001"
+    ports: ["6006:6006"]
+    depends_on:
+      quantcore-api:
+        condition: service_healthy
+    restart: on-failure
+    networks: [quantcore]
+
   # --- QuantUI: React/Vite SPA served + /api reverse-proxied to quantcore-api ---
   # Build context is ./frontend (the repo-root .dockerignore excludes frontend/),
   # so the Dockerfile lives one level up at ../Dockerfile.ui. No QUANTCORE_API_TOKEN

--- a/fastMCPTest/portfolio_server.py
+++ b/fastMCPTest/portfolio_server.py
@@ -1,0 +1,110 @@
+"""
+Portfolio MCP Server (issue #126 PR 4, Step 4.8)
+
+Provides three **read-only** tools over the caller's own portfolio:
+
+  get_portfolio         — per-symbol roll-up (value, gain/loss, $/day) + totals
+  get_symbol_lots        — the individual lots making up one symbol's position
+  get_portfolio_summary  — just the portfolio-wide totals
+
+Usage (standalone):
+    fastmcp run portfolio_server.py
+
+HTTP gateway wrapper (architectural standard v2 §11, Rule 6 —
+``AI Agent → MCP wrapper → REST tier → Service``): each tool translates its call
+into a single HTTP request against the FastAPI front door via
+``mcp_gateway.rest_client``; no business logic or DB access lives here. The
+REST tier resolves the owner from the caller's authenticated token
+(``require_owner``) — there is no ``owner``/``ticker``-as-cross-user-filter
+argument on any tool here, so a caller can only ever see their own portfolio.
+
+This wrapper is deliberately **read-only**: there are no ``create_lot``,
+``close_lot``, or ``delete_lot`` tools, and ``mcp_gateway.rest_client`` has no
+``put``/``patch``/``delete`` verbs to call even if one were added here. Adding
+write tools is a decision the plan defers (#126 Q19), not an oversight.
+"""
+
+import os
+import platform
+import sys
+from importlib import metadata as importlib_metadata
+from pathlib import Path
+
+MCP_DIR = Path(__file__).resolve().parent
+PROJECT_ROOT = MCP_DIR.parent
+for path in (PROJECT_ROOT, MCP_DIR):
+    path_str = str(path)
+    if path_str not in sys.path:
+        sys.path.insert(0, path_str)
+
+from fastmcp import FastMCP
+
+from mcp_gateway import rest_client
+
+mcp = FastMCP("portfolio-server")
+
+
+@mcp.tool()
+def mcp_health_check() -> dict:
+    """Return lightweight version/config info for MCP diagnostics."""
+    try:
+        fastmcp_version = importlib_metadata.version("fastmcp")
+    except importlib_metadata.PackageNotFoundError:
+        fastmcp_version = "unknown"
+
+    return {
+        "server": "portfolio-server",
+        "python_version": sys.version.split()[0],
+        "platform": platform.platform(),
+        "fastmcp_version": fastmcp_version,
+    }
+
+
+@mcp.tool()
+def get_portfolio() -> dict:
+    """Return the caller's portfolio as a per-symbol roll-up, with totals.
+
+    Each entry aggregates every open lot held in that symbol: total
+    investment, current value, gain/loss ($ and %), $/day, and 7/30/90-day
+    returns. Always the caller's own holdings — the owner is resolved from
+    the caller's authenticated token, never from an argument.
+
+    Returns:
+        symbols — list of per-symbol roll-up dicts
+        totals  — portfolio-wide investment/value/gain-loss/$-per-day
+    """
+    return rest_client.get("/api/portfolio/symbols")
+
+
+@mcp.tool()
+def get_symbol_lots(ticker: str) -> dict:
+    """Return the caller's individual lots for one symbol.
+
+    Each lot carries its own purchase price, quantity, purchase date,
+    current price, and per-lot gain/loss — useful for questions about cost
+    basis or when a specific lot was opened, which the per-symbol roll-up
+    from get_portfolio collapses away.
+
+    Args:
+        ticker: Stock ticker symbol (e.g. 'AAPL')
+    """
+    ticker = ticker.strip().upper()
+    lots = rest_client.get("/api/portfolio/lots").get("lots", [])
+    return {"ticker": ticker, "lots": [lot for lot in lots if lot.get("symbol") == ticker]}
+
+
+@mcp.tool()
+def get_portfolio_summary() -> dict:
+    """Return just the caller's portfolio-wide totals (no per-symbol detail).
+
+    Returns:
+        total_investment, total_current_value, total_gain_loss,
+        total_gain_loss_pct, total_dollars_per_day
+    """
+    return rest_client.get("/api/portfolio/symbols").get("totals") or {}
+
+
+if __name__ == "__main__":
+    # Streamable HTTP transport (Rule 6). PORT is overridable so the same image
+    # can be reused per wrapper in docker-compose / Cloud Run.
+    mcp.run(transport="http", host="0.0.0.0", port=int(os.environ.get("PORT", "6006")))

--- a/frontend/src/chat/componentRegistry.test.ts
+++ b/frontend/src/chat/componentRegistry.test.ts
@@ -20,9 +20,37 @@ describe('COMPONENT_REGISTRY', () => {
       'arbitrage_premium',
       'arbitrage_scan',
       'arbitrage_discovery',
+      'portfolio_table',
+      'symbol_lots',
     ]) {
       expect(COMPONENT_REGISTRY[name]?.component, name).toBeTypeOf('function');
     }
+  });
+
+  it('portfolio_table takes no props — never an owner prop, never a ticker', () => {
+    // Mirrors test_chat_tools.py: the card resolves the caller's own
+    // portfolio from the authenticated session. A model-settable owner
+    // would allow a cross-user read (decision #20).
+    expect(validateDirective({ component: 'portfolio_table', props: {} }).ok).toBe(true);
+    expect(
+      validateDirective({ component: 'portfolio_table', props: { owner: 'someone_else' } }).ok,
+    ).toBe(false);
+    expect(
+      validateDirective({ component: 'portfolio_table', props: { ticker: 'INTC' } }).ok,
+    ).toBe(false);
+  });
+
+  it('symbol_lots takes a ticker and rejects an owner prop', () => {
+    expect(validateDirective({ component: 'symbol_lots', props: { ticker: 'INTC' } }).ok).toBe(
+      true,
+    );
+    expect(validateDirective({ component: 'symbol_lots', props: {} }).ok).toBe(false);
+    expect(
+      validateDirective({
+        component: 'symbol_lots',
+        props: { ticker: 'INTC', owner: 'someone_else' },
+      }).ok,
+    ).toBe(false);
   });
 
   it('accepts the arbitrage chart directives and rejects wrong props', () => {

--- a/frontend/src/chat/componentRegistry.tsx
+++ b/frontend/src/chat/componentRegistry.tsx
@@ -15,6 +15,8 @@ import {
   ArbScanCard,
   DiscoveryCard,
 } from '../components/chat/ArbitrageChartCards';
+import PortfolioTableCard from '../components/chat/PortfolioTableCard';
+import SymbolLotsCard from '../components/chat/SymbolLotsCard';
 import type { ChatDirective } from './types';
 
 type PropKind = 'string' | 'number';
@@ -56,6 +58,11 @@ export const COMPONENT_REGISTRY: Record<string, RegistryEntry> = {
   // Universe-wide: no props at all.
   arbitrage_scan: { component: ArbScanCard, spec: {}, titled: false },
   arbitrage_discovery: { component: DiscoveryCard, spec: { symbols: 'string' } },
+  // No props: always the caller's own portfolio via the browser's
+  // authenticated session — never add an `owner` prop (decision #20).
+  portfolio_table: { component: PortfolioTableCard, spec: {}, titled: false },
+  // Carries its own "TICKER — Lots" heading, so no titled wrapper.
+  symbol_lots: { component: SymbolLotsCard, spec: TICKER_ONLY },
 };
 
 /**

--- a/frontend/src/components/chat/PortfolioTableCard.test.tsx
+++ b/frontend/src/components/chat/PortfolioTableCard.test.tsx
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+
+import PortfolioTableCard from './PortfolioTableCard';
+import { mockApi, portfolioTotals, renderWithProviders, symbolRow } from '../../testUtils';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('PortfolioTableCard', () => {
+  it('renders symbol rows and totals once the portfolio loads', async () => {
+    mockApi([
+      [
+        '/api/portfolio/symbols',
+        { symbols: [symbolRow(), symbolRow({ symbol: 'MSFT' })], totals: portfolioTotals() },
+      ],
+    ]);
+    renderWithProviders(<PortfolioTableCard />);
+    await waitFor(() => expect(screen.getByTestId('portfolio-table-card')).toBeInTheDocument());
+    expect(screen.getByText('INTC')).toBeInTheDocument();
+    expect(screen.getByText('MSFT')).toBeInTheDocument();
+  });
+
+  it('shows an info alert when the portfolio is empty', async () => {
+    mockApi([['/api/portfolio/symbols', { symbols: [], totals: null }]]);
+    renderWithProviders(<PortfolioTableCard />);
+    await waitFor(() =>
+      expect(screen.getByText(/portfolio is empty/i)).toBeInTheDocument(),
+    );
+  });
+
+  it('shows an error alert when the fetch fails', async () => {
+    mockApi([['/api/portfolio/symbols', () => ({ __status: 500, error: 'boom' })]]);
+    renderWithProviders(<PortfolioTableCard />);
+    await waitFor(() =>
+      expect(screen.getByText(/Couldn't load your portfolio/i)).toBeInTheDocument(),
+    );
+  });
+});

--- a/frontend/src/components/chat/PortfolioTableCard.tsx
+++ b/frontend/src/components/chat/PortfolioTableCard.tsx
@@ -1,0 +1,123 @@
+/**
+ * Self-fetching chat card for the Sidekick — renders the caller's own
+ * portfolio (per-symbol roll-up + totals). Read-only: no edit/delete/close
+ * actions, mirroring the Portfolio page's data but never its mutations
+ * (decision #20 — Sidekick is display-only).
+ *
+ * Every number here comes straight from GET /api/portfolio/symbols. No
+ * gain/loss, percentage, or totals math happens in this file (Rule 8.4).
+ */
+import {
+  Alert,
+  Box,
+  CircularProgress,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
+import { useSymbolRows } from '../../hooks/usePortfolio';
+import { formatCurrency, formatDollarsPerDay, formatPercentRaw } from '../../utils/formatting';
+
+function gainColor(value: number | null): string | undefined {
+  if (value == null) return undefined;
+  return value >= 0 ? '#10b981' : '#ef4444';
+}
+
+export default function PortfolioTableCard() {
+  const { data, isLoading, error } = useSymbolRows();
+
+  if (isLoading) {
+    return (
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 2 }}>
+        <CircularProgress size={18} />
+        <Typography variant="body2" color="text.secondary">
+          Loading your portfolio…
+        </Typography>
+      </Box>
+    );
+  }
+  if (error) {
+    return <Alert severity="error">Couldn&apos;t load your portfolio.</Alert>;
+  }
+  const rows = data?.symbols ?? [];
+  if (rows.length === 0) {
+    return <Alert severity="info">No lots yet — the portfolio is empty.</Alert>;
+  }
+
+  const totals = data?.totals;
+
+  return (
+    <Box data-testid="portfolio-table-card">
+      <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+        Your portfolio
+      </Typography>
+      {totals && (
+        <Stack direction="row" spacing={3} flexWrap="wrap" useFlexGap sx={{ mb: 1 }}>
+          <Metric label="Investment" value={formatCurrency(totals.total_investment)} />
+          <Metric label="Current Value" value={formatCurrency(totals.total_current_value)} />
+          <Metric
+            label="Gain/Loss"
+            value={formatCurrency(totals.total_gain_loss)}
+            color={gainColor(totals.total_gain_loss)}
+          />
+          <Metric
+            label="Gain/Loss %"
+            value={formatPercentRaw(totals.total_gain_loss_pct)}
+            color={gainColor(totals.total_gain_loss_pct)}
+          />
+          <Metric label="$/Day" value={formatDollarsPerDay(totals.total_dollars_per_day)} />
+        </Stack>
+      )}
+      <Paper variant="outlined" sx={{ overflowX: 'auto' }}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Symbol</TableCell>
+              <TableCell align="right">Value</TableCell>
+              <TableCell align="right">Gain/Loss $</TableCell>
+              <TableCell align="right">Gain/Loss %</TableCell>
+              <TableCell align="right">$/Day</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {rows.map((row) => (
+              <TableRow key={row.symbol}>
+                <TableCell>
+                  <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                    {row.symbol}
+                  </Typography>
+                </TableCell>
+                <TableCell align="right">{formatCurrency(row.total_current_value)}</TableCell>
+                <TableCell align="right" sx={{ color: gainColor(row.total_gain_loss) }}>
+                  {formatCurrency(row.total_gain_loss)}
+                </TableCell>
+                <TableCell align="right" sx={{ color: gainColor(row.total_gain_loss_pct) }}>
+                  {formatPercentRaw(row.total_gain_loss_pct)}
+                </TableCell>
+                <TableCell align="right">{formatDollarsPerDay(row.total_dollars_per_day)}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Paper>
+    </Box>
+  );
+}
+
+function Metric({ label, value, color }: { label: string; value: string; color?: string }) {
+  return (
+    <Box>
+      <Typography variant="caption" color="text.secondary" display="block">
+        {label}
+      </Typography>
+      <Typography variant="body2" sx={color ? { color, fontWeight: 600 } : { fontWeight: 600 }}>
+        {value}
+      </Typography>
+    </Box>
+  );
+}

--- a/frontend/src/components/chat/SymbolLotsCard.test.tsx
+++ b/frontend/src/components/chat/SymbolLotsCard.test.tsx
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+
+import SymbolLotsCard from './SymbolLotsCard';
+import { lotRow, mockApi, portfolioTotals, renderWithProviders, symbolRow } from '../../testUtils';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('SymbolLotsCard', () => {
+  it('renders only the requested ticker\'s lots', async () => {
+    mockApi([
+      [
+        '/api/portfolio/symbols',
+        {
+          symbols: [
+            symbolRow({ symbol: 'INTC', lots: [lotRow({ lot_id: 1 }), lotRow({ lot_id: 2 })] }),
+            symbolRow({ symbol: 'MSFT' }),
+          ],
+          totals: portfolioTotals(),
+        },
+      ],
+    ]);
+    renderWithProviders(<SymbolLotsCard ticker="INTC" />);
+    await waitFor(() => expect(screen.getByTestId('symbol-lots-card')).toBeInTheDocument());
+    expect(screen.getByText('INTC — Lots')).toBeInTheDocument();
+    expect(screen.queryByText('MSFT')).not.toBeInTheDocument();
+  });
+
+  it('shows an info alert when the symbol has no lots', async () => {
+    mockApi([
+      ['/api/portfolio/symbols', { symbols: [symbolRow({ symbol: 'MSFT' })], totals: portfolioTotals() }],
+    ]);
+    renderWithProviders(<SymbolLotsCard ticker="INTC" />);
+    await waitFor(() =>
+      expect(screen.getByText(/No INTC lots in your portfolio/i)).toBeInTheDocument(),
+    );
+  });
+
+  it('shows an error alert when the fetch fails', async () => {
+    mockApi([['/api/portfolio/symbols', () => ({ __status: 500, error: 'boom' })]]);
+    renderWithProviders(<SymbolLotsCard ticker="INTC" />);
+    await waitFor(() =>
+      expect(screen.getByText(/Couldn't load lots for INTC/i)).toBeInTheDocument(),
+    );
+  });
+});

--- a/frontend/src/components/chat/SymbolLotsCard.test.tsx
+++ b/frontend/src/components/chat/SymbolLotsCard.test.tsx
@@ -28,6 +28,21 @@ describe('SymbolLotsCard', () => {
     expect(screen.queryByText('MSFT')).not.toBeInTheDocument();
   });
 
+  it('normalizes a lowercase ticker to match the API\'s uppercase symbol', async () => {
+    mockApi([
+      [
+        '/api/portfolio/symbols',
+        {
+          symbols: [symbolRow({ symbol: 'INTC', lots: [lotRow({ lot_id: 1 })] })],
+          totals: portfolioTotals(),
+        },
+      ],
+    ]);
+    renderWithProviders(<SymbolLotsCard ticker="intc" />);
+    await waitFor(() => expect(screen.getByTestId('symbol-lots-card')).toBeInTheDocument());
+    expect(screen.getByText('INTC — Lots')).toBeInTheDocument();
+  });
+
   it('shows an info alert when the symbol has no lots', async () => {
     mockApi([
       ['/api/portfolio/symbols', { symbols: [symbolRow({ symbol: 'MSFT' })], totals: portfolioTotals() }],

--- a/frontend/src/components/chat/SymbolLotsCard.tsx
+++ b/frontend/src/components/chat/SymbolLotsCard.tsx
@@ -1,0 +1,122 @@
+/**
+ * Self-fetching chat card for the Sidekick — renders the caller's own lots
+ * for one symbol. Read-only, same rationale as PortfolioTableCard: no
+ * edit/delete/close actions (decision #20).
+ *
+ * Filters the shared portfolio-symbols response client-side rather than
+ * hitting a dedicated endpoint, since none exists for a single symbol.
+ */
+import {
+  Alert,
+  Box,
+  CircularProgress,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
+import { useSymbolRows } from '../../hooks/usePortfolio';
+import {
+  formatCurrency,
+  formatDollarsPerDay,
+  formatPercentRaw,
+  formatShares,
+} from '../../utils/formatting';
+
+function gainColor(value: number | null): string | undefined {
+  if (value == null) return undefined;
+  return value >= 0 ? '#10b981' : '#ef4444';
+}
+
+export default function SymbolLotsCard({ ticker }: { ticker: string }) {
+  const { data, isLoading, error } = useSymbolRows();
+
+  if (isLoading) {
+    return (
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 2 }}>
+        <CircularProgress size={18} />
+        <Typography variant="body2" color="text.secondary">
+          Loading {ticker} lots…
+        </Typography>
+      </Box>
+    );
+  }
+  if (error) {
+    return <Alert severity="error">Couldn&apos;t load lots for {ticker}.</Alert>;
+  }
+
+  const row = (data?.symbols ?? []).find((s) => s.symbol === ticker);
+  if (!row) {
+    return <Alert severity="info">No {ticker} lots in your portfolio.</Alert>;
+  }
+
+  return (
+    <Box data-testid="symbol-lots-card">
+      <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
+        {ticker} — Lots
+      </Typography>
+      <Stack direction="row" spacing={3} flexWrap="wrap" useFlexGap sx={{ mb: 1 }}>
+        <Metric label="Investment" value={formatCurrency(row.total_investment)} />
+        <Metric label="Current Value" value={formatCurrency(row.total_current_value)} />
+        <Metric
+          label="Gain/Loss"
+          value={formatCurrency(row.total_gain_loss)}
+          color={gainColor(row.total_gain_loss)}
+        />
+        <Metric
+          label="Gain/Loss %"
+          value={formatPercentRaw(row.total_gain_loss_pct)}
+          color={gainColor(row.total_gain_loss_pct)}
+        />
+        <Metric label="$/Day" value={formatDollarsPerDay(row.total_dollars_per_day)} />
+      </Stack>
+      <Paper variant="outlined" sx={{ overflowX: 'auto' }}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Price Paid</TableCell>
+              <TableCell>Shares</TableCell>
+              <TableCell>Gain/Loss %</TableCell>
+              <TableCell>Gain/Loss $</TableCell>
+              <TableCell>Days Held</TableCell>
+              <TableCell>$/Day</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {row.lots.map((lot) => (
+              <TableRow key={lot.lot_id}>
+                <TableCell>{formatCurrency(lot.purchase_price)}</TableCell>
+                <TableCell>{formatShares(lot.quantity)}</TableCell>
+                <TableCell sx={{ color: gainColor(lot.gain_loss_pct) }}>
+                  {formatPercentRaw(lot.gain_loss_pct)}
+                </TableCell>
+                <TableCell sx={{ color: gainColor(lot.gain_loss) }}>
+                  {formatCurrency(lot.gain_loss)}
+                </TableCell>
+                <TableCell>{lot.days_held ?? '—'}</TableCell>
+                <TableCell>{formatDollarsPerDay(lot.dollars_per_day)}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Paper>
+    </Box>
+  );
+}
+
+function Metric({ label, value, color }: { label: string; value: string; color?: string }) {
+  return (
+    <Box>
+      <Typography variant="caption" color="text.secondary" display="block">
+        {label}
+      </Typography>
+      <Typography variant="body2" sx={color ? { color, fontWeight: 600 } : { fontWeight: 600 }}>
+        {value}
+      </Typography>
+    </Box>
+  );
+}

--- a/frontend/src/components/chat/SymbolLotsCard.tsx
+++ b/frontend/src/components/chat/SymbolLotsCard.tsx
@@ -33,6 +33,7 @@ function gainColor(value: number | null): string | undefined {
 }
 
 export default function SymbolLotsCard({ ticker }: { ticker: string }) {
+  const normalizedTicker = ticker.trim().toUpperCase();
   const { data, isLoading, error } = useSymbolRows();
 
   if (isLoading) {
@@ -40,24 +41,24 @@ export default function SymbolLotsCard({ ticker }: { ticker: string }) {
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, py: 2 }}>
         <CircularProgress size={18} />
         <Typography variant="body2" color="text.secondary">
-          Loading {ticker} lots…
+          Loading {normalizedTicker} lots…
         </Typography>
       </Box>
     );
   }
   if (error) {
-    return <Alert severity="error">Couldn&apos;t load lots for {ticker}.</Alert>;
+    return <Alert severity="error">Couldn&apos;t load lots for {normalizedTicker}.</Alert>;
   }
 
-  const row = (data?.symbols ?? []).find((s) => s.symbol === ticker);
+  const row = (data?.symbols ?? []).find((s) => s.symbol === normalizedTicker);
   if (!row) {
-    return <Alert severity="info">No {ticker} lots in your portfolio.</Alert>;
+    return <Alert severity="info">No {normalizedTicker} lots in your portfolio.</Alert>;
   }
 
   return (
     <Box data-testid="symbol-lots-card">
       <Typography variant="subtitle2" sx={{ mb: 0.5 }}>
-        {ticker} — Lots
+        {normalizedTicker} — Lots
       </Typography>
       <Stack direction="row" spacing={3} flexWrap="wrap" useFlexGap sx={{ mb: 1 }}>
         <Metric label="Investment" value={formatCurrency(row.total_investment)} />

--- a/mcp_gateway/rest_client.py
+++ b/mcp_gateway/rest_client.py
@@ -118,6 +118,11 @@ def _handle(response: httpx.Response) -> Any:
     raise RestError(response.status_code, payload)
 
 
+# No put/patch/delete verbs exist here, deliberately (#126 Q19): the
+# portfolio-server wrapper (fastMCPTest/portfolio_server.py) is read-only by
+# decision, and a wrapper physically unable to issue a write is defense in
+# depth that doesn't depend on nobody adding a mutating tool later. If MCP
+# writes are ever revisited, adding the verb here is the first step.
 def get(path: str, *, auth_token: Optional[str] = None, **params: Any) -> Any:
     """``GET {REST}/{path}`` with query params; return parsed JSON or raise ``RestError``.
 
@@ -131,6 +136,7 @@ def get(path: str, *, auth_token: Optional[str] = None, **params: Any) -> Any:
         return _handle(client.get(_path(path), params=clean, headers=_headers(auth_token)))
 
 
+# Same note as get() above — no put/patch/delete verb, deliberately.
 def post(
     path: str,
     *,

--- a/quantcore/services/chat_tools.py
+++ b/quantcore/services/chat_tools.py
@@ -35,6 +35,11 @@ BACKEND_COMPONENT_REGISTRY: dict[str, dict[str, object]] = {
     # No props: the scan covers the whole curated universe.
     "arbitrage_scan": {},
     "arbitrage_discovery": {"symbols": str},
+    # No props: the card fetches the caller's own portfolio via the browser's
+    # authenticated session. Never add an `owner` prop here — that would let
+    # the model pick whose portfolio to show, a cross-user read (decision #20).
+    "portfolio_table": {},
+    "symbol_lots": {"ticker": str},
 }
 
 
@@ -359,7 +364,14 @@ TOOL_SCHEMAS: list[dict] = [
             "universe (no props), "
             "'arbitrage_discovery' plots a cointegration sweep — correlation "
             "against test statistic, with near-misses visible against the "
-            "critical-value line (requires symbols, comma-separated)."
+            "critical-value line (requires symbols, comma-separated), "
+            "'portfolio_table' shows the caller's own portfolio as a per-symbol "
+            "table with totals (no props — always the caller's own holdings, "
+            "never another user's), "
+            "'symbol_lots' shows the caller's individual lots for one symbol in "
+            "their portfolio (requires ticker). Both portfolio components are "
+            "read-only — there is no component or tool for adding, editing, or "
+            "closing a lot; tell the user to use the Portfolio page for that."
         ),
         "input_schema": {
             "type": "object",

--- a/scripts/ci_wrapper_smoke.py
+++ b/scripts/ci_wrapper_smoke.py
@@ -28,6 +28,7 @@ WRAPPERS = [
     ("fastMCPTest.company_fundamentals_server", "company-fundamentals", 1),
     ("fastMCPTest.news_sentiment_server", "news-sentiment", 1),
     ("fastMCPTest.market_analysis_server", "market-analysis", 1),
+    ("fastMCPTest.portfolio_server", "portfolio", 4),
 ]
 
 

--- a/tests/test_chat_tools.py
+++ b/tests/test_chat_tools.py
@@ -1,0 +1,66 @@
+"""Registry-content tests for the portfolio Sidekick components (issue #126,
+PR 4 Step 4.7).
+
+Generic cross-registry consistency (show_component enum matches
+BACKEND_COMPONENT_REGISTRY, every registry prop is declared in the tool
+schema, etc.) is already covered for all components by
+tests/test_chat_protocol.py. This file covers the two portfolio-specific
+components: their exact prop specs, and the guarantee that neither can ever
+be pointed at another user's data via an `owner` prop.
+
+There is no automated cross-language check against
+frontend/src/chat/componentRegistry.tsx — parity is maintained by mirroring
+these cases in frontend/src/chat/componentRegistry.test.ts, same convention
+already used for every other component here.
+"""
+import unittest
+
+from quantcore.services.chat_tools import (
+    BACKEND_COMPONENT_REGISTRY,
+    validate_directive,
+)
+
+
+class TestPortfolioTableDirective(unittest.TestCase):
+    def test_registered_with_no_props(self):
+        self.assertEqual(BACKEND_COMPONENT_REGISTRY["portfolio_table"], {})
+
+    def test_empty_props_accepted(self):
+        ok, reason = validate_directive("portfolio_table", {})
+        self.assertTrue(ok, reason)
+
+    def test_owner_prop_rejected(self):
+        """A model-settable owner would let the LLM request another user's
+        portfolio; the card must always resolve the owner from the caller's
+        own authenticated session instead."""
+        ok, reason = validate_directive("portfolio_table", {"owner": "someone_else"})
+        self.assertFalse(ok)
+        self.assertIn("owner", reason)
+
+    def test_ticker_prop_rejected(self):
+        """No ticker either — this component is portfolio-wide, not per-symbol."""
+        ok, _ = validate_directive("portfolio_table", {"ticker": "INTC"})
+        self.assertFalse(ok)
+
+
+class TestSymbolLotsDirective(unittest.TestCase):
+    def test_registered_with_ticker_only(self):
+        self.assertEqual(BACKEND_COMPONENT_REGISTRY["symbol_lots"], {"ticker": str})
+
+    def test_valid_ticker_accepted(self):
+        ok, reason = validate_directive("symbol_lots", {"ticker": "INTC"})
+        self.assertTrue(ok, reason)
+
+    def test_missing_ticker_rejected(self):
+        ok, reason = validate_directive("symbol_lots", {})
+        self.assertFalse(ok)
+        self.assertIn("ticker", reason)
+
+    def test_owner_prop_rejected(self):
+        ok, reason = validate_directive("symbol_lots", {"ticker": "INTC", "owner": "someone_else"})
+        self.assertFalse(ok)
+        self.assertIn("owner", reason)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Step 4.7: registers `portfolio_table`/`symbol_lots` as GenUI-compliant components (`PortfolioTableCard`, `SymbolLotsCard`) with matching strict prop specs in both the backend `BACKEND_COMPONENT_REGISTRY` and the frontend `componentRegistry`, per arch-v2 Rules 8-9.
- Step 4.8: adds a read-only `portfolio-server` MCP wrapper (`get_portfolio`, `get_symbol_lots`, `get_portfolio_summary`, `mcp_health_check`) over the REST tier, wired into docker-compose/.mcp.json/CI smoke/deploy alongside the other 5 wrappers. No write tools, since `mcp_gateway.rest_client` has no put/patch/delete verbs by design (#126 Q19).

This is a follow-up to #153 (already merged) — continues issue #126 / PR 4 of the portfolio-lots plan.

## Test plan
- [x] Backend: `coverage run -m unittest discover -s tests -t .` — 1132 tests, 86.4% coverage (clean solo run)
- [x] Frontend: `npx vitest run --coverage` — 435 tests, 87.72% statements
- [x] `tsc --noEmit` clean
- [x] OpenAPI snapshot unchanged
- [x] `python scripts/ci_wrapper_smoke.py` — 6/6 wrappers healthy (portfolio: listTools=4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)