### PR TITLE
ci: roll images onto quantcore-portfolio in prod-rollout.yml (refs #163)

### DIFF
--- a/.github/workflows/prod-rollout.yml
+++ b/.github/workflows/prod-rollout.yml
@@ -172,6 +172,21 @@ jobs:
             echo "quantcore-arbitrage not found in prod — first deploy is a manual one-time step; skipping."
           fi
 
+      - name: Deploy quantcore-portfolio (prod, image-only)
+        # Same shape and same reason as the arbitrage step above: outside the
+        # unguarded loop because this service's first prod deploy is a manual
+        # one-time creation (SERVER_MODULE=fastMCPTest.portfolio_server,
+        # PORT=6006). deploy.yml has carried the matching guarded step for test
+        # since portfolio-lots-plan.md Step 4.8; prod was missed, so once the
+        # service is created it would still never receive an image.
+        run: |
+          if gcloud run services describe quantcore-portfolio --project "$PROD_PROJECT" --region "$REGION" >/dev/null 2>&1; then
+            gcloud run deploy quantcore-portfolio --project "$PROD_PROJECT" --region "$REGION" \
+              --image "$REGION-docker.pkg.dev/$PROD_PROJECT/$AR_REPO/quantcore-mcp@$QUANTCORE_MCP_DIGEST"
+          else
+            echo "quantcore-portfolio not found in prod — first deploy is a manual one-time step; skipping."
+          fi
+
       - name: Update report Job image (prod)
         run: |
           gcloud run jobs update quantcore-report --project "$PROD_PROJECT" --region "$REGION" \


### PR DESCRIPTION
Half of [#163](https://github.com/JohnFunkCode/StockPortfolioManager/issues/163) — the half that is safe to land now.

`prod-rollout.yml`'s wrapper loop covers only the original five services
(`stock-price options-analysis company-fundamentals news-sentiment market-analysis`),
and the guarded `quantcore-arbitrage` step added later was never mirrored for portfolio.
`deploy.yml` has carried the matching guarded step for **test** since
`portfolio-lots-plan.md` Step 4.8, so prod was the only side missing it.

This adds the step in the same shape as the arbitrage one — guarded on existence,
because the service's first deploy in each project is a manual one-time creation
(`SERVER_MODULE=fastMCPTest.portfolio_server`, `PORT=6006`) and a fresh service can't
be image-only deployed.

### Scope

One file, one step, `+15 −0`. Deliberately **not** in this PR: creating the
`quantcore-portfolio` service, which doesn't exist in *either* project — that's the rest
of #163 and needs a supervised gcloud step per project.

### Risk

Inert on merge. The service is absent from prod, so the step takes the `else` branch and
logs a skip, exactly as `deploy.yml`'s has been doing on test every run since #145.
Landing the workflow half first means the service can't be created and then still never
receive an image.

Verified the file still parses and the step lands between arbitrage and the report job:

```
Deploy quantcore-api (prod, image-only)
Deploy the 5 wrappers (shared prod mcp image; per-service env preserved)
Deploy quantcore-arbitrage (prod, image-only)
Deploy quantcore-portfolio (prod, image-only)   <-- new
Deploy quantui (prod, image-only)
Deploy quantcore-keyproxy (prod, image-only)
```

### Ordering note

This can sit unmerged during the #162 watchlist prod rollout — a `prod-rollout.yml`
dispatch takes its workflow definition from `main`, but with the service absent the step
is a no-op either way. It only needs to be merged **before** `quantcore-portfolio` is
created in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)