### PR TITLE
docs: full documentation audit + make docs part of every change

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+## What changed
+
+<!-- One or two sentences. What does this PR do, and why? -->
+
+## Documentation
+
+Docs ship **with** the change, not after it. Tick what applies:
+
+- [ ] No doc change needed — this PR alters nothing a reader of the docs would be told
+- [ ] `CLAUDE.md` — architecture, constraints, or a rule agents must follow
+- [ ] `readme.md` — the human tour (install, config, endpoints, UI, containers, MCP)
+- [ ] `docs/proposals/*.md` — checkpoint log appended for the step this PR lands
+- [ ] Gotchas recorded — anything that cost real time to figure out is written down
+
+> Update the docs when you add/remove/rename a service, repository, gateway, or analytics module;
+> add or change a REST route group, MCP tool, or UI page; change the schema, deployment, CI/CD,
+> environment, or auth wiring; add an operational script; or change a default or config file's
+> role. Full rule: "Documentation is part of the change" in `CLAUDE.md`.
+
+## Checks
+
+- [ ] Backend tests pass — `python -m unittest discover -s tests -t .`
+- [ ] Front-end tests pass (if `frontend/` changed) — `cd frontend && npx vitest run --coverage`
+- [ ] Schema changes ship **twice** — a Flyway file under `db/migrations/` *and* `init_schema()`
+- [ ] No credentials, keys, `Authorization` headers, envelopes, or request bodies reach any log
+
+## Verification
+
+<!-- How did you prove this works? Commands run, output, screenshots, the test/prod URL you hit. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,19 @@
 # AGENTS.md
-Codex --resume 44dcf10f-5cc7-494e-90b2-1e4d0bc4a672
 
-This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+Guidance for coding agents (Codex and friends) working in this repository.
+
+## Read `CLAUDE.md` first — it is the single source of truth
+
+The full architecture, deployment topology, environment rules, and working constraints live in
+[`CLAUDE.md`](CLAUDE.md). **Read it before making changes.**
+
+This file used to carry its own copy of that guidance and silently rotted — it was still
+describing a 16-table schema, a Flask `api/app.py`, and modules (`HarvesterPlanStore.py`,
+`ohlcv_cache.py`) that no longer exist. Rather than maintain two documents that drift apart, this
+one now points at the other. **Do not re-add architecture notes here** — put them in `CLAUDE.md`.
+
+For the human-facing tour — installation, endpoints, the UI, the container stack, MCP setup —
+see [`readme.md`](readme.md).
 
 ## Commands
 
@@ -9,69 +21,52 @@ This file provides guidance to Codex (Codex.ai/code) when working with code in t
 # Run the application (generates HTML report + sends Discord notifications)
 python main.py
 
-# Run all tests
-python -m unittest discover
+# Run all tests (suites live under tests/; tests/__init__.py swaps in the test
+# DSN before quantcore.db is imported)
+python -m unittest discover -s tests -t .
 
-# Run a single test file
-python -m unittest test_money
-python -m unittest test_stock_portfolio_manager
+# A single test module (dotted path from the repo root)
+python -m unittest tests.test_money
 
-# Activate virtualenv
+# Backend coverage (CI enforces a ratchet floor)
+coverage run -m unittest discover -s tests -t . && coverage report
+
+# Frontend tests with coverage
+cd frontend && npx vitest run --coverage
+
+# REST API
+uvicorn api.main:app --host 127.0.0.1 --port 5001
+
+# Database migrations (defaults to the test database; prompts before a prod migrate)
+./scripts/flyway.sh info
+
+# Activate virtualenv / install dependencies
 source .venv/bin/activate
