### PR TITLE
test: enforce that init_schema() and the Flyway files agree (#165, PR 2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,8 +61,9 @@ These are the constraints most likely to be violated by an agent that skipped `C
 - **Adapters are one service call deep.** Business logic goes in `quantcore/services/`; REST
   routes (`api/routers/*`) and MCP tool bodies (`fastMCPTest/*`) are thin. Service modules never
   import each other or the registry.
-- **Every schema change ships twice** — as a Flyway file under `db/migrations/` *and* mirrored
-  into `init_schema()` in `quantcore/db.py`.
+- **Every schema change touches three files** — a new `db/migrations/V*.sql`, `_SCHEMA` in
+  `quantcore/db.py`, and the regenerated `db/schema_snapshot.json`. This is no longer a
+  convention: `tests/test_schema_parity.py` fails CI if the first two disagree.
 - **BYOK never-log policy:** no API keys, `Authorization` headers, envelopes, decrypted payloads,
   request bodies, or exception dumps containing credentials may reach any log or print. New
   failure paths must add the corresponding log assertion.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,8 @@ Update the docs when you:
 
 - add, remove, or rename a **service, repository, gateway, or analytics module**
 - add or change a **REST route group**, an **MCP server or tool**, or a **UI page or route**
-- change the **schema** (which also means a Flyway file *and* `init_schema()` — see Migrations)
+- change the **schema** (which means **three** files — a Flyway migration, `_SCHEMA` in
+  `quantcore/db.py`, and `db/schema_snapshot.json`; enforced by CI, see Migrations)
 - change **deployment, CI/CD, environment, or auth** wiring
 - add an **operational script**, or change how an existing one is invoked
 - change a **default, environment variable, or configuration file's role**
@@ -278,7 +279,18 @@ expires after 90 days and recommend quarterly rotation** (and a per-user `--sub`
 ./scripts/flyway.sh --prod migrate  # prompts
 ```
 
-Every schema change ships as a migration file **and** is mirrored into `init_schema()` **and** regenerates the committed `db/schema_snapshot.json` (`python scripts/check_schema_snapshot.py --update`) — CI's `gate` job fails if the snapshot drifts from what `init_schema()` actually produces. Because `init_schema()` runs on every application startup, a deployed database has usually already reached the right *shape* before Flyway sees it — so pure-DDL migrations are expected to report "already exists, skipping", and **`flyway info` is a changelog view, not evidence of what a deployed database actually contains** — run `python scripts/schema_check.py --prod` for that (read-only; diffs live objects against `db/schema_snapshot.json` and prints the Flyway changelog separately, labelled for what it is). That two-owners-of-the-schema problem is tracked as [issue #165](https://github.com/JohnFunkCode/StockPortfolioManager/issues/165); plan and checkpoint log in [`docs/proposals/schema-ownership-plan.md`](docs/proposals/schema-ownership-plan.md).
+Every schema change touches exactly **three** files, and CI fails if you miss one:
+
+| File | What it is | Guarded by |
+|---|---|---|
+| `db/migrations/V*.sql` | a **new** version, never an edit to an applied one | `tests/test_schema_parity.py` |
+| `_SCHEMA` in `quantcore/db.py` | what `init_schema()` creates on startup | `tests/test_schema_parity.py` |
+| `db/schema_snapshot.json` | the committed expectation (`python scripts/check_schema_snapshot.py --update`) | `scripts/check_schema_snapshot.py` in the `gate` job |
+
+`tests/test_schema_parity.py` builds one scratch database from `init_schema()` and another from
+`db/baseline/V1__*.sql` + every `db/migrations/V*.sql`, and fails with the full object-level diff
+unless they are identical — so a change that ships to only one owner cannot merge. It is a hard
+failure in CI, never a skip. Because `init_schema()` runs on every application startup, a deployed database has usually already reached the right *shape* before Flyway sees it — so pure-DDL migrations are expected to report "already exists, skipping", and **`flyway info` is a changelog view, not evidence of what a deployed database actually contains** — run `python scripts/schema_check.py --prod` for that (read-only; diffs live objects against `db/schema_snapshot.json` and prints the Flyway changelog separately, labelled for what it is). That two-owners-of-the-schema problem is tracked as [issue #165](https://github.com/JohnFunkCode/StockPortfolioManager/issues/165); plan and checkpoint log in [`docs/proposals/schema-ownership-plan.md`](docs/proposals/schema-ownership-plan.md).
 
 ## Key Dependencies
 

--- a/db/migrations/V6__parity_backfill.sql
+++ b/db/migrations/V6__parity_backfill.sql
@@ -1,0 +1,70 @@
+-- V6: Back-fill the three tables that only ever shipped through init_schema()
+--     (issue #165, PR 2 of docs/proposals/schema-ownership-plan.md)
+--
+-- This is the first parity run's finding, written down as SQL. `gex_history`,
+-- `user_settings`, and `arb_nav_snapshots` were added to `_SCHEMA` in
+-- `quantcore/db.py` and never given a migration, so a database built purely
+-- from db/baseline + db/migrations was missing all three. Nothing broke,
+-- because `init_schema()` runs on every application startup and created them
+-- anyway -- which is exactly the failure mode #165 is about: the migrations
+-- stopped describing the schema and nobody could tell.
+--
+-- Per decision D6, prod reality wins. All three tables are confirmed present
+-- in prod (`quantcore-prod-20260606`, verified read-only on 2026-08-09), so
+-- the migrations are the side that was wrong and this file makes them agree.
+--
+-- Every statement is idempotent. Deployed databases already have these
+-- objects, so when Flyway finally applies V6 there it will find nothing to do
+-- and record the version -- that no-op is the point. The DDL below is copied
+-- verbatim from `_SCHEMA` so the two owners stay byte-identical under
+-- `tests/test_schema_parity.py`; change one and you must change the other.
+
+CREATE TABLE IF NOT EXISTS gex_history (
+    id SERIAL PRIMARY KEY,
+    symbol TEXT NOT NULL,
+    date_only TEXT NOT NULL,
+    captured_at TEXT NOT NULL,
+    price REAL,
+    net_gex REAL,
+    zero_gamma_level REAL,
+    regime TEXT,
+    payload TEXT,
+    UNIQUE(symbol, date_only)
+);
+
+CREATE INDEX IF NOT EXISTS idx_gex_history_symbol_date ON gex_history(symbol, date_only DESC);
+
+-- Per-owner UI preferences (issue #124). Currently just the Sidekick chat
+-- model; `SettingsService` validates the value against the allow-list in
+-- `quantcore/chat_models.py` rather than a CHECK constraint, so a retired
+-- model id degrades to the default instead of making the row unreadable.
+CREATE TABLE IF NOT EXISTS user_settings (
+    owner       TEXT PRIMARY KEY,
+    chat_model  TEXT NOT NULL,
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Arbitrage scanner: point-in-time holdings/capital-structure snapshots for
+-- NAV vehicles (MSTR-style treasuries, closed-end funds, trusts). Curated
+-- input rather than fetched -- no free API publishes a coin count or a
+-- preferred stack -- so each row carries its own as-of date and source, and a
+-- premium history becomes computable as snapshots accumulate.
+-- DOUBLE PRECISION rather than the REAL used for prices elsewhere: these are
+-- whole-balance-sheet figures (a $16.5B preferred stack), and float4's ~7
+-- significant digits would quietly round them.
+CREATE TABLE IF NOT EXISTS arb_nav_snapshots (
+    security            TEXT NOT NULL,
+    as_of               TEXT NOT NULL,
+    underlying          TEXT NOT NULL,
+    units               DOUBLE PRECISION NOT NULL CHECK(units >= 0),
+    senior_claims       DOUBLE PRECISION NOT NULL DEFAULT 0 CHECK(senior_claims >= 0),
+    annual_senior_cost  DOUBLE PRECISION NOT NULL DEFAULT 0 CHECK(annual_senior_cost >= 0),
+    other_assets        DOUBLE PRECISION NOT NULL DEFAULT 0,
+    diluted_shares      DOUBLE PRECISION CHECK(diluted_shares IS NULL OR diluted_shares > 0),
+    source              TEXT,
+    ingested_at         INTEGER NOT NULL,
+    PRIMARY KEY (security, as_of)
+);
+
+CREATE INDEX IF NOT EXISTS idx_arb_nav_latest
+    ON arb_nav_snapshots(security, as_of DESC);

--- a/docs/proposals/schema-ownership-plan.md
+++ b/docs/proposals/schema-ownership-plan.md
@@ -381,6 +381,57 @@ later.
   `_SCHEMA` in `quantcore/db.py`, and `db/schema_snapshot.json`.
 - **`readme.md`** Migrations section: same, in human voice.
 
+### What the first parity run found
+
+Three tables, and **nothing else**:
+
+```
+MISSING  table arb_nav_snapshots
+MISSING  table gex_history
+MISSING  table user_settings
+```
+
+All three were added to `_SCHEMA` in `quantcore/db.py` and never given a migration, so a database
+built purely from `db/baseline` + `db/migrations` lacked them entirely. **The migrations were the
+wrong side.** Prod has all three (confirmed read-only on 2026-08-09 against
+`quantcore-prod-20260606`: `schema_check.py --prod` reports `22 tables, 0 missing, 0 extra`, plus a
+direct `information_schema.tables` query naming the three), so under D6 prod reality wins and the
+resolution is `db/migrations/V6__parity_backfill.sql` — idempotent `CREATE TABLE IF NOT EXISTS`
+DDL copied verbatim from `_SCHEMA`. `V2`–`V5` were not touched.
+
+Three things worth recording, because they are the parts nobody can reconstruct later:
+
+1. **The predicted failures did not happen.** This plan expected constraint names dropped by name
+   in `_SCHEMA` (`db.py:100-102`), index-name drift, and a `positions.quantity` numeric-type
+   mismatch. The parity run produced **zero MISMATCH lines** — every table both sides have is
+   identical down to columns, indexes, and constraints. The drift was purely *additive*: new
+   tables shipped through `init_schema()` only. That is a much better start state than assumed,
+   and it means the interesting failure mode here is "someone added a table and forgot the
+   migration", not "the two sources describe the same table differently".
+
+2. **The drift was invisible precisely because nothing broke.** `init_schema()` runs on every
+   application startup, so it created these tables on every deployed database before Flyway ever
+   looked. There was no outage, no error, no log line — the migrations silently stopped describing
+   the schema and the only symptom was that `flyway info` said `V5` while the database had 22
+   tables. This is the concrete instance of the claim in `CLAUDE.md` that `flyway info` is a
+   changelog view, not evidence.
+
+3. **V6 will be a no-op everywhere it runs, and that is correct.** Every deployed database already
+   has these three tables, so applying V6 finds nothing to do and just records the version. Do not
+   mistake the no-op for the migration being unnecessary: its job is to make the *file set* a
+   complete description of the schema, which is what the parity test now enforces. A future
+   database built from empty — a new environment, a scratch database, a restore drill — is the
+   case that would actually have failed.
+
+**Gotcha caught while running the evidence command:** both PR 1 scripts shipped without the
+`sys.path.insert(REPO_ROOT)` preamble every other script in `scripts/` has, so
+`python scripts/schema_check.py --prod` from the repo root died with `ModuleNotFoundError: No
+module named 'quantcore'` before printing anything. CI sets `PYTHONPATH: .` job-wide, which is
+exactly why it passed review — the failure only reproduces interactively, which is the only way
+`schema_check.py` is ever invoked. Fixed in PR 2 for both `scripts/schema_check.py` and
+`scripts/check_schema_snapshot.py`. The general lesson: a command whose entire purpose is
+hand-invocation cannot be validated solely by a CI job that pre-configures its environment.
+
 ---
 
 ## PR 3 — Verify mode
@@ -545,3 +596,4 @@ Append one row per PR **as it lands**, not at the end.
 | PR | Date | Commit | What landed | What it found |
 |----|------|--------|-------------|---------------|
 | 1 (Evidence) | 2026-08-09 | — | `db/baseline/V1__quantcore_baseline.sql` (extracted from `9a9d204^`'s `init_schema()`, 16 tables / 0 `ALTER TABLE`, D3: lives outside `flyway.locations`); `quantcore/schema_introspect.py` (`describe_schema`/`diff_schemas`/`scratch_database`/`snapshot_from_dsn`, D4: MISSING/MISMATCH are errors, EXTRA is a warning) + `tests/test_schema_introspect.py` (13 tests, DB-free); `db/schema_snapshot.json` (generated from a live `init_schema()` run, 22 tables) + `scripts/check_schema_snapshot.py` (`--update`/diff, drift-detection proven with an injected table then reverted); wired into `.github/workflows/deploy.yml`'s `gate` job as a "Schema snapshot up to date" step; `scripts/schema_check.py` (read-only `--test`/`--prod` evidence command, mirrors `flyway.sh`'s DSN selection); docs updated (`readme.md`, `CLAUDE.md`, `scripts/flyway.sh` header) to point at the evidence command instead of "check the objects directly". | Ran `scripts/schema_check.py` against both live databases per Step 5 — **both clean**: test (`127.0.0.1:5434`) and prod (`127.0.0.1:5433`) each report `22 tables, 0 missing, 0 extra`, both with Flyway ledger `applied through V5__watchlist (2026-07-28)`. No MISSING/MISMATCH on either side, so no drift to report — `init_schema()` and Flyway agree on both databases today. This is the evidence PR 2's parity test will hold going forward. |
+| 2 (Enforcement) | 2026-08-09 | — | `tests/test_schema_parity.py` (7 tests): builds one scratch database from `init_schema()` and another from `db/baseline/V1__*.sql` + every `db/migrations/V*.sql` in parsed-integer version order, asserts `diff_schemas(...) == []` with the full diff as the failure message; `MigrationOrderTests` pins `V10`-after-`V9` ordering and baseline-first contiguity; `SkipGuardTests` pins that the skip path *fails* rather than skips when `CI` is set, so a silently-skipping guard can't pass as a green build. `db/migrations/V6__parity_backfill.sql` resolves the first run's finding under D6. Coverage repair carried over from PR 1: `tests/test_schema_introspect_live.py` (5 live-DB tests) + 4 more cases in `tests/test_schema_introspect.py` lift `quantcore/schema_introspect.py` from 52% → 98%. `sys.path.insert(REPO_ROOT)` preamble added to both PR 1 scripts. Docs: `CLAUDE.md`, `AGENTS.md`, `readme.md` now state the three-file rule as CI-enforced rather than a convention. | The first parity run failed as designed, with exactly three `MISSING table` lines and **zero MISMATCH lines** — see ["What the first parity run found"](#what-the-first-parity-run-found) above for the detail, the D6 resolution, and the three lessons. Two process findings alongside it: PR 1's CI run never actually reached the new "Schema snapshot up to date" step (it aborted earlier at the PR-only `Diff coverage` gate, which the post-merge push run then skips), so the step's first real execution was the `main` run `31336550437` — green, 22 tables; and `scripts/schema_check.py` could not be run by hand at all as shipped (the `PYTHONPATH` gotcha recorded above). |

--- a/readme.md
+++ b/readme.md
@@ -139,7 +139,21 @@ running, and asks for confirmation before a prod `migrate`:
 ./scripts/flyway.sh --prod migrate     # prompts before writing
 ```
 
-Every schema change ships **both** as a migration file and as a change to `init_schema()`.
+Every schema change touches **three** files, and CI fails if you miss one:
+
+| File | What it is |
+|---|---|
+| `db/migrations/V*.sql` | a **new** version — never an edit to a migration that has already been applied |
+| `_SCHEMA` in `quantcore/db.py` | the DDL `init_schema()` runs on every startup |
+| `db/schema_snapshot.json` | the committed expectation — regenerate with `python scripts/check_schema_snapshot.py --update` |
+
+The first two are checked against each other by `tests/test_schema_parity.py`: it builds one
+throwaway database from `init_schema()` and another from `db/baseline/V1__*.sql` plus every
+migration, and fails with the full list of differing tables, columns, indexes, and constraints
+unless the two are identical. A change that ships to only one owner cannot merge, and in CI that
+check can never quietly skip. The third is checked by `scripts/check_schema_snapshot.py` in the
+`gate` job.
+
 Since `init_schema()` runs on every application startup, a deployed database has usually already
 reached the right *shape* before Flyway sees it — pure-DDL migrations are expected to report
 "already exists, skipping", and **`flyway info` is a changelog view, not evidence of what a

--- a/scripts/check_schema_snapshot.py
+++ b/scripts/check_schema_snapshot.py
@@ -35,7 +35,13 @@ import os
 import sys
 from pathlib import Path
 
-SNAPSHOT = Path(__file__).resolve().parent.parent / "db" / "schema_snapshot.json"
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SNAPSHOT = REPO_ROOT / "db" / "schema_snapshot.json"
+
+# CI sets PYTHONPATH job-wide, but this also gets run by hand from the repo
+# root; without this it dies on `import quantcore` before printing anything.
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 
 def current_schema() -> dict:

--- a/scripts/schema_check.py
+++ b/scripts/schema_check.py
@@ -33,6 +33,12 @@ import psycopg2
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SNAPSHOT = REPO_ROOT / "db" / "schema_snapshot.json"
 
+# Run from the repo root without PYTHONPATH=. -- this is an operator command
+# typed by hand, and `ModuleNotFoundError: No module named 'quantcore'` is a
+# poor first impression. Same convention as scripts/import_watchlist.py.
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 
 def _dsn_for(target: str) -> str:
     # Mirrors scripts/flyway.sh's mapping exactly, so the two agree on what

--- a/tests/test_schema_introspect.py
+++ b/tests/test_schema_introspect.py
@@ -1,14 +1,14 @@
-"""Unit tests for quantcore.schema_introspect.diff_schemas.
+"""Unit tests for quantcore.schema_introspect's pure functions.
 
-All cases here are hand-built dicts -- no database connection, no scratch
-database. describe_schema()/scratch_database()/snapshot_from_dsn() need a
-live Postgres and are exercised indirectly by scripts/check_schema_snapshot.py
-and scripts/schema_check.py (both run manually against test/prod), per PR 1
-Step 2 of docs/proposals/schema-ownership-plan.md.
+All cases here are hand-built dicts or plain strings -- no database
+connection, no scratch database. describe_schema()/scratch_database()/
+snapshot_from_dsn() need a live Postgres; those are covered by
+tests/test_schema_introspect_live.py (runs against the CI Postgres service /
+QUANTCORE_DB_DSN), per PR 1 Step 2 of docs/proposals/schema-ownership-plan.md.
 """
 import unittest
 
-from quantcore.schema_introspect import IGNORED_TABLES, diff_schemas
+from quantcore.schema_introspect import IGNORED_TABLES, _column_type, _with_database, diff_schemas
 
 
 def _col(type_="integer", nullable=False, default=None):
@@ -155,6 +155,118 @@ class DiffSchemasTests(unittest.TestCase):
             diff_schemas(expected, actual),
             ["MISSING  table a_table", "MISSING  table z_table"],
         )
+
+    def test_index_definition_mismatch(self):
+        expected = {
+            "tables": {
+                "positions": _table(
+                    indexes={"positions_pkey": "CREATE UNIQUE INDEX positions_pkey ON positions (position_id)"}
+                )
+            }
+        }
+        actual = {
+            "tables": {
+                "positions": _table(
+                    indexes={"positions_pkey": "CREATE UNIQUE INDEX positions_pkey ON positions (owner, position_id)"}
+                )
+            }
+        }
+        self.assertEqual(
+            diff_schemas(expected, actual),
+            [
+                "MISMATCH index positions.positions_pkey"
+                "  expected 'CREATE UNIQUE INDEX positions_pkey ON positions (position_id)'"
+                "  actual 'CREATE UNIQUE INDEX positions_pkey ON positions (owner, position_id)'"
+            ],
+        )
+
+    def test_constraint_definition_mismatch(self):
+        expected = {
+            "tables": {
+                "watchlist": _table(
+                    constraints={"watchlist_symbol_id_fkey": "FOREIGN KEY (symbol_id) REFERENCES symbols(symbol_id)"}
+                )
+            }
+        }
+        actual = {
+            "tables": {
+                "watchlist": _table(
+                    constraints={
+                        "watchlist_symbol_id_fkey": "FOREIGN KEY (symbol_id) REFERENCES symbols(id)"
+                    }
+                )
+            }
+        }
+        self.assertEqual(
+            diff_schemas(expected, actual),
+            [
+                "MISMATCH constraint watchlist.watchlist_symbol_id_fkey"
+                "  expected 'FOREIGN KEY (symbol_id) REFERENCES symbols(symbol_id)'"
+                "  actual 'FOREIGN KEY (symbol_id) REFERENCES symbols(id)'"
+            ],
+        )
+
+
+class ColumnTypeTests(unittest.TestCase):
+    """_column_type() is a pure formatter; describe_schema() (the only other
+    caller) needs a live database, so it's exercised separately in
+    tests/test_schema_introspect_live.py."""
+
+    def _col(self, **overrides):
+        base = {
+            "data_type": "integer",
+            "character_maximum_length": None,
+            "numeric_precision": None,
+            "numeric_scale": None,
+        }
+        base.update(overrides)
+        return base
+
+    def test_plain_type_has_no_suffix(self):
+        self.assertEqual(_column_type(self._col(data_type="integer")), "integer")
+
+    def test_character_type_includes_max_length(self):
+        self.assertEqual(
+            _column_type(self._col(data_type="character varying", character_maximum_length=8)),
+            "character varying(8)",
+        )
+
+    def test_numeric_type_includes_precision_and_scale(self):
+        self.assertEqual(
+            _column_type(
+                self._col(data_type="numeric", numeric_precision=18, numeric_scale=6)
+            ),
+            "numeric(18,6)",
+        )
+
+    def test_numeric_type_defaults_missing_scale_to_zero(self):
+        self.assertEqual(
+            _column_type(self._col(data_type="numeric", numeric_precision=10, numeric_scale=None)),
+            "numeric(10,0)",
+        )
+
+    def test_integer_type_ignores_numeric_precision(self):
+        # numeric_precision is populated for integer types too (e.g. 32), but
+        # only numeric/decimal render it -- an int column shouldn't grow a
+        # spurious "(32,0)" suffix.
+        self.assertEqual(
+            _column_type(self._col(data_type="integer", numeric_precision=32, numeric_scale=0)),
+            "integer",
+        )
+
+
+class WithDatabaseTests(unittest.TestCase):
+    def test_swaps_path_keeps_everything_else(self):
+        dsn = "postgresql://quantcore:secret@localhost:5432/quantcore?sslmode=disable"
+        self.assertEqual(
+            _with_database(dsn, "scratch_db"),
+            "postgresql://quantcore:secret@localhost:5432/scratch_db?sslmode=disable",
+        )
+
+    def test_original_dsn_is_unchanged(self):
+        dsn = "postgresql://quantcore:secret@localhost:5432/quantcore"
+        _with_database(dsn, "postgres")
+        self.assertEqual(dsn, "postgresql://quantcore:secret@localhost:5432/quantcore")
 
 
 if __name__ == "__main__":

--- a/tests/test_schema_introspect_live.py
+++ b/tests/test_schema_introspect_live.py
@@ -1,0 +1,101 @@
+"""Live-database tests for quantcore.schema_introspect (issue #165, PR 1).
+
+describe_schema()/scratch_database()/snapshot_from_dsn() are I/O -- they only
+mean anything against a real Postgres. tests/__init__.py has already swapped
+QUANTCORE_DB_DSN to the test database (or, in CI, left it pointed at the
+gate job's disposable postgres service), so this suite runs there, never
+against production.
+"""
+import unittest
+from contextlib import closing
+
+import psycopg2
+
+from quantcore.db_safety import assert_not_production  # noqa: E402
+
+assert_not_production()
+
+import quantcore.db as db  # noqa: E402
+from quantcore.schema_introspect import (  # noqa: E402
+    ScratchDatabaseUnavailable,
+    describe_schema,
+    scratch_database,
+    snapshot_from_dsn,
+)
+
+
+def _raw_connection():
+    # describe_schema() takes a plain psycopg2 connection (it calls
+    # .cursor(cursor_factory=...) directly), not quantcore.db's sqlite3-
+    # compatible _PGConn wrapper -- matches how scripts/schema_check.py and
+    # scripts/check_schema_snapshot.py call it.
+    db.ensure_schema()
+    return psycopg2.connect(db.DB_DSN)
+
+
+class DescribeSchemaLiveTests(unittest.TestCase):
+    def test_describes_a_known_table_with_columns_and_constraints(self):
+        with closing(_raw_connection()) as conn:
+            schema = describe_schema(conn)
+
+        self.assertIn("positions", schema["tables"])
+        positions = schema["tables"]["positions"]
+        self.assertIn("owner", positions["columns"])
+        self.assertIn("symbol_id", positions["columns"])
+        # Every table init_schema() creates gets a primary key index.
+        self.assertTrue(positions["indexes"])
+
+    def test_ignores_flyway_schema_history_table(self):
+        with closing(_raw_connection()) as conn:
+            schema = describe_schema(conn)
+
+        self.assertNotIn("flyway_schema_history", schema["tables"])
+
+    def test_two_descriptions_of_the_same_connection_are_identical(self):
+        # describe_schema() sorts every level internally, so calling it twice
+        # against an unchanged schema must be byte-for-byte equal -- this is
+        # what makes it usable as a diffable snapshot rather than a log.
+        with closing(_raw_connection()) as conn:
+            first = describe_schema(conn)
+            second = describe_schema(conn)
+        self.assertEqual(first, second)
+
+
+class ScratchDatabaseLiveTests(unittest.TestCase):
+    def test_scratch_database_is_created_then_dropped(self):
+        try:
+            with scratch_database(db.DB_DSN) as scratch_dsn:
+                self.assertNotEqual(scratch_dsn, db.DB_DSN)
+                # Usable while the context is open.
+                conn = psycopg2.connect(scratch_dsn)
+                conn.close()
+        except ScratchDatabaseUnavailable:
+            self.skipTest("connecting role lacks CREATEDB against this database")
+            return
+
+        # Dropped on exit: connecting again must fail.
+        with self.assertRaises(psycopg2.OperationalError):
+            psycopg2.connect(scratch_dsn)
+
+
+class SnapshotFromDsnLiveTests(unittest.TestCase):
+    def test_snapshot_matches_a_direct_describe_schema_call(self):
+        # snapshot_from_dsn() runs init_schema() on a throwaway database and
+        # describes it; describe_schema() against the already-initialized
+        # QUANTCORE_DB_DSN database should see the identical set of tables
+        # (init_schema() is idempotent DDL, so both are "what the code
+        # produces today").
+        try:
+            snapshot = snapshot_from_dsn(db.DB_DSN)
+        except ScratchDatabaseUnavailable:
+            self.skipTest("connecting role lacks CREATEDB against this database")
+            return
+
+        with closing(_raw_connection()) as conn:
+            live = describe_schema(conn)
+
+        self.assertEqual(set(snapshot["tables"]), set(live["tables"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_schema_parity.py
+++ b/tests/test_schema_parity.py
@@ -1,0 +1,199 @@
+"""The two owners of the deployed schema must agree (issue #165, PR 2).
+
+``init_schema()`` in ``quantcore/db.py`` and the Flyway files under
+``db/`` both claim to produce the QuantCore schema, and nothing has ever
+compared them. This test builds a scratch database from each and asserts the
+descriptions are identical, so a change that ships to only one owner cannot
+merge.
+
+The diff *is* the bug report: on failure the assertion message carries every
+MISSING/EXTRA/MISMATCH line, which names the object and which side has it.
+"""
+import os
+import re
+import unittest
+from contextlib import closing
+from pathlib import Path
+
+import psycopg2
+
+from quantcore.db_safety import assert_not_production  # noqa: E402
+
+assert_not_production()
+
+import quantcore.db as db  # noqa: E402
+from quantcore.schema_introspect import (  # noqa: E402
+    ScratchDatabaseUnavailable,
+    describe_schema,
+    diff_schemas,
+    scratch_database,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BASELINE_DIR = REPO_ROOT / "db" / "baseline"
+MIGRATIONS_DIR = REPO_ROOT / "db" / "migrations"
+
+_VERSION_RE = re.compile(r"^V(\d+)__")
+
+
+def _version(path: Path) -> int:
+    """Numeric version from a Flyway filename, for ordering.
+
+    Sorting the paths as strings would run V10 before V9; Flyway orders by
+    parsed version, so this does too.
+    """
+    match = _VERSION_RE.match(path.name)
+    if match is None:
+        raise ValueError(f"not a Flyway migration filename: {path.name}")
+    return int(match.group(1))
+
+
+def sql_files_in_order() -> list[Path]:
+    """The baseline, then every migration, in the order Flyway would apply them.
+
+    The baseline lives outside ``flyway.locations`` on purpose (decision D3 in
+    docs/proposals/schema-ownership-plan.md) -- deployed databases were
+    baselined at V1 and must never replay it. This test is the one caller that
+    does replay it, because it is building an empty database from scratch.
+    """
+    baseline = sorted(BASELINE_DIR.glob("V*.sql"), key=_version)
+    migrations = sorted(MIGRATIONS_DIR.glob("V*.sql"), key=_version)
+    return baseline + migrations
+
+
+def _apply_sql_files(dsn: str, paths: list[Path]) -> None:
+    """Run each file as one multi-statement execute on an autocommit connection.
+
+    psycopg2 executes a multi-statement string in one round trip, and
+    autocommit matches how ``init_schema()`` runs (see its docstring: per
+    statement commit is what keeps the DDL from holding locks on every table
+    it has touched).
+    """
+    conn = psycopg2.connect(dsn)
+    try:
+        conn.set_session(autocommit=True)
+        with conn.cursor() as cur:
+            for path in paths:
+                try:
+                    cur.execute(path.read_text())
+                except psycopg2.Error as exc:
+                    raise AssertionError(f"{path.name} failed to apply: {exc}") from exc
+    finally:
+        conn.close()
+
+
+def _describe(dsn: str) -> dict:
+    with closing(psycopg2.connect(dsn)) as conn:
+        return describe_schema(conn)
+
+
+class MigrationOrderTests(unittest.TestCase):
+    """Pure ordering logic -- no database."""
+
+    def test_versions_are_parsed_as_integers(self):
+        self.assertEqual(_version(Path("V10__later.sql")), 10)
+        self.assertEqual(_version(Path("V2__positions_multi_owner.sql")), 2)
+
+    def test_v10_sorts_after_v9_not_before(self):
+        paths = [Path("V10__ten.sql"), Path("V9__nine.sql"), Path("V2__two.sql")]
+        self.assertEqual(
+            [p.name for p in sorted(paths, key=_version)],
+            ["V2__two.sql", "V9__nine.sql", "V10__ten.sql"],
+        )
+
+    def test_non_migration_filename_is_rejected(self):
+        with self.assertRaises(ValueError):
+            _version(Path("afterMigrate__seed.sql"))
+
+    def test_baseline_comes_first_and_files_are_contiguous(self):
+        paths = sql_files_in_order()
+        self.assertTrue(paths, "no SQL files found -- wrong repo layout?")
+        self.assertEqual(paths[0].name, "V1__quantcore_baseline.sql")
+        versions = [_version(p) for p in paths]
+        self.assertEqual(
+            versions,
+            list(range(1, len(versions) + 1)),
+            f"Flyway versions are not contiguous from V1: {versions}",
+        )
+
+
+class SkipGuardTests(unittest.TestCase):
+    """The skip path must not be reachable in CI.
+
+    A guard that quietly skips is the failure mode this whole plan exists to
+    remove: the build goes green and nobody learns the two owners diverged.
+    These cases pin the behaviour so a later edit can't soften it back into a
+    silent skip.
+    """
+
+    def setUp(self):
+        self.case = SchemaParityTests("test_init_schema_and_flyway_files_agree")
+        self._original_ci = os.environ.get("CI")
+
+    def tearDown(self):
+        if self._original_ci is None:
+            os.environ.pop("CI", None)
+        else:
+            os.environ["CI"] = self._original_ci
+
+    def test_skips_when_ci_is_not_set(self):
+        os.environ.pop("CI", None)
+        with self.assertRaises(unittest.SkipTest):
+            self.case._skip_or_fail("database unreachable")
+
+    def test_fails_instead_of_skipping_when_ci_is_set(self):
+        os.environ["CI"] = "true"
+        with self.assertRaises(self.failureException) as ctx:
+            self.case._skip_or_fail("database unreachable")
+        self.assertIn("must run in CI", str(ctx.exception))
+        self.assertIn("database unreachable", str(ctx.exception))
+
+
+class SchemaParityTests(unittest.TestCase):
+    """init_schema() and the Flyway files must produce the same schema."""
+
+    def _skip_or_fail(self, reason: str) -> None:
+        """Skip locally, but never in CI.
+
+        A guard that quietly skips is worse than no guard: the build goes
+        green and nobody learns the two owners diverged. CI is the
+        authoritative run, so there the same condition is a failure.
+        """
+        if os.environ.get("CI"):
+            self.fail(f"schema parity must run in CI, but would have skipped: {reason}")
+        self.skipTest(reason)
+
+    def test_init_schema_and_flyway_files_agree(self):
+        paths = sql_files_in_order()
+        try:
+            with scratch_database(db.DB_DSN) as code_dsn:
+                db.init_schema(code_dsn)
+                code_schema = _describe(code_dsn)
+
+                with scratch_database(db.DB_DSN) as sql_dsn:
+                    _apply_sql_files(sql_dsn, paths)
+                    sql_schema = _describe(sql_dsn)
+        except ScratchDatabaseUnavailable as exc:
+            self._skip_or_fail(f"cannot build scratch databases: {exc}")
+            return
+        except psycopg2.OperationalError as exc:
+            self._skip_or_fail(f"database unreachable: {exc}")
+            return
+
+        # expected = the code, actual = the SQL files. So MISSING means the
+        # migrations never got a change init_schema() has, and EXTRA means the
+        # reverse.
+        differences = diff_schemas(code_schema, sql_schema)
+        self.assertEqual(
+            differences,
+            [],
+            "init_schema() and db/baseline + db/migrations disagree.\n"
+            "expected = init_schema(), actual = "
+            + " -> ".join(p.name for p in paths)
+            + "\n\n"
+            + "\n".join(differences),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
PR 2 (Enforcement) of [`docs/proposals/schema-ownership-plan.md`](docs/proposals/schema-ownership-plan.md), for issue #165. PR 1 (#172) built the evidence tooling; this makes divergence between the two owners of the schema impossible to merge.

## What lands

- **`tests/test_schema_parity.py`** — builds one scratch database from `init_schema()` and another from `db/baseline/V1__*.sql` + every `db/migrations/V*.sql` in parsed-integer version order, and asserts the two descriptions are identical. The failure message carries the full MISSING/EXTRA/MISMATCH list, because the diff *is* the bug report. `MigrationOrderTests` pins V10-after-V9 ordering and baseline-first contiguity; `SkipGuardTests` pins that the guard **fails rather than skips** when `CI` is set.
- **`db/migrations/V6__parity_backfill.sql`** — the first parity run's finding, resolved.
- Docs: `CLAUDE.md`, `AGENTS.md`, `readme.md` now state the three-file rule as CI-enforced rather than a convention, and the plan doc gains the "What the first parity run found" section plus the PR 2 checkpoint row.
- Two carry-overs from PR 1, kept here deliberately rather than split into their own PR: the coverage repair that lifts `quantcore/schema_introspect.py` from 52% → 98%, and the `sys.path` preamble both operator scripts shipped without.

## What the first parity run found

Three `MISSING table` lines — `arb_nav_snapshots`, `gex_history`, `user_settings` — and **zero MISMATCH lines**.

The plan predicted constraint-name drift, index-name drift, and a `positions.quantity` type mismatch. None of that exists: every table both sides have is identical down to columns, indexes, and constraints. The drift was purely *additive* — three tables added to `_SCHEMA` that never got a migration. So the interesting failure mode here is "someone added a table and forgot the migration", not "the two sources describe the same table differently".

Under decision **D6, prod reality wins**. Prod has all three (verified read-only against `quantcore-prod-20260606`: `schema_check.py --prod` reports `22 tables, 0 missing, 0 extra`, plus a direct `information_schema.tables` query naming them), so the migrations were the wrong side. V6 is idempotent DDL copied verbatim from `_SCHEMA`. **`V2`–`V5` untouched.**

V6 will be a no-op on every existing database — that is the point, not a sign it's unnecessary. Its job is to make the *file set* a complete description of the schema. The case it actually fixes is a database built from empty: a new environment, a scratch database, a restore drill.

The drift was invisible precisely because nothing broke: `init_schema()` runs on every application startup and created these tables before Flyway ever looked. No outage, no error, no log line — the only symptom was `flyway info` saying `V5` while the database had 22 tables. This is the concrete instance of the claim in `CLAUDE.md` that `flyway info` is a changelog view, not evidence.

## Verification

- Full suite: **1228 tests, OK, 5 skipped** (up from 1221 — exactly the 7 new tests; the same 5 pre-existing skips).
- `./.claude/with-test-db.sh .venv/bin/python -m unittest tests.test_schema_parity -v` → 7/7 pass in 10.4s against a real Postgres. The database-backed case genuinely runs; it does not skip.
- `python scripts/check_schema_snapshot.py` → `schema snapshot up to date (22 tables)`. `db/schema_snapshot.json` is unchanged, as expected — V6 adds nothing `init_schema()` didn't already have.
- No deployment needed. Nothing here is imported by any service, router, MCP wrapper, or `main.py`.

## Gotcha worth reading

Both PR 1 scripts shipped without the `sys.path.insert(REPO_ROOT)` preamble every other script in `scripts/` has, so `python scripts/schema_check.py --prod` from the repo root died with `ModuleNotFoundError: No module named 'quantcore'` before printing anything. CI sets `PYTHONPATH: .` job-wide, which is exactly why it passed review — the failure only reproduces interactively, and interactive is the only way `schema_check.py` is ever invoked. **A command whose entire purpose is hand-invocation cannot be validated solely by a CI job that pre-configures its environment.**

Related: PR 1's CI run never actually reached its new "Schema snapshot up to date" step — it aborted earlier at the PR-only `Diff coverage` gate, which the post-merge push run then skips. The step's first real execution was run `31336550437` on `main`, which passed.

Next: PR 3 (verify mode), which is the first one that touches deployed behaviour — warn-only by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)