-
-# Install dependencies
 pip install -r requirements.txt
 ```
 
-## Architecture
+## Non-negotiables
 
-This is a Python stock portfolio tracker that fetches live prices from Yahoo Finance, generates an HTML report (with charts), optionally uploads to S3, and sends Discord notifications when price thresholds are breached.
+These are the constraints most likely to be violated by an agent that skipped `CLAUDE.md`:
 
-### Core Domain (`portfolio/`)
-
-- **`money.py`** — `Money` value object using `Decimal` for precision. Supports arithmetic operators and currency conversion via the open.er-api.com exchange rate API.
-- **`stock.py`** — `Stock` entity holding purchase info, current price, and a `Metrics` object. Computes gain/loss, gain/loss %, and dollars-per-day.
-- **`portfolio.py`** — `Portfolio` aggregates `Stock` objects (keyed by symbol). Reads holdings from `portfolio.csv`. Delegates price updates and metrics to gateway/metrics modules.
-- **`watch_list.py`** — `WatchList` is similar to Portfolio but for non-owned stocks. Reads from `watchlist.yaml` (supports per-stock `tags`).
-- **`metrics.py`** — `Metrics` dataclass plus `get_historical_metrics()` which bulk-downloads 2 years of daily data via yfinance and computes moving averages (10/30/50/100/200-day), period returns, and percent change today.
-- **`yfinance_gateway.py`** — Thin wrapper around `yf.download()` for latest prices and `yf.Tickers()` for descriptive info (earnings dates, income statements).
-
-### Report Generation (`main.py`)
-
-`main.py` is the entry point. It loads portfolio from CSV + watchlist from YAML, fetches prices/metrics, generates matplotlib charts (embedded as base64 in HTML via Jinja2 template), optionally uploads to S3, and triggers notifications.
-
-### Notifications (`notifier.py`)
-
-Sends Discord webhook alerts for: moving average violations (30/50/100/200-day), price below purchase price, and Harvester plan rung hits. Uses `notification.log` file to deduplicate alerts within a run.
-
-### Harvester System (`experiments/`)
-
-An experimental "harvest ladder" strategy for systematically selling shares as prices rise:
-
-- **`HarvesterExperiment.py`** — Core algorithm: computes volatility-based harvest thresholds (H), builds forward price target ladders, and backtests harvest plans.
-- **`HarvesterPlanStore.py`** — `HarvesterPlanDB` persists plans in the unified **QuantCore** PostgreSQL database. Schema includes symbols, OHLCV bars, plan templates, plan instances, plan rungs, and alerts. `HarvesterController` scans prices against active plan rungs and fires alerts.
-
-The Harvester integrates with the notification system: when `main.py` runs, it checks each portfolio stock against active harvest plan rungs and sends Discord alerts for any hits.
-
-### Unified Database (`quantcore/`)
-
-All persistence is consolidated into a single **QuantCore** PostgreSQL database, accessed via `psycopg2`:
-
-- **`quantcore/db.py`** — Shared connection factory (`get_connection()`) backed by `psycopg2`, connecting via the `QUANTCORE_DB_DSN` environment variable. Centralized schema DDL for all 16 tables (`init_schema()`), using `SERIAL` primary keys and `ON CONFLICT` upserts. Imported as `from quantcore.db import get_connection`.
-- **Schema** includes: symbols, OHLCV (merged from daily + intraday intervals), fetch_log, plan_templates/instances/rungs/alerts (Harvester), options_snapshots/expirations/contracts/gamma_wall_history/options_positions, news_articles, sentiment_snapshots, fundamentals_history.
-
-All MCP store modules (`ohlcv_cache.py`, `options_store.py`, `news_store.py`, `sentiment_store.py`, `fundamentals_cache.py`) and the REST API (`api/app.py`) use the shared factory instead of managing individual database connections.
-
-**Migrating from a legacy SQLite database:** `scripts/migrate_sqlite_to_postgres.py` performs a one-shot copy of an existing `quantcore.sqlite` file into PostgreSQL — it initializes the schema, migrates all 16 tables in FK-safe order via batched `execute_values()` inserts, resets `SERIAL` sequences, and verifies row counts. Run it with `--sqlite <path>` and `--dsn <postgresql-uri>`.
-
-## Configuration
-
-- **`.env`** — `QUANTCORE_DB_DSN` is the PostgreSQL connection string for the unified database (e.g. `postgresql://<user>:<password>@<host>:<port>/<database>`); `QUANTCORE_TEST_DB_DSN` optionally points the same code at an isolated database for testing; `DISCORD_WEBHOOK_URL` for notifications; `BUCKET_NAME`/`BUCKET_KEY` for optional S3 upload.
-- **`portfolio.csv`** — Holdings data: `name,symbol,purchase_price,quantity,purchase_date,currency,sale_price,sale_date,current_price`
-- **`watchlist.yaml`** — Watchlist entries with `name`, `symbol`, `currency`, and optional `tags` list.
-
-**Database Initialization:** The unified PostgreSQL database and its 16-table schema are automatically created on startup by any application entry point (`main.py`, REST API, or MCP servers) — `init_schema()` runs before any database operations. The database itself (and its `quantcore` user) must already exist; point `QUANTCORE_DB_DSN` at any reachable PostgreSQL instance — local, or a managed service such as Cloud SQL accessed through the Cloud SQL Auth Proxy (which exposes the remote instance as a local TCP host:port, so no code changes are needed to switch targets).
-
-## Key Dependencies
-
-pandas, yfinance, matplotlib, jinja2, python-dotenv, boto3, PyYAML, requests, psycopg2
+- **Documentation is part of the change.** Any change that alters what a reader of the docs would
+  be told must update the docs **in the same PR** — a new or renamed service/route/tool/UI page, a
+  schema change, deployment or auth wiring, a new script, a changed default. `CLAUDE.md` holds
+  architecture and constraints for agents; `readme.md` is the human tour; `docs/proposals/*.md`
+  carry plans and their checkpoint logs. One fact, one home — if two docs would state it, one
+  states it and the other links. See the "Documentation is part of the change" section in
+  `CLAUDE.md` for the full rule.
+- **Prod (`quantcore-prod-20260606`) is the system of record**; test is for development and CI
+  only.
+- **Adapters are one service call deep.** Business logic goes in `quantcore/services/`; REST
+  routes (`api/routers/*`) and MCP tool bodies (`fastMCPTest/*`) are thin. Service modules never
+  import each other or the registry.
+- **Every schema change ships twice** — as a Flyway file under `db/migrations/` *and* mirrored
+  into `init_schema()` in `quantcore/db.py`.
+- **BYOK never-log policy:** no API keys, `Authorization` headers, envelopes, decrypted payloads,
+  request bodies, or exception dumps containing credentials may reach any log or print. New
+  failure paths must add the corresponding log assertion.
+- **On existing Cloud Run services always use `--update-env-vars` / `--update-secrets`** — the
+  `--set-*` variants replace the entire set and have broken prod before.
+- **New or materially changed UI components** must be GenUI-compliant, registered in both
+  component registries, and ship vitest tests in the same PR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,42 @@ claude --resume 44dcf10f-5cc7-494e-90b2-1e4d0bc4a672
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Documentation is part of the change (read this first)
+
+**Any change that alters what a reader of the docs would be told must update the docs in the same
+PR.** Docs are not a follow-up task and not a separate ticket — a PR that leaves them stale is
+incomplete, and reviewers should say so.
+
+Update the docs when you:
+
+- add, remove, or rename a **service, repository, gateway, or analytics module**
+- add or change a **REST route group**, an **MCP server or tool**, or a **UI page or route**
+- change the **schema** (which also means a Flyway file *and* `init_schema()` — see Migrations)
+- change **deployment, CI/CD, environment, or auth** wiring
+- add an **operational script**, or change how an existing one is invoked
+- change a **default, environment variable, or configuration file's role**
+- discover that something documented is **already wrong** — fix it while you're there
+
+Where it goes:
+
+| Doc | Audience | Holds |
+|-----|----------|-------|
+| `CLAUDE.md` | agents (auto-loaded every session) | architecture, constraints, and the rules an agent must not violate |
+| `AGENTS.md` | non-Claude agents | a pointer to `CLAUDE.md` plus the non-negotiables — **never a second copy of the architecture** |
+| `readme.md` | humans | the tour: install, configure, run, endpoints, UI, containers, MCP setup |
+| `docs/proposals/*.md` | both | plans and their checkpoint logs — append the checkpoint as each step lands, not at the end |
+
+Two rules that keep this from rotting:
+
+1. **One fact, one home.** If two documents would both state something, one states it and the
+   other links. `AGENTS.md` drifted for months precisely because it was a copy.
+2. **Record the gotcha, not just the outcome.** When something cost real time to figure out — a
+   command that half-succeeded, a flag that behaved differently than documented — write down what
+   misled you, in the plan doc for that work. That is the part nobody can reconstruct later.
+
+Prefer a smaller true statement to a larger stale one: if you can't verify a claim, cut it or
+mark it, rather than leaving a confident sentence that no longer holds.
+
 ## Commands
 
 ```bash
@@ -23,6 +59,13 @@ cd frontend && npx vitest run --coverage
 python -m unittest tests.test_money
 python -m unittest tests.test_stock_portfolio_manager
 
+# Start the REST API
+uvicorn api.main:app --host 127.0.0.1 --port 5001
+
+# Database migrations (defaults to the TEST database; prompts before a prod migrate)
+./scripts/flyway.sh info
+./scripts/flyway.sh --prod info
+
 # Activate virtualenv
 source .venv/bin/activate
 
@@ -38,14 +81,14 @@ This is a Python stock portfolio tracker that fetches live prices from Yahoo Fin
 
 - **`money.py`** — `Money` value object using `Decimal` for precision. Supports arithmetic operators and currency conversion via the open.er-api.com exchange rate API.
 - **`stock.py`** — `Stock` entity holding purchase info, current price, and a `Metrics` object. Computes gain/loss, gain/loss %, and dollars-per-day.
-- **`portfolio.py`** — `Portfolio` aggregates `Stock` objects (keyed by symbol). Reads holdings from `portfolio.csv`. Delegates price updates and metrics to gateway/metrics modules.
+- **`portfolio.py`** — `Portfolio` aggregates `Stock` objects (keyed by symbol). `read_stocks_from_records()` loads holdings from the DB-backed `positions` table; `read_stocks_from_csv()` remains for the `portfolio.csv` import path. Delegates price updates and metrics to gateway/metrics modules.
 - **`watch_list.py`** — `WatchList` is similar to Portfolio but for non-owned stocks. `read_stocks_from_records()` loads it from the DB-backed `watchlist` table (issue #83); `read_stocks_from_yaml()` remains for the `watchlist.yaml` import path. Supports per-stock `tags`.
 - **`metrics.py`** — `Metrics` dataclass plus `get_historical_metrics()` which bulk-downloads 2 years of daily data via yfinance and computes moving averages (10/30/50/100/200-day), period returns, and percent change today.
 - **`yfinance_gateway.py`** — Thin wrapper around `yf.download()` for latest prices and `yf.Tickers()` for descriptive info (earnings dates, income statements).
 
 ### Report Generation (`main.py`)
 
-`main.py` is the entry point. It loads portfolio from CSV + watchlist from YAML, fetches prices/metrics, generates matplotlib charts (embedded as base64 in HTML via Jinja2 template), optionally uploads to S3, and triggers notifications. It also captures a full options chain snapshot per portfolio/watchlist symbol (in-process `OptionsService.get_full_options_chain`, capped expirations, per-symbol try/except) so open-interest history accumulates daily for `get_oi_change_analysis`.
+`main.py` is the entry point. It loads John's positions and the shared watchlist from the database (via `get_services().portfolio` / `.watchlist` — never from `portfolio.csv` or `watchlist.yaml`), fetches prices/metrics, generates matplotlib charts (embedded as base64 in HTML via Jinja2 template), optionally uploads to S3, and triggers notifications. It also captures a full options chain snapshot per portfolio/watchlist symbol (in-process `OptionsService.get_full_options_chain`, capped expirations, per-symbol try/except) so open-interest history accumulates daily for `get_oi_change_analysis`.
 
 ### Notifications (`notifier.py`)
 
@@ -107,10 +150,10 @@ All repositories under `quantcore/repositories/` and the REST API (`api/main.py`
 
 Per [`docs/proposals/architectural-standard-v2.md`](docs/proposals/architectural-standard-v2.md), all business logic lives in an object-oriented services layer; the MCP tool bodies (`fastMCPTest/*_server.py`, `options_analysis.py`) and FastAPI routes (`api/routers/*`, app assembled in `api/main.py`) are thin adapters that are **exactly one service call deep**.
 
-- **`quantcore/gateways/`** — external-IO wrappers: `YFinanceGateway` (yfinance), `PolygonGateway` (Polygon HTTP/pagination). These are the *only* place outside `portfolio/` (the legacy domain layer, retained for `main.py`'s report path) and the standalone `experiments/` monitors that imports `yfinance`.
-- **`quantcore/repositories/`** — SQL-only persistence, no analytics: `OhlcvRepository`, `OptionsStore`, `OptionsPositionStore`, `NewsStore`, `SentimentStore`, `FundamentalsRepository`, `HarvesterPlanDB`, `PortfolioRepository`, `UserSettingsRepository`, `ArbitrageRepository` (also loads the curated `arb_universe.yaml`).
-- **`quantcore/analytics/`** — pure functions (DataFrame/dict in, value out), no I/O: `indicators.py` (RSI/MACD, Wilder ATR, anchored VWAP, swing detection), `volume_profile.py` (volume-at-price histogram: POC, value area, HVN/LVN nodes), `options_math.py` (Black–Scholes delta/gamma/vega/vanna/charm, max-pain, expected-move — single home, deduped), `pairs.py` (hedge ratio + stability, ADF with AIC lag selection, Engle–Granger cointegration, OU half-life, spread z-score/trend — implemented on numpy so `statsmodels`/`scipy` stay out of the lean image), `nav.py` (net-of-senior-claims NAV per share, premium/discount, carry drag, exposure ratio).
-- **`quantcore/services/`** — the business logic: `PricesService`, `OptionsService`, `OptionsScreeningService`, `FundamentalsService`, `SentimentService`, `MicrostructureService`, `HarvesterService`, `PortfolioService`, `SettingsService`, `ArbitrageService`, `RecommendationsService` (composes the other services).
+- **`quantcore/gateways/`** — external-IO wrappers: `YFinanceGateway` (yfinance), `PolygonGateway` (Polygon HTTP/pagination), `AnthropicGateway` + `KeyproxyGateway` (the Sidekick/BYOK hops, with `keyproxy_fake.py` for tests). These are the *only* place outside `portfolio/` (the legacy domain layer, retained for `main.py`'s report path) and the standalone `experiments/` monitors that imports `yfinance`.
+- **`quantcore/repositories/`** — SQL-only persistence, no analytics: `OhlcvRepository`, `OptionsStore`, `OptionsPositionStore`, `NewsStore`, `SentimentStore`, `FundamentalsRepository`, `HarvesterPlanDB`, `PortfolioRepository`, `WatchlistRepository`, `OwnerIdentityRepository`, `UserSettingsRepository`, `ArbitrageRepository` (also loads the curated `arb_universe.yaml`).
+- **`quantcore/analytics/`** — pure functions (DataFrame/dict in, value out), no I/O: `indicators.py` (RSI/MACD, Wilder ATR, anchored VWAP, swing detection), `volume_profile.py` (volume-at-price histogram: POC, value area, HVN/LVN nodes), `options_math.py` (Black–Scholes delta/gamma/vega/vanna/charm, max-pain, expected-move — single home, deduped), `pairs.py` (hedge ratio + stability, ADF with AIC lag selection, Engle–Granger cointegration, OU half-life, spread z-score/trend — implemented on numpy so `statsmodels`/`scipy` stay out of the lean image), `nav.py` (net-of-senior-claims NAV per share, premium/discount, carry drag, exposure ratio), `portfolio_math.py` (lot/position roll-ups), `market_time.py` (session and trading-day arithmetic).
+- **`quantcore/services/`** — the business logic: `PricesService`, `OptionsService`, `OptionsContractsService`, `OptionsScreeningService`, `FundamentalsService`, `SentimentService`, `MicrostructureService`, `HarvesterService`, `PortfolioService`, `WatchlistService`, `SettingsService`, `IdentityService`, `ChatService` (+ `chat_tools.py`, `chat_fake.py`), `ArbitrageService`, `RecommendationsService` (composes the other services).
 - **`quantcore/chat_models.py`** — pure-data catalog of the three user-selectable Sidekick chat models (issue #124: `claude-sonnet-5` default, `claude-opus-4-8`, `claude-fable-5`), injected by the registry into both `SettingsService` and `ChatService` so the two never import each other for it. `SettingsService` (backed by `UserSettingsRepository`'s `user_settings` table) resolves a per-owner chat model — falling back to the default if the stored value has since been retired from the allow-list — and validates writes against the same allow-list; exposed via `GET/PUT /api/settings` (`api/routers/settings.py`). The frontend Settings page and the Sidekick chat-header quick-switch both read/write this endpoint, converging on one server-side source of truth rather than sharing a JS module.
 - **`quantcore/services/registry.py`** — the composition root: a lazy `@lru_cache get_services()` returning a frozen `Services` dataclass with all dependencies constructor-injected. Adapters call `get_services().<service>.<method>(...)`; service modules never import each other or the registry (acyclic).
 
@@ -120,7 +163,7 @@ Positions are DB-backed with multi-owner support (`positions` table, `owner` col
 
 The watchlist is DB-backed too (`watchlist` table, `WatchlistRepository` → `WatchlistService`, issue #83) but — unlike positions — it is **global**: one shared list, no `owner` column, with the writing principal recorded in `added_by` for audit only. `watchlist.yaml` is now purely an import format (`scripts/import_watchlist.py`, full-sync replace); every consumer (the daily report, the options screener, the fundamentals report, the REST tier) reads the table, and there is deliberately **no fallback to the YAML file** — an empty table is a loud Discord alarm (`alert_if_watchlist_empty` in `main.py`), not a quiet degrade. Surfaced as `GET/POST /api/watchlist` and `DELETE /api/watchlist/{ticker}`, plus `list_watchlist` / `add_to_watchlist` on the portfolio MCP wrapper. Removal is a UI-only action: the seam `mcp_gateway/rest_client.py` has no `delete` verb, so no agent can drop symbols off a list the whole team shares.
 
-**Refactor status:** Phase 1 of architectural-standard-v2 (services-layer extraction) is **complete** — see [`docs/proposals/phase1-migration-plan.md`](docs/proposals/phase1-migration-plan.md) for the checkpoint log. Phase 2 (FastAPI/Pydantic REST tier) is **complete** — the Flask app (`api/app.py`) has been retired and rebuilt on FastAPI (app factory `api/main.py`, route groups under `api/routers/*`, Pydantic request/response schemas under `api/schemas/*`), preserving every route path and JSON shape so the React front end runs unmodified; OpenAPI docs are served at `/docs` and the spec at `/openapi.json`. See [`docs/proposals/phase2-fastapi-plan.md`](docs/proposals/phase2-fastapi-plan.md) for the checkpoint log. Run it with `uvicorn api.main:app --host 127.0.0.1 --port 5001` (or `python -m api.main`). Phase 3 (AI gateway + GCP deployment) is **complete on the test project** — see [`docs/proposals/phase3-gateway-plan.md`](docs/proposals/phase3-gateway-plan.md): the five MCP servers (`fastMCPTest/*_server.py`, `options_analysis.py`) were inverted into thin **HTTP gateway wrappers** that call the REST tier through the single seam `mcp_gateway/rest_client.py` (Rule 6 — `AI Agent → MCP wrapper → REST tier → Service`); `api/auth.py` adds JWT verification (inert until a key is configured, so local/compose stay open); everything is containerized (`Dockerfile.{api,mcp,report}`, `docker-compose.yml` local stack) and deployed to **GCP Cloud Run** — `quantcore-api` (JWT-enforced) + 5 wrapper services + `main.py` as a daily Cloud Run **Job** on Cloud Scheduler (in-process services, never HTTP). CI/CD is `.github/workflows/deploy.yml` (tests + wrapper smoke + OpenAPI surface diff, then build/roll-out; push/PR triggers are gated by a `preflight` job that skips the deploy when the test-WIF secrets are absent — wire them with `scripts/setup_test_wif.sh`). **Production rollout is COMPLETE** — see [`docs/proposals/prod-rollout-plan.md`](docs/proposals/prod-rollout-plan.md): rather than a test-service DSN flip, the same stack was stood up in a **dedicated prod project** `quantcore-prod-20260606` (project # `127961694257`, `us-central1`) reaching its own prod Cloud SQL — `quantcore-api` (JWT-enforced) + 5 wrapper services + the report Cloud Run Job on Cloud Scheduler, on images **copied by digest** test→prod (api `ac5cd17f…`, mcp `1b7da905…`, report `65d70659…`). Gated prod CI/CD is `.github/workflows/prod-rollout.yml` (`workflow_dispatch`/`release`, `prod` GitHub Environment with required reviewers, separate prod WIF). `.mcp.json` points AI clients at the prod wrapper `/mcp` URLs (`https://quantcore-<svc>-127961694257.us-central1.run.app`, bearer `${QUANTCORE_MCP_TOKEN}`); the 5 `*-local` entries remain for the docker-compose stack. The deferred `portfolio/yfinance_gateway.py` `get_latest_prices` fragility is now **hardened** (retry/back-off + graceful all-None degrade so a flaky Yahoo response no longer crashes the daily report); rebuilding/redeploying the prod report image with this fix is a pending user/CI step.
+**Refactor status:** Phase 1 of architectural-standard-v2 (services-layer extraction) is **complete** — see [`docs/proposals/phase1-migration-plan.md`](docs/proposals/phase1-migration-plan.md) for the checkpoint log. Phase 2 (FastAPI/Pydantic REST tier) is **complete** — the Flask app (`api/app.py`) has been retired and rebuilt on FastAPI (app factory `api/main.py`, route groups under `api/routers/*`, Pydantic request/response schemas under `api/schemas/*`), preserving every route path and JSON shape so the React front end runs unmodified; OpenAPI docs are served at `/docs` and the spec at `/openapi.json`. See [`docs/proposals/phase2-fastapi-plan.md`](docs/proposals/phase2-fastapi-plan.md) for the checkpoint log. Run it with `uvicorn api.main:app --host 127.0.0.1 --port 5001` (or `python -m api.main`). Phase 3 (AI gateway + GCP deployment) is **complete on the test project** — see [`docs/proposals/phase3-gateway-plan.md`](docs/proposals/phase3-gateway-plan.md): the MCP servers (`fastMCPTest/*_server.py`, `options_analysis.py`) were inverted into thin **HTTP gateway wrappers** that call the REST tier through the single seam `mcp_gateway/rest_client.py` (Rule 6 — `AI Agent → MCP wrapper → REST tier → Service`); `api/auth.py` adds JWT verification (inert until a key is configured, so local/compose stay open); everything is containerized (`Dockerfile.{api,mcp,report}`, `docker-compose.yml` local stack) and deployed to **GCP Cloud Run** — `quantcore-api` (JWT-enforced) + 7 wrapper services + `main.py` as a daily Cloud Run **Job** on Cloud Scheduler (in-process services, never HTTP). CI/CD is `.github/workflows/deploy.yml` (tests + wrapper smoke + OpenAPI surface diff, then build/roll-out; push/PR triggers are gated by a `preflight` job that skips the deploy when the test-WIF secrets are absent — wire them with `scripts/setup_test_wif.sh`). **Production rollout is COMPLETE** — see [`docs/proposals/prod-rollout-plan.md`](docs/proposals/prod-rollout-plan.md): rather than a test-service DSN flip, the same stack was stood up in a **dedicated prod project** `quantcore-prod-20260606` (project # `127961694257`, `us-central1`) reaching its own prod Cloud SQL — `quantcore-api` (JWT-enforced) + 7 wrapper services + the report Cloud Run Job on Cloud Scheduler, on images **copied by digest** test→prod (api `ac5cd17f…`, mcp `1b7da905…`, report `65d70659…`). Gated prod CI/CD is `.github/workflows/prod-rollout.yml` (`workflow_dispatch`/`release`, `prod` GitHub Environment with required reviewers, separate prod WIF). `.mcp.json` points AI clients at the prod wrapper `/mcp` URLs (`https://quantcore-<svc>-127961694257.us-central1.run.app`, bearer `${QUANTCORE_MCP_TOKEN}`); the 7 `*-local` entries remain for the docker-compose stack. The deferred `portfolio/yfinance_gateway.py` `get_latest_prices` fragility is now **hardened** (retry/back-off + graceful all-None degrade so a flaky Yahoo response no longer crashes the daily report); rebuilding/redeploying the prod report image with this fix is a pending user/CI step.
 
 ### QuantUI front end on Cloud Run (behind IAP)
 
@@ -226,6 +269,16 @@ expires after 90 days and recommend quarterly rotation** (and a per-user `--sub`
 - **`watchlist.yaml`** — *Import format only* (issue #83). Entries with `name`, `symbol`, `currency`, and optional `tags` list; load them into the global `watchlist` table with `python scripts/import_watchlist.py --yaml watchlist.yaml` (full-sync replace). Nothing reads the file at runtime — the table is the source of truth, and the UI's add/remove actions write straight to it.
 
 **Database Initialization:** The unified PostgreSQL database and its 22-table schema are automatically created on startup by any application entry point (`main.py`, REST API, or MCP servers) — `init_schema()` runs before any database operations. The database itself (and its `quantcore` user) must already exist; point `QUANTCORE_DB_DSN` at any reachable PostgreSQL instance — local, or a managed service such as Cloud SQL accessed through the Cloud SQL Auth Proxy (which exposes the remote instance as a local TCP host:port, so no code changes are needed to switch targets).
+
+**Migrations (Flyway):** versioned SQL lives in `db/migrations/V*.sql`, configured by `db/flyway.conf` (which deliberately holds **no credentials** — `baselineOnMigrate=true`, `baselineVersion=1`). Run it with the wrapper, which derives the JDBC URL and login from the DSNs in `.env`, defaults to **test**, echoes the target host before running, and confirms before a prod `migrate`:
+
+```bash
+./scripts/flyway.sh info            # test (default)
+./scripts/flyway.sh --prod info
+./scripts/flyway.sh --prod migrate  # prompts
+```
+
+Every schema change ships as a migration file **and** is mirrored into `init_schema()`. Because `init_schema()` runs on every application startup, a deployed database has usually already reached the right *shape* before Flyway sees it — so pure-DDL migrations are expected to report "already exists, skipping", and **`flyway info` is not evidence of what a deployed database actually contains** (check the objects directly with `to_regclass`/`information_schema.columns`). Only migrations carrying data changes — backfills, seeds — do real work on a deployed DB. That two-owners-of-the-schema problem is tracked as [issue #165](https://github.com/JohnFunkCode/StockPortfolioManager/issues/165).
 
 ## Key Dependencies
 

--- a/docs/proposals/portfolio-lots-plan.md
+++ b/docs/proposals/portfolio-lots-plan.md
@@ -986,6 +986,58 @@ grep -n "def put\|def patch\|def delete" mcp_gateway/rest_client.py
 
 **Done when** the smoke script boots six wrappers and the grep returns nothing.
 
+### Step 4.8a — one-time Cloud Run service creation (done 2026-07-29)
+
+Step 4.8 deferred the actual Cloud Run service under "Don't" but never recorded the
+command, so **`quantcore-portfolio` was never created in either project** — the CI
+existence guard printed "skipping" on every run and the wrapper's tools were
+unreachable for weeks. Filed as [#163](https://github.com/JohnFunkCode/StockPortfolioManager/issues/163);
+`prod-rollout.yml` was missing the guarded step entirely until
+[#164](https://github.com/JohnFunkCode/StockPortfolioManager/pull/164).
+
+Both services now exist. Keep this as the template for the **next** wrapper:
+
+**1. Get the image — never hardcode a commit tag.** In test, a tag works because
+`deploy.yml` pushes tags there. In **prod it does not**: `prod-rollout.yml` promotes
+images test→prod **by digest**, so test's commit tags never appear in the prod repo.
+Read the image off a sibling wrapper instead, which also guarantees the new service
+starts in lockstep with the rest:
+
+```bash
+PROJECT=quantcore-prod-20260606   # or quantcore-test-20260606
+IMAGE=$(gcloud run services describe quantcore-arbitrage \
+  --project "$PROJECT" --region us-central1 \
+  --format='value(spec.template.spec.containers[0].image)')
+echo "$IMAGE"   # …/quantcore-mcp@sha256:…
+```
+
+**2. Create the service** (`--set-env-vars` is correct *only* here, on a brand-new
+service; on an existing one always `--update-env-vars`/`--update-secrets`, since
+`--set-*` replaces the whole set):
+
+```bash
+gcloud run deploy quantcore-portfolio \
+  --project "$PROJECT" --region us-central1 --platform managed \
+  --image "$IMAGE" \
+  --allow-unauthenticated --port 6006 \
+  --service-account "quantcore-run@${PROJECT}.iam.gserviceaccount.com" \
+  --set-env-vars SERVER_MODULE=fastMCPTest.portfolio_server,QUANTCORE_REST_URL=<project's quantcore-api URL>/
+```
+
+**3. Verify over MCP**, not just by HTTP status — `initialize`, then `tools/list`,
+then one real data tool. An unauthenticated call returning
+`REST tier returned 401: missing bearer token` is *correct*: it proves identity
+passthrough reached `quantcore-api`. Mint a token with
+`scripts/mint_prod_jwt.py` (add `--project quantcore-test-20260606` for test).
+
+**Gotcha that cost an hour:** a `gcloud run deploy` naming an image tag that is not
+yet in Artifact Registry **still creates the service object** with its full spec —
+env, port, concurrency all persist — and fails only the revision. It looks like a
+clean failure but silently flips CI's `gcloud run services describe` guard to
+passing, so the service exists while nothing serves. Confirm the image is in AR
+*before* running the creation command; `deploy.yml`'s build job takes several
+minutes after a merge.
+
 ### PR 4 acceptance
 
 ```bash

--- a/readme.md
+++ b/readme.md
@@ -4,24 +4,33 @@ A Python-based stock portfolio tracker with real-time price updates, multi-curre
 
 ## Features
 
-- Track stocks portfolio positions including purchase information (price, date, quantity) read from posrtolio.csv
+- Track portfolio positions with per-lot purchase information (price, date, quantity), stored in
+  the database per owner and editable from the UI (`portfolio.csv` is the import format)
 - Tracks a shared watchlist including per-stock 'tags', stored in the database and editable from the UI (watchlist.yaml is the import format)
 - Fetch real-time stock prices via Yahoo Finance API
 - Calculate gain/loss for individual stocks and total portfolio
 - Support for multiple currencies with real-time conversion
 - Generate HTML reports with portfolio performance metrics
 - Calculate portfolio performance statistics
+- Technical, fundamental, options, and sentiment analytics served over a REST API and to AI
+  agents through seven **MCP servers**
+- An **arbitrage scanner** for securities that have stretched against a structurally linked
+  underlying (NAV vehicles, commodity ETFs, producers)
 - Web dashboard (**QuantUI**) with an AI chat **Sidekick** — each user brings their own Anthropic
   API key (**BYOK**), stored encrypted in the browser and never visible to the backend (see
   [BYOK Sidekick](#byok-sidekick-bring-your-own-llm-api-key))
 
 ## Technologies Used
 
-- Python 3.9+
-- pandas - Data manipulation and analysis
+- Python 3.12 (the version every container image and CI job runs)
+- pandas / numpy - Data manipulation and analysis
 - yfinance - Yahoo Finance API integration
-- requests - HTTP library
-- Jinja2 - HTML template rendering
+- PostgreSQL via psycopg2 - the unified **QuantCore** database
+- FastAPI + Pydantic - the REST tier (`api/`)
+- FastMCP - the MCP servers that expose analysis to AI agents (`fastMCPTest/`)
+- React 19 + TypeScript + Vite + MUI - the QuantUI front end (`frontend/`)
+- Jinja2 + matplotlib - HTML report rendering
+- Docker / Google Cloud Run - how everything is deployed
 
 ## Example Stocks
 
@@ -89,7 +98,16 @@ That is a full-sync replace: the table ends up matching the file exactly. YAML f
    pip install -r requirements.txt
    ```
 
-3. Create a `stocks.csv` file with your portfolio data following the format in the example above.
+3. Point `QUANTCORE_DB_DSN` at a PostgreSQL database (see [Database](#database)) — the schema is
+   created on first start.
+
+4. Seed your holdings. Positions live in the database; `portfolio.csv` (format shown above) is the
+   import format:
+   ```bash
+   python scripts/import_portfolio.py --csv portfolio.csv --owner <you>
+   ```
+   That is a full-sync replace for that owner. You can also add positions directly in the QuantUI
+   Portfolio page or over `POST /api/portfolio`.
 
 ## Configuration
 
@@ -109,6 +127,25 @@ The application uses a unified **PostgreSQL** database (codename **QuantCore**, 
 - `QUANTCORE_TEST_DB_DSN` — optional DSN for an isolated database, used to run the app or test suite against a separate copy of the data without touching the primary database
 - `DISCORD_WEBHOOK_URL` — Discord webhook for price alerts (optional)
 - `BUCKET_NAME` / `BUCKET_KEY` — AWS S3 credentials for report uploads (optional)
+
+**Migrations (Flyway):** versioned SQL lives in `db/migrations/V*.sql`. `db/flyway.conf`
+deliberately holds **no credentials**, so use the wrapper — it derives the JDBC URL and login
+from the DSNs in `.env`, defaults to the **test** database, echoes the target host before
+running, and asks for confirmation before a prod `migrate`:
+
+```bash
+./scripts/flyway.sh info               # test (default)
+./scripts/flyway.sh --prod info
+./scripts/flyway.sh --prod migrate     # prompts before writing
+```
+
+Every schema change ships **both** as a migration file and as a change to `init_schema()`.
+Since `init_schema()` runs on every application startup, a deployed database has usually already
+reached the right *shape* before Flyway sees it — pure-DDL migrations are expected to report
+"already exists, skipping", and **`flyway info` is not evidence of what a deployed database
+actually contains** (check the objects directly). Only migrations that carry data changes —
+backfills, seeds — do real work on a deployed database. That two-owners-of-the-schema problem is
+tracked as [issue #165](https://github.com/JohnFunkCode/StockPortfolioManager/issues/165).
 
 **Migrating from a legacy SQLite database:** if you have an existing `quantcore.sqlite` file, `scripts/migrate_sqlite_to_postgres.py` performs a one-shot copy into PostgreSQL — it initializes the schema, migrates all tables in foreign-key-safe order using batched inserts, resets primary-key sequences, and verifies row counts:
 ```bash
@@ -144,40 +181,53 @@ python main.py
 
 ## Project Structure
 
-- `main.py`: Application entry point, reads CSV data and displays portfolio information
-- portfolio/ – domain modules (stock.py, money.py, metrics.py, portfolio.py, watch_list.py, yfinance_gateway.py).
-- html_summary.py, simple_text_summary.py – reporting utilities.
-- notifier.py – notification hook.
-- templates/ – Jinja2 HTML template.
-- Tests: test_money.py, test_stock_portfolio_manager.py.
-- Data samples / import files: portfolio.csv, watchlist.csv, watchlist.yaml.
+Layered per [`docs/proposals/architectural-standard-v2.md`](docs/proposals/architectural-standard-v2.md):
+business logic lives in the services layer, and the REST routes and MCP tool bodies are thin
+adapters exactly one service call deep.
+
+| Path | What's in it |
+|------|--------------|
+| `quantcore/` | The core. `db.py` (connection factory + `init_schema()`), `gateways/` (yfinance, Polygon, Anthropic, keyproxy), `repositories/` (SQL only), `analytics/` (pure functions — indicators, options math, pairs, NAV, volume profile), `services/` (the business logic), `services/registry.py` (the composition root) |
+| `api/` | FastAPI REST tier — app factory `api/main.py`, route groups under `routers/`, Pydantic schemas under `schemas/`, JWT verification in `auth.py` |
+| `frontend/` | React 19 + TypeScript + Vite SPA (**QuantUI**), including the Sidekick chat and the browser BYOK vault; `server/` is the Express host used by the deployed container |
+| `fastMCPTest/` | The seven FastMCP servers — thin HTTP gateway wrappers over the REST tier |
+| `mcp_gateway/` | `rest_client.py`, the single seam every MCP wrapper calls through (read verbs only — no `delete`) |
+| `keyproxy/` | Standalone BYOK credential-isolation service; decrypts envelopes in memory, holds no database |
+| `portfolio/` | Legacy domain layer retained for `main.py`'s report path (`stock.py`, `money.py`, `metrics.py`, `portfolio.py`, `watch_list.py`, `yfinance_gateway.py`) |
+| `main.py`, `html_summary.py`, `simple_text_summary.py`, `notifier.py`, `templates/` | The daily report job: fetch, chart, render, upload, and Discord-notify |
+| `experiments/` | `HarvesterExperiment.py` (harvest-ladder algorithm and backtests) plus standalone spread monitors |
+| `db/` | `flyway.conf` + versioned migrations under `db/migrations/` |
+| `scripts/` | Operational scripts — importers, `flyway.sh`, `mint_prod_jwt.py`, IAP/WIF setup, the SQLite→Postgres migration |
+| `tests/` | Backend test suites (`python -m unittest discover -s tests -t .`); front-end tests live beside the code in `frontend/src` |
+| `docs/` | Design proposals, plans with their checkpoint logs, and analysis write-ups |
+| `Dockerfile.*`, `docker-compose.yml`, `cloudbuild.yaml`, `.github/workflows/` | Images, the local container stack, and CI/CD |
+| `portfolio.csv`, `watchlist.yaml`, `arb_universe.yaml` | Import / curation files — none of them are read at runtime except `arb_universe.yaml` |
 
 ## REST API (`api/`)
 
-A FastAPI REST API that exposes the Harvester Plan Store and Securities Dashboard over HTTP for use by the React frontend or other clients. Interactive OpenAPI docs are served at `/docs` and the spec at `/openapi.json`.
+The FastAPI front door for everything: it runs the services in-process and is the *only* thing that
+talks to the database. The React front end and all seven MCP wrappers reach the system through it.
+Interactive OpenAPI docs are served at `/docs` and the spec at `/openapi.json` — **that spec is the
+authoritative endpoint list**; the ~106 routes are too many to mirror here without going stale.
 
 **Entry point:** `api/main.py` (the FastAPI `app`)
 
-### Endpoints
+### Route groups
 
-| Method | Path | Description |
-|--------|------|-------------|
-| GET | `/api/health` | Health check — confirms the API and PostgreSQL database are reachable |
-| GET | `/api/plans` | List harvest plans; filter by `?status=ACTIVE\|SUPERSEDED\|ALL` |
-| POST | `/api/plans` | Create a new harvest plan for a symbol |
-| GET | `/api/plans/<id>` | Get a single plan with its rungs |
-| PATCH | `/api/plans/<id>` | Update plan notes or metadata |
-| DELETE | `/api/plans/<id>` | Delete (supersede) a plan |
-| GET | `/api/plans/<id>/rungs` | List all rungs for a plan |
-| GET | `/api/rungs/<id>` | Get a single rung |
-| POST | `/api/rungs/<id>/achieve` | Mark a rung as achieved at a given trigger price |
-| POST | `/api/rungs/<id>/execute` | Record that shares were sold at a rung (price, quantity, tax) |
-| GET | `/api/symbols` | List all ticker symbols that have plans |
-| GET | `/api/symbols/<ticker>/price` | Fetch the latest close price for a ticker |
-| GET | `/api/dashboard/stats` | Aggregate stats for the dashboard |
-| GET | `/api/watchlist` | List the shared watchlist (global — no `?owner=`) |
-| POST | `/api/watchlist` | Add a symbol to the shared watchlist (409 if already on it) |
-| DELETE | `/api/watchlist/<ticker>` | Remove a symbol from the shared watchlist (404 if absent) |
+| Router | Prefix | What it covers |
+|--------|--------|----------------|
+| `system.py` | `/api/health` | Health check — confirms the API and PostgreSQL database are reachable |
+| `portfolio.py` | `/api/portfolio*`, `/api/watchlist*`, `/api/securities` | Positions and lots (`?owner=`, defaults to `john`), CSV import, and the **global** shared watchlist (no `?owner=`) |
+| `prices.py` | `/api/securities/{ticker}/…` | OHLCV, technicals and technical/risk signals, RSI, MACD, stochastic, volume + OBV, ATR bands, volume profile, VWAP (+ anchored, + history), candlesticks, higher lows, gaps, drawdown |
+| `options.py` | `/api/securities/{ticker}/options/…`, `/api/options/…` | Chain and contract lookup, exact vertical-spread pricing, IV rank, unusual calls, OI change, GEX profile, gamma-wall history, delta exposure, watchlist screening |
+| `fundamentals.py` | `/api/securities/…` | Fundamental score (+ batch, + changes), revenue growth, earnings acceleration, earnings calendar, history, sector breakdown, cache stats |
+| `sentiment.py` | `/api/securities/…/news…` | News collection, per-symbol sentiment, sentiment trend |
+| `microstructure.py` | `/api/securities/{ticker}/…` | Short interest, dark-pool proxy, bid/ask spread |
+| `recommendations.py` | `/api/securities/{ticker}/…` | `get_trade_recommendation`, stop-loss analysis, relative strength (+ history), support confluence |
+| `arbitrage.py` | `/api/arbitrage/…` | Curated universe, pair analysis, scan, cointegration discovery, spread/premium history |
+| `plans.py`, `rungs.py`, `symbols.py`, `dashboard.py` | `/api/plans`, `/api/rungs`, `/api/symbols`, `/api/dashboard` | The Harvester: plans and their rungs (create, supersede, mark achieved, record executions), plan symbols, dashboard roll-ups |
+| `settings.py` | `/api/settings` | Per-owner UI preferences (currently the Sidekick chat model) |
+| `chat.py`, `keyproxy.py` | `/api/chat`, `/api/keyproxy` | Sidekick chat turns and the BYOK public key / envelope validation (see [BYOK Sidekick](#byok-sidekick-bring-your-own-llm-api-key)) |
 
 ### Starting the API server
 
@@ -195,19 +245,22 @@ The server starts on `http://127.0.0.1:5001`. CORS is enabled for all origins on
 
 ## React Frontend (`frontend/`)
 
-A **Harvest Ladder** dashboard built with React 19, TypeScript, Vite, and Material UI. It communicates exclusively with the FastAPI service above.
+**QuantUI** — a portfolio and market-analysis dashboard built with React 19, TypeScript, Vite, and
+Material UI. It communicates exclusively with the FastAPI service above.
 
 ### Pages
 
 | Page | Route | Description |
 |------|-------|-------------|
-| Dashboard | `/` | Summary stats: total active plans, rungs hit, shares harvested, and estimated proceeds |
-| Securities | `/securities` | Securities dashboard with per-symbol technical/fundamental views |
-| Security Detail | `/securities/:symbol` | Deep-dive charts and analytics for one symbol |
+| Portfolio | `/` | Your positions and lots — value, gain/loss, and per-lot detail |
+| Harvester | `/harvester` | Summary stats: total active plans, rungs hit, shares harvested, and estimated proceeds |
+| Securities | `/securities` | Securities dashboard with per-symbol technical/fundamental views; add/remove watchlist symbols here |
+| Security Detail | `/securities/:symbol` | Deep-dive charts and analytics for one symbol, including the Technical Analysis tab's Support Confluence card |
+| Arbitrage | `/arbitrage` | The arbitrage scanner — universe, scan results, and per-pair factor breakdowns |
 | Plans | `/plans` | Table of all harvest plans with status badges; create or delete plans |
 | Plan Detail | `/plans/:id` | Full rung ladder for a plan; mark rungs as achieved or record executions |
 | Symbols | `/symbols` | Look up the latest live price for any ticker symbol |
-| Settings | `/settings` | Manage your BYOK API keys (add/rotate/remove, vault unlock) |
+| Settings | `/settings` | Manage your BYOK API key (vault unlock, rotate, remove) and pick your Sidekick chat model |
 
 Every page also carries the **Sidekick** chat rail — an AI assistant powered by the user's own
 Anthropic API key (see [BYOK Sidekick](#byok-sidekick-bring-your-own-llm-api-key)).
@@ -393,9 +446,10 @@ restarts.
 ```
 
 What it does:
+- Starts the **Cloud SQL Auth Proxy** if it isn't already listening — output logged to `cloud-sql-proxy.log`
 - Activates the Python virtualenv (`.venv/`)
 - Starts the FastAPI (uvicorn) server in the background — output logged to `api.log`
-- Starts the Vite frontend dev server in the background — output logged to `frontent.log`
+- Starts the Vite frontend dev server in the background — output logged to `frontend.log`
 - Prints the PID of each process and the URLs for both servers
 
 Both processes run independently; closing the terminal does not stop them. The script prints a `kill` command with both PIDs so you can shut them down when done.
@@ -406,7 +460,7 @@ Both processes run independently; closing the terminal does not stop them. The s
 
 The whole backend runs as containers locally — the team's daily driver and the
 fallback if the GCP deployment has issues. The topology mirrors the Cloud Run
-target: AI agents talk to the five **MCP wrapper** containers over streamable
+target: AI agents talk to the seven **MCP wrapper** containers over streamable
 HTTP; each wrapper is a thin HTTP gateway that calls the **`quantcore-api`**
 FastAPI front door (`QUANTCORE_REST_URL=http://quantcore-api:5001`); the api runs
 the services in-process and reaches **Cloud SQL** through a `cloud-sql-proxy`
@@ -414,7 +468,8 @@ sidecar — all on one bridge network.
 
 ```text
 AI agents ──HTTP──► stock-price :6001 │ options-analysis :6002 │ company-fundamentals :6003
-                    news-sentiment :6004 │ market-analysis :6005
+                    news-sentiment :6004 │ market-analysis :6005 │ portfolio :6006
+                    arbitrage :6007
                               │  QUANTCORE_REST_URL
                               ▼
                        quantcore-api :5001  (FastAPI; services in-process)
@@ -456,7 +511,7 @@ so the team can test immediately. JWT validation is enabled only on Cloud Run.
 | Image | Dockerfile | Deps | Role |
 |-------|-----------|------|------|
 | `quantcore-api` | `Dockerfile.api` | `requirements-ml.txt` (incl. torch/transformers for FinBERT) | FastAPI front door + service execution |
-| MCP wrappers (×5) | `Dockerfile.mcp` | `requirements-base.txt` (lean) | one image reused per wrapper via `SERVER_MODULE`/`PORT` |
+| MCP wrappers (×7) | `Dockerfile.mcp` | `requirements-base.txt` (lean) | one image reused per wrapper via `SERVER_MODULE`/`PORT` |
 | `report` | `Dockerfile.report` | `requirements-base.txt` (lean) | `main.py` once-and-exit (Cloud Run Job) |
 | `quantcore-keyproxy` | `Dockerfile.keyproxy` | `keyproxy/requirements.txt` (slim) | BYOK credential-isolation boundary; no DB (IAM-locked on Cloud Run) |
 | `quantui` | `Dockerfile.ui` | Node/Express | serves the built SPA + `/api/*` proxy (see QuantUI section) |
@@ -483,10 +538,12 @@ A suite of **FastMCP servers** that expose real-time market analysis as tools co
 
 ### Connecting AI clients to prod (MCP token)
 
-The repo's `.mcp.json` already points the five remote servers at the **prod** wrapper URLs
-(`https://quantcore-<svc>-swgixldxzq-uc.a.run.app/mcp`), each sending
+The repo's `.mcp.json` already points the seven remote servers at the **prod** wrapper URLs
+(`https://quantcore-<svc>-swgixldxzq-uc.a.run.app/mcp`, or the equivalent
+`https://quantcore-<svc>-127961694257.us-central1.run.app/mcp` form), each sending
 `Authorization: Bearer ${QUANTCORE_MCP_TOKEN}`. The wrappers do **identity passthrough** — they
-forward that bearer to `quantcore-api`, which enforces an HS256 JWT (`api/auth.py`). So the only
+forward that bearer to `quantcore-api`, whose `api/auth.py` is **dual-mode**: HS256 for these
+service/MCP tokens, ES256 for the per-user tokens QuantUI mints. So the only
 thing each team member supplies is their own prod token in `QUANTCORE_MCP_TOKEN`; without it every
 data tool returns `401: … Not enough segments`.
 
@@ -691,11 +748,65 @@ fastmcp run fastMCPTest/stock_price_server.py
 
 ---
 
+## Harvester System
+
+A "harvest ladder" strategy for systematically selling shares into strength. It computes a
+volatility-based harvest threshold (H) per symbol, builds a forward ladder of price targets
+("rungs"), and tracks each rung from *planned* → *achieved* → *executed*.
+
+- `experiments/HarvesterExperiment.py` — the algorithm and its backtests
+- `quantcore/repositories/harvester_repository.py` — `HarvesterPlanDB` + `PlanBuildParams`; SQL only
+- `quantcore/services/harvester.py` — `HarvesterService`, which scans prices against active rungs
+- REST: `/api/plans`, `/api/rungs`, `/api/symbols`, `/api/dashboard`; UI: `/harvester`, `/plans`
+
+It also hooks into notifications: each `main.py` run checks every portfolio stock against the
+active plan rungs and fires a Discord alert for any hit.
+
+## Arbitrage Scanner
+
+Finds securities whose price has stretched against a structurally linked underlying, across three
+families: **nav_vehicle** (treasury companies and trusts — the only family with a computable fair
+value), **commodity_etf** (a fund vs its reference future), and **producer** (a miner or E&P vs the
+commodity it sells). Curated links live in `arb_universe.yaml`; `discover_pairs` additionally
+sweeps for undeclared cointegrated links against a reference panel, gated by a sector/industry
+economic-link filter.
+
+**The scoring is deliberately inverted: spread width only qualifies a candidate, the convergence
+mechanism ranks it.** The score is a product of named factors — `opportunity × evidence ×
+convergence × hedge × carry × trend × freshness` — all returned in the `factors` block alongside
+`reasons` and `breaks_on`, so any score is attributable. Because the account is equity/ETF-only,
+any pair whose only clean hedge is a futures contract is flagged `hedge_available: false` and
+halved. **Expect most scans to return nothing above `watch` — that is the intended behaviour, not
+a bug.**
+
+REST: `GET /api/arbitrage/{universe,scan,discover,pairs/{security}}`; MCP: `arbitrage-server`;
+UI: `/arbitrage`. For example prompts, how to read the `factors` breakdown, the MSTR worked
+example (gross vs net discount), and how to add a pair, see
+[docs/arbitrage-scanner-usage.md](docs/arbitrage-scanner-usage.md).
+
+---
+
 ## Testing
 
-Run the unit tests:
+Backend suites live under `tests/`. The `tests/__init__.py` package initializer swaps in the test
+DSN before `quantcore.db` is imported, so the suite never touches the primary database:
+
+```bash
+python -m unittest discover -s tests -t .
 ```
-python -m unittest discover
+
+Run a single module by dotted path from the repo root:
+
+```bash
+python -m unittest tests.test_money
+```
+
+CI enforces a coverage ratchet on both sides — a floor for the backend (`.coveragerc` + the gate in
+`deploy.yml`) and thresholds for the front end (`frontend/vitest.config.ts`) that only move upward:
+
+```bash
+coverage run -m unittest discover -s tests -t . && coverage report
+cd frontend && npx vitest run --coverage
 ```
 
 ## Report Features

--- a/scripts/flyway.sh
+++ b/scripts/flyway.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Run Flyway against the test or prod QuantCore database.
+#
+# `db/flyway.conf` deliberately holds no credentials, so the JDBC URL and login
+# have to be derived from the DSNs in `.env` every time. Before this script that
+# was reconstructed by hand on each rollout, which is both tedious and a good way
+# to point a migration at the wrong database.
+#
+# Usage:
+#   ./scripts/flyway.sh info                 # test (default — the safe target)
+#   ./scripts/flyway.sh migrate
+#   ./scripts/flyway.sh --prod info
+#   ./scripts/flyway.sh --prod migrate       # prompts for confirmation
+#
+# The target database is echoed (host:port/name only) before Flyway runs. The
+# password is exported to Flyway's environment and never printed.
+#
+# NOTE: `init_schema()` in `quantcore/db.py` runs 22 tables of idempotent DDL on
+# every application startup, so a deployed database usually already has the right
+# *shape* before Flyway ever runs — pure-DDL migrations are expected to report
+# "already exists, skipping". `flyway info` is therefore NOT evidence of what a
+# deployed database contains; check the objects directly. See issue #165.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+TARGET=test
+case "${1:-}" in
+  --test) TARGET=test; shift ;;
+  --prod) TARGET=prod; shift ;;
+esac
+
+if [ "$TARGET" = prod ]; then
+  VAR=QUANTCORE_DB_DSN
+else
+  VAR=QUANTCORE_TEST_DB_DSN
+fi
+
+DSN=$(grep -E "^${VAR}=" .env | head -1 | cut -d= -f2-)
+if [ -z "$DSN" ]; then
+  echo "${VAR} not found in .env" >&2
+  exit 1
+fi
+
+# postgresql://user:password@host:port/database  ->  Flyway's three settings
+rest=${DSN#*://}
+creds=${rest%%@*}
+hostpart=${rest#*@}
+FLYWAY_USER=${creds%%:*}
+FLYWAY_PASSWORD=${creds#*:}
+FLYWAY_URL="jdbc:postgresql://${hostpart}"
+export FLYWAY_USER FLYWAY_PASSWORD FLYWAY_URL
+
+echo "target: ${TARGET}  ${hostpart}  (user: ${FLYWAY_USER})"
+
+# Guard the one command that writes. `info`, `validate`, etc. are read-only.
+if [ "$TARGET" = prod ] && [ "${1:-}" = migrate ]; then
+  read -r -p "Run 'migrate' against PROD (${hostpart})? [yes/N] " reply
+  [ "$reply" = yes ] || { echo "aborted"; exit 1; }
+fi
+
+exec flyway -configFiles=db/flyway.conf "$@"


### PR DESCRIPTION
## What changed

Started as the seven-MCP-wrapper corrections (the docs still said five) and became a full
documentation audit — most of the drift shared one cause: **nothing required the docs to move when
the code did.** So this PR both fixes the stale content and adds the rule that prevents the next
round.

### Corrections

**`readme.md`** (the bulk of it)
- `Python 3.9+` → **3.12**, the version every container image and both CI workflows actually run.
- Positions are DB-backed per owner; `portfolio.csv` is the import format, not the source of truth.
- Install step 3 told you to create a **`stocks.csv`** — a file that has never existed in this repo.
  Replaced with the DSN step plus `python scripts/import_portfolio.py --csv portfolio.csv --owner <you>`.
- **Project Structure** was a 7-line list naming `test_money.py` at the repo root and `watchlist.csv`.
  Now a table covering `quantcore/`, `api/`, `frontend/`, `fastMCPTest/`, `mcp_gateway/`,
  `keyproxy/`, the legacy `portfolio/`, the report files, `db/`, `scripts/`, `tests/`, and CI.
- **Frontend Pages** was missing Portfolio (`/`) and Arbitrage (`/arbitrage`), and had Dashboard at
  `/` instead of Harvester at `/harvester`.
- New **Harvester System** and **Arbitrage Scanner** sections; new **Migrations (Flyway)** block;
  five wrappers → seven throughout; MCP token section corrected to the dual-mode HS256/ES256 wording.
- Test commands corrected to the `-s tests -t .` form (the bare `discover` doesn't work here).

**The endpoint table is the structural fix.** The 16-row list of routes is replaced by 13
router-level **route groups**, with `/openapi.json` declared the authoritative list. 106 routes
can't be mirrored by hand without going stale again; this version can.

**`CLAUDE.md`** — the report path reads the database, not `portfolio.csv`/`watchlist.yaml`;
refreshed gateway/repository/analytics/service inventories; added the Flyway paragraph and the
#165 caveat.

**`AGENTS.md`** was a copy of a long-dead `CLAUDE.md` — 16-table schema, a Flask `api/app.py`,
`HarvesterPlanStore.py`, `ohlcv_cache.py`, none of which exist. It was actively harmful: a
non-Claude agent reading it would act on an architecture that's gone. It's now a **pointer** plus
current commands and non-negotiables, so it can't drift again — copies rot, links don't.

### Prevention

Three locations that compose rather than duplicate, matched to their audiences:

| Where | Reaches |
|-------|---------|
| **`CLAUDE.md`** — new "Documentation is part of the change (read this first)" section | Every Claude Code session, auto-loaded, for anyone who clones |
| **`AGENTS.md`** — same rule, first non-negotiable | Codex, Cursor, Copilot, Gemini CLI |
| **`.github/pull_request_template.md`** — new, the repo had none | Humans at the review gate `main` already requires |

The rule carries a trigger list (new/renamed service, route group, MCP tool, UI page, schema
change, deploy/auth wiring, new script, changed default), a where-it-goes table, and two anti-rot
rules: **one fact, one home** and **record the gotcha, not just the outcome**.

### Also

- **`scripts/flyway.sh`** (new) — the JDBC URL and login were being reconstructed by hand on every
  rollout, which is a good way to point a migration at the wrong database. Defaults to **test**,
  echoes the target host before running, never prints the password, prompts before a prod `migrate`.
- **`docs/proposals/portfolio-lots-plan.md`** — Step 4.8a checkpoint for the one-time
  `quantcore-portfolio` service creation, including the gotcha that cost an hour: a `gcloud run
  deploy` naming an **absent image still creates the service object** with its full spec and fails
  only the revision — silently flipping CI's existence guard to passing.

## Verification

- `./scripts/flyway.sh info` run against test: schema version 5, V1 baseline + V2–V5 all Success.
- Every claim written here was checked against the repo first — route counts off `api/routers/*`,
  the frontend routes off the router config, table count off `init_schema()`, Python version off
  the Dockerfiles and both workflows, and `portfolio.py`/`watch_list.py` method names grepped
  before being named in `CLAUDE.md`.
- Docs-only plus one new script; no application code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
