### PR TITLE
refactor: extract the nav/route seam out of App.tsx (#147 PR 0)

### DIFF
--- a/docs/proposals/legacy-report-retirement-plan.md
+++ b/docs/proposals/legacy-report-retirement-plan.md
@@ -1,7 +1,7 @@
 # Retire the legacy HTML report into QuantUI
 
 **Source issue:** [#147](https://github.com/JohnFunkCode/StockPortfolioManager/issues/147)
-**Status:** APPROVED — no code written
+**Status:** IN PROGRESS — PR 0 (the seam) in review; PRs 1–8 not started
 **Shape:** nine PRs (0–8) across three tracks that different people can work in parallel; see
 [Sequencing](#sequencing) and [Working alongside other people](#working-alongside-other-people)
 **Related:** [`watchlist-db-plan.md`](watchlist-db-plan.md) (#83, the DB-backed watchlist this plan
@@ -561,25 +561,45 @@ symbol held by that owner.** When the last share is sold, the plan closes with i
 
 ### H1. Schema — `owner` on `plan_instances`
 
-`db/migrations/V6__plan_owner.sql`, mirrored into `init_schema()` (both, per CLAUDE.md):
+`db/migrations/V7__plan_owner.sql`, mirrored into `init_schema()` (both, per CLAUDE.md):
+
+> **Renumbered 2026-08-10.** This part originally claimed `V6`, which #165's PR 3 took for
+> `V6__parity_backfill.sql`. `V7` here and `V8` in H8; the uniqueness guard added in PR 0
+> (`tests/test_schema_parity.MigrationOrderTests.test_migration_versions_are_unique`) fails CI on a
+> collision rather than letting it reach `flyway migrate`.
+
 
 - `ALTER TABLE plan_instances ADD COLUMN IF NOT EXISTS owner TEXT NOT NULL DEFAULT 'john'` — the
   exact V2 move that gave `positions` its owner (`V2__positions_multi_owner.sql:13`). Existing rows
   backfill to `john`, which is correct: he is the only owner holding positions.
 - **Swap the uniqueness key**: `DROP INDEX IF EXISTS ux_one_active_plan_per_symbol`, then
   `CREATE UNIQUE INDEX IF NOT EXISTS ux_one_active_plan_per_owner_symbol ON plan_instances(owner, symbol_id) WHERE status = 'ACTIVE'`.
-  Both statements go in `init_schema()` too, in that order — the DROP is what makes the two schema
-  owners converge instead of fighting. It is also the first non-additive statement in that function,
-  so flag it there in a comment pointing at
-  [issue #165](https://github.com/JohnFunkCode/StockPortfolioManager/issues/165) — and **add a
-  comment to #165** recording this escalation: until now the two schema owners merely duplicated each
-  other, and this is the first case where they can actively disagree about what the database holds.
-  Do not open a new issue; #165 already tracks exactly this problem.
+  Both statements go in `init_schema()` too, **in that order** — see the ordering note below.
 - `CREATE INDEX IF NOT EXISTS idx_instances_owner_status ON plan_instances(owner, status)`, mirroring
   `idx_positions_owner_status`.
 
 `position_id` stays as-is — still unused, still NULL. Ownership is carried by `owner`, not by a lot
 FK, because a plan spans *all* lots of a symbol and lots come and go beneath it.
+
+**Ordering in `_SCHEMA` is load-bearing here, for a reason that changed under this plan's feet.**
+That `DROP INDEX` is the first non-additive statement to enter `init_schema()`. When this part was
+written, two owners of the schema were both executing DDL on deployed databases, and the escalation
+this bullet asked to record on
+[#165](https://github.com/JohnFunkCode/StockPortfolioManager/issues/165) was that they could now
+disagree rather than merely duplicate each other. **That escalation is resolved** —
+[#165](https://github.com/JohnFunkCode/StockPortfolioManager/issues/165) shipped 2026-08-09/10, and
+`QUANTCORE_SCHEMA_MODE=auto` now resolves to `verify` wherever a `flyway_schema_history` ledger
+exists, so on test and prod `init_schema()` runs no DDL at all. Flyway performs the DROP exactly
+once; startup only checks the result. There is nothing left to interleave, and
+`tests/test_schema_parity.py` proves both owners still express the swap identically.
+
+What survives is narrower and worth a comment in `_SCHEMA` explaining *why*, not just pointing at
+the issue: `QUANTCORE_SCHEMA_MODE=create` is the escape hatch an operator reaches for mid-incident.
+Today every statement in `_SCHEMA` is additive and idempotent, so flipping to `create` costs only
+wasted work. After this part, flipping to `create` on a deployed database executes a `DROP INDEX` —
+recreated by the very next statement, so it converges, but there is a window with no uniqueness
+constraint on a database serving traffic. Keep the two statements adjacent and in that order, and
+say so in the comment.
 
 ### H2. A terminal status distinct from SUPERSEDED
 
@@ -678,11 +698,22 @@ treating it as routine housekeeping would defeat the point.
 
 ### H8. Migrations — two files, because only one of them is dangerous
 
-`V6__plan_owner.sql` is the H1 DDL and nothing else. Per the "flyway info is not evidence" rule it
-will report "already exists, skipping" against a deployed DB that `init_schema()` has already
-converged — expected, and harmless.
+`V7__plan_owner.sql` is the H1 DDL and nothing else.
 
-`V7__close_orphan_plans.sql` is one data statement: close every ACTIVE plan with no OPEN lot for its
+> **This paragraph used to say the DDL would report "already exists, skipping" against a deployed
+> database, and that this was expected and harmless. That is no longer true**, and the inversion
+> matters. It relied on `init_schema()` having already converged the shape at startup; since
+> [#165](https://github.com/JohnFunkCode/StockPortfolioManager/issues/165) shipped (2026-08-10),
+> startup on test and prod only *verifies*. So the `ALTER TABLE … ADD COLUMN owner`, the
+> `DROP INDEX`, and the `CREATE UNIQUE INDEX` all genuinely execute there, against live tables. That
+> is a strict improvement — the migration is now the thing that actually happens, which was the whole
+> point of #165 — but it is no longer a rehearsed no-op, and it inherits the rule that came with it:
+> **migrate before the image carrying the schema change deploys, in both projects**
+> (`./scripts/flyway.sh migrate` before merging to `main`, `./scripts/flyway.sh --prod migrate`
+> before dispatching `prod-rollout.yml`). Nothing creates the column for you now, and a drifted
+> schema aborts startup with `SchemaDriftError`.
+
+`V8__close_orphan_plans.sql` is one data statement: close every ACTIVE plan with no OPEN lot for its
 owner. **This is the part that does real work**, and the only statement in this whole plan that
 mutates existing rows, so it ships as its own reviewable file rather than hiding behind the DDL.
 
@@ -715,10 +746,10 @@ work is concentrated in a handful of files that *any* feature branch also touche
 
 | File | Touched by | Why it collides |
 |------|-----------|-----------------|
-| `frontend/src/App.tsx` | C, D, G | Flat `navItems` array (`:39-47`) **and** a flat `<Routes>` list (`:186-197`) — two places, same PR, and the only place anyone adds a page |
+| `frontend/src/navigation.tsx` | C, D, G | ~~Flat `navItems` array **and** a flat `<Routes>` list in `App.tsx` — two places, same PR~~ **Resolved by PR 0:** one `routes` array, and adding a page is a one-object append. Still the only place anyone adds a page, so appends can still collide — but on adjacent lines rather than in two files |
 | `frontend/vitest.config.ts` | A, C, D, G | One 4-line `thresholds` block with a dated comment — a per-PR ratchet conflicts with *every* concurrent frontend PR |
 | `quantcore/services/registry.py` | B4, H5 | Single `Services` dataclass + single `get_services()` body; anyone adding a service edits it |
-| `db/migrations/` + `init_schema()` | H1 | `V5` is the latest, so `V6`/`V7` are unclaimed — and a duplicate version number is a **runtime** Flyway failure, not a merge conflict, so git won't warn anyone |
+| `db/migrations/` + `init_schema()` | H1 | `V6` is the latest, so `V7`/`V8` are unclaimed — a duplicate version number used to be a **runtime** Flyway failure rather than a merge conflict, so git wouldn't warn anyone; PR 0 added the CI guard that now catches it |
 | `quantcore/repositories/harvester_repository.py` | H3 | ~15 method signatures at once — the single largest mechanical diff in the plan |
 | `chat_tools.py` + `componentRegistry.tsx` | A, C, D | Dual GenUI registration; two literals every new component appends to |
 | `requirements-base.txt` | F | Installed by `Dockerfile.{api,mcp,report}`; anyone adding a dependency edits it, and a bad merge here breaks three images rather than one file |
@@ -758,7 +789,7 @@ must land in this series — not be deferred — or the window becomes permanent
 existing route, field, or default changes**, so nobody's branch breaks on a rebase and no coordinated
 front-end/back-end landing is needed.
 
-**5. Announce the reservations up front.** Comment on the tracking issue claiming `V6`/`V7`, the
+**5. Announce the reservations up front.** Comment on the tracking issue claiming `V7`/`V8`, the
 `CLOSED` plan status, and the `owner` column before PR 0 merges. Migration numbers and status
 vocabularies are the two things another branch can duplicate without git noticing.
 
@@ -804,12 +835,12 @@ order to put conflict-free and seam-clearing work first:
 4. **Part C** — the `/watchlist` page and sidekick card. *This is the report replacement; everything
    after it is additive.*
 5. **Parts B4 + D** — `scope` plumbing and the `/fundamentals` page.
-6. **Parts H1–H4** — `owner` on `plan_instances` (`V6`), the index swap, owner threaded through the
+6. **Parts H1–H4** — `owner` on `plan_instances` (`V7`), the index swap, owner threaded through the
    repository/service/routes/`notifier.py` (keyword-only with a default, per mitigation 3), `CLOSED`
    in the vocabulary. Behaviour-preserving for the single-owner world, which is what makes it safe to
    ship on its own.
 7. **Parts H5–H8** — drop the `owner` default, the holding invariant, the portfolio chip, the orphan
-   flag, and the `V7` orphan-close backfill. Separate because this is the one PR that mutates existing
+   flag, and the `V8` orphan-close backfill. Separate because this is the one PR that mutates existing
    rows and the one that can break a live plan; it deserves an unhurried review on its own.
 8. **Part G** — remove `/symbols` and group the nav; raise the vitest floors once, here. Ships after H
    (which supplies the symbol→plan link `/symbols` was carrying) and after the two new pages, so the
@@ -1046,12 +1077,27 @@ Append a row as each PR lands. Any dev machine can resume by reading the last ro
 | Date | PR / Item | Status | Notes |
 |------|-----------|--------|-------|
 | 2026-07-29 | — | Plan written | Approved after nine review rounds; all decisions in "Decisions already settled" answered by the repo owner. No code written |
-| | 0 | | Seam PR — `frontend/src/navigation.tsx` + migration-version CI guard |
+| 2026-08-10 | 0 | In review | Seam PR. `frontend/src/navigation.tsx` holds one `routes` array (`{path,label,icon,element,group?,nav?:false}`) that both the `<Stack>` of nav buttons and `<Routes>` map over; the two detail routes carry `nav: false`, `/` stays the index route, and the active-path predicate is hoisted to an exported `isPathActive(path, pathname)` so Part G2's group buttons can reuse it. `App.tsx` drops 16 imports and both lists — behaviour identical, 454 frontend tests green (up 12; new `navigation.test.tsx`), floors cleared at 89.75/87.74/87.63/71.06 and **not raised** (mitigation 2). Migration-version guard landed as `MigrationOrderTests.test_migration_versions_are_unique` rather than a new workflow step — it runs in the existing `gate` job, needs no database, and names both colliding files; verified by planting a duplicate `V6`. Also folded in the plan corrections below |
 | | 1 | | Parts E + F — warmer, report extraction, dependency split, `runOnPi.sh`, docs |
 | | 2 | | Part A — stacked bar on the Portfolio page |
 | | 3 | | Parts B1–B3, B5 — analytics, bulk returns, `WatchlistService`, the new route |
 | | 4 | | Part C — the `/watchlist` page |
 | | 5 | | Parts B4 + D — `scope` plumbing and the `/fundamentals` page |
 | | 6 | | Parts H1–H4 — `owner` on `plan_instances`, index swap, `CLOSED` |
-| | 7 | | Parts H5–H8 — holding invariant, portfolio chip, orphan flag, `V7` backfill |
+| | 7 | | Parts H5–H8 — holding invariant, portfolio chip, orphan flag, `V8` backfill |
 | | 8 | | Part G — remove `/symbols`, group the nav, ratchet the vitest floors |
+
+**Corrections folded in with PR 0** (2026-08-10), all of them consequences of
+[#165](https://github.com/JohnFunkCode/StockPortfolioManager/issues/165) landing after this plan was
+approved:
+
+1. **Part H's migration versions were renumbered `V6`/`V7` → `V7`/`V8`.** #165's PR 3 took `V6` for
+   `V6__parity_backfill.sql`. PR 0's CI guard now catches exactly this class of collision.
+2. **H8's "already exists, skipping … harmless" paragraph was wrong as written** and is replaced.
+   `init_schema()` no longer converges the schema on test or prod, so Part H's DDL genuinely
+   executes there and must be migrated ahead of the deploy in both projects.
+3. **Part H1's escalation to #165 is closed rather than pending.** The two schema owners can no
+   longer disagree on a deployed database, because only one of them executes DDL there. What
+   replaces it is narrower: the `QUANTCORE_SCHEMA_MODE=create` escape hatch stops being trivially
+   safe once a `DROP` lives in `_SCHEMA`, which makes statement ordering there load-bearing for the
+   first time.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,28 +4,13 @@ import {
   AppBar, Toolbar, Typography, Button, Container, Box, Stack, alpha,
   IconButton, Tooltip,
 } from '@mui/material';
-import DashboardIcon from '@mui/icons-material/Dashboard';
-import AccountBalanceWalletIcon from '@mui/icons-material/AccountBalanceWallet';
-import ListAltIcon from '@mui/icons-material/ListAlt';
-import ShowChartIcon from '@mui/icons-material/ShowChart';
-import BarChartIcon from '@mui/icons-material/BarChart';
-import CompareArrowsIcon from '@mui/icons-material/CompareArrows';
-import SettingsIcon from '@mui/icons-material/Settings';
 import LightModeIcon from '@mui/icons-material/LightMode';
 import DarkModeIcon from '@mui/icons-material/DarkMode';
 import ChatIcon from '@mui/icons-material/Chat';
 import ChatRail from './components/chat/ChatRail';
 import { useChat } from './chat/ChatContext';
-import DashboardPage from './components/dashboard/DashboardPage';
-import PortfolioPage from './components/portfolio/PortfolioPage';
-import PlansPage from './components/plans/PlansPage';
-import PlanDetailPage from './components/plans/PlanDetailPage';
-import SymbolsPage from './components/symbols/SymbolsPage';
-import SecuritiesPage from './components/securities/SecuritiesPage';
-import SecurityDetailPage from './components/securities/SecurityDetailPage';
-import ArbitragePage from './components/arbitrage/ArbitragePage';
-import SettingsPage from './components/settings/SettingsPage';
 import RestrictedAccess from './components/access/RestrictedAccess';
+import { isPathActive, navItems, routes } from './navigation';
 import { useAppTheme } from './ThemeContext';
 import { onNotProvisioned } from './api/client';
 
@@ -35,16 +20,6 @@ function Layout() {
   const { railOpen, setRailOpen, expanded } = useChat();
   const chatFullscreen = railOpen && expanded;
   const isLight = themeName === 'light';
-
-  const navItems = [
-    { label: 'Portfolio', path: '/', icon: <AccountBalanceWalletIcon /> },
-    { label: 'Harvester', path: '/harvester', icon: <DashboardIcon /> },
-    { label: 'Securities', path: '/securities', icon: <BarChartIcon /> },
-    { label: 'Arbitrage', path: '/arbitrage', icon: <CompareArrowsIcon /> },
-    { label: 'Plans', path: '/plans', icon: <ListAltIcon /> },
-    { label: 'Symbols', path: '/symbols', icon: <ShowChartIcon /> },
-    { label: 'Settings', path: '/settings', icon: <SettingsIcon /> },
-  ];
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', height: '100vh', overflow: 'hidden' }}>
@@ -68,8 +43,7 @@ function Layout() {
 
           <Stack direction="row" spacing={1}>
             {navItems.map((item) => {
-              const active = location.pathname === item.path ||
-                (item.path !== '/' && location.pathname.startsWith(item.path));
+              const active = isPathActive(item.path, location.pathname);
               return (
                 <Button
                   key={item.path}
@@ -183,15 +157,9 @@ export default function App() {
   return (
     <Routes>
       <Route element={<Layout />}>
-        <Route path="/" element={<PortfolioPage />} />
-        <Route path="/harvester" element={<DashboardPage />} />
-        <Route path="/securities" element={<SecuritiesPage />} />
-        <Route path="/securities/:symbol" element={<SecurityDetailPage />} />
-        <Route path="/arbitrage" element={<ArbitragePage />} />
-        <Route path="/plans" element={<PlansPage />} />
-        <Route path="/plans/:id" element={<PlanDetailPage />} />
-        <Route path="/symbols" element={<SymbolsPage />} />
-        <Route path="/settings" element={<SettingsPage />} />
+        {routes.map((route) => (
+          <Route key={route.path} path={route.path} element={route.element} />
+        ))}
         <Route path="*" element={<Typography variant="h5" sx={{ mt: 4 }}>Page not found</Typography>} />
       </Route>
     </Routes>

--- a/frontend/src/navigation.test.tsx
+++ b/frontend/src/navigation.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import { isPathActive, navItems, routes } from './navigation';
+
+describe('routes', () => {
+  it('has no duplicate paths', () => {
+    const paths = routes.map((route) => route.path);
+    expect(new Set(paths).size).toBe(paths.length);
+  });
+
+  it('keeps "/" as the index route', () => {
+    expect(routes[0].path).toBe('/');
+  });
+
+  it('gives every route an element', () => {
+    for (const route of routes) {
+      expect(route.element, route.path).toBeTruthy();
+    }
+  });
+
+  it('hides the drill-down detail routes from the nav bar', () => {
+    const hidden = routes.filter((route) => route.nav === false).map((r) => r.path);
+    expect(hidden).toEqual(['/securities/:symbol', '/plans/:id']);
+  });
+});
+
+describe('navItems', () => {
+  it('is every route except the detail routes', () => {
+    expect(navItems.map((item) => item.path)).toEqual([
+      '/', '/harvester', '/securities', '/arbitrage', '/plans', '/symbols', '/settings',
+    ]);
+  });
+
+  it('gives every nav button a label and an icon', () => {
+    for (const item of navItems) {
+      expect(item.label, item.path).toBeTruthy();
+      expect(item.icon, item.path).toBeTruthy();
+    }
+  });
+
+  it('never puts a parameterized path in the bar', () => {
+    for (const item of navItems) {
+      expect(item.path, item.path).not.toContain(':');
+    }
+  });
+});
+
+describe('isPathActive', () => {
+  it('matches the exact path', () => {
+    expect(isPathActive('/plans', '/plans')).toBe(true);
+  });
+
+  it('matches a child path', () => {
+    expect(isPathActive('/plans', '/plans/7')).toBe(true);
+  });
+
+  it('does not match an unrelated path', () => {
+    expect(isPathActive('/plans', '/securities')).toBe(false);
+  });
+
+  it('only lights up the index route on the index itself', () => {
+    // Without the '/' guard, startsWith would make Portfolio active everywhere.
+    expect(isPathActive('/', '/')).toBe(true);
+    expect(isPathActive('/', '/securities')).toBe(false);
+  });
+});

--- a/frontend/src/navigation.tsx
+++ b/frontend/src/navigation.tsx
@@ -1,0 +1,78 @@
+/**
+ * The single source of truth for what pages QuantUI has.
+ *
+ * `App.tsx` used to carry two parallel lists — a `navItems` array for the nav
+ * buttons and a `<Routes>` block for the router — so adding a page meant two
+ * edits in two places, and it was possible for them to disagree. Both render
+ * sites now map over `routes` below, which makes adding a page a one-object
+ * append (issue #147, seam PR; see
+ * docs/proposals/legacy-report-retirement-plan.md).
+ *
+ * `group` is unused today. Part G2 of that plan collapses the flat button row
+ * into dropdown menus and derives them from this field; it is declared here so
+ * that change is a render-site change rather than another list rewrite.
+ */
+import type { ReactElement } from 'react';
+import DashboardIcon from '@mui/icons-material/Dashboard';
+import AccountBalanceWalletIcon from '@mui/icons-material/AccountBalanceWallet';
+import ListAltIcon from '@mui/icons-material/ListAlt';
+import ShowChartIcon from '@mui/icons-material/ShowChart';
+import BarChartIcon from '@mui/icons-material/BarChart';
+import CompareArrowsIcon from '@mui/icons-material/CompareArrows';
+import SettingsIcon from '@mui/icons-material/Settings';
+import DashboardPage from './components/dashboard/DashboardPage';
+import PortfolioPage from './components/portfolio/PortfolioPage';
+import PlansPage from './components/plans/PlansPage';
+import PlanDetailPage from './components/plans/PlanDetailPage';
+import SymbolsPage from './components/symbols/SymbolsPage';
+import SecuritiesPage from './components/securities/SecuritiesPage';
+import SecurityDetailPage from './components/securities/SecurityDetailPage';
+import ArbitragePage from './components/arbitrage/ArbitragePage';
+import SettingsPage from './components/settings/SettingsPage';
+
+type BaseRoute = {
+  path: string;
+  label: string;
+  element: ReactElement;
+  /** Nav grouping, for Part G2. Ungrouped entries stay top-level. */
+  group?: string;
+};
+
+/** A destination that appears in the nav bar. The icon is required there. */
+export type NavRoute = BaseRoute & { icon: ReactElement; nav?: true };
+
+/** Reached by drill-down (`/plans/:id`), never shown in the bar. */
+export type DetailRoute = BaseRoute & { nav: false; icon?: never };
+
+export type AppRoute = NavRoute | DetailRoute;
+
+/**
+ * Every route under `Layout`, in nav-bar order. The `*` fallback is not here:
+ * it is not a destination, and `App.tsx` renders it last on its own.
+ */
+export const routes: AppRoute[] = [
+  { path: '/', label: 'Portfolio', icon: <AccountBalanceWalletIcon />, element: <PortfolioPage /> },
+  { path: '/harvester', label: 'Harvester', icon: <DashboardIcon />, element: <DashboardPage /> },
+  { path: '/securities', label: 'Securities', icon: <BarChartIcon />, element: <SecuritiesPage /> },
+  { path: '/securities/:symbol', label: 'Security detail', nav: false, element: <SecurityDetailPage /> },
+  { path: '/arbitrage', label: 'Arbitrage', icon: <CompareArrowsIcon />, element: <ArbitragePage /> },
+  { path: '/plans', label: 'Plans', icon: <ListAltIcon />, element: <PlansPage /> },
+  { path: '/plans/:id', label: 'Plan detail', nav: false, element: <PlanDetailPage /> },
+  { path: '/symbols', label: 'Symbols', icon: <ShowChartIcon />, element: <SymbolsPage /> },
+  { path: '/settings', label: 'Settings', icon: <SettingsIcon />, element: <SettingsPage /> },
+];
+
+/** The subset of `routes` that gets a button in the nav bar. */
+export const navItems: NavRoute[] = routes.filter(
+  (route): route is NavRoute => route.nav !== false,
+);
+
+/**
+ * Whether `pathname` is on (or beneath) `path`.
+ *
+ * The `'/'` guard matters: Portfolio is the index route, so a plain
+ * `startsWith` would light it up on every page.
+ */
+export function isPathActive(path: string, pathname: string): boolean {
+  return pathname === path || (path !== '/' && pathname.startsWith(path));
+}

--- a/tests/test_schema_parity.py
+++ b/tests/test_schema_parity.py
@@ -12,6 +12,7 @@ MISSING/EXTRA/MISMATCH line, which names the object and which side has it.
 import os
 import re
 import unittest
+from collections import Counter
 from contextlib import closing
 from pathlib import Path
 
@@ -104,6 +105,29 @@ class MigrationOrderTests(unittest.TestCase):
     def test_non_migration_filename_is_rejected(self):
         with self.assertRaises(ValueError):
             _version(Path("afterMigrate__seed.sql"))
+
+    def test_migration_versions_are_unique(self):
+        """Two branches numbering their migration V7 is the one collision git
+        allows silently: both files apply cleanly on the branch that wrote them,
+        and the merge produces two V7 files rather than a conflict. Flyway then
+        refuses to migrate ("Found more than one migration with version 7"), on
+        a deployed database, at rollout time. Catch it in CI instead.
+
+        The contiguity check below would also fail on a duplicate, but on the
+        wrong grounds -- it would report a gap at the far end of the sequence.
+        """
+        counts = Counter(_version(p) for p in MIGRATIONS_DIR.glob("V*.sql"))
+        duplicates = {
+            version: sorted(p.name for p in MIGRATIONS_DIR.glob(f"V{version}__*.sql"))
+            for version, count in counts.items()
+            if count > 1
+        }
+        self.assertEqual(
+            duplicates,
+            {},
+            f"duplicate Flyway migration versions: {duplicates}. Renumber the "
+            f"newer file -- Flyway keys its ledger on the version, not the name.",
+        )
 
     def test_baseline_comes_first_and_files_are_contiguous(self):
         paths = sql_files_in_order()


### PR DESCRIPTION
PR 0 of nine for #147, per the Sequencing section of
[`docs/proposals/legacy-report-retirement-plan.md`](docs/proposals/legacy-report-retirement-plan.md).
This is the seam PR — mitigation 1. It ships no feature; it makes the eight PRs behind it
stop colliding.

## Why

`App.tsx` carried two parallel lists — a `navItems` array for the nav buttons and a
`<Routes>` block for the router — so adding a page meant two edits in two places, with
nothing stopping them from disagreeing. #147 adds four pages across four PRs on two
parallel tracks, which would have made `App.tsx` the hottest file in the series and every
one of those PRs a merge-conflict candidate against the same two lists.

## What changed

- **`frontend/src/navigation.tsx` (new)** — one exported `routes` array of
  `{ path, label, icon, element, group?, nav? }` that both render sites map over, so adding
  a page is a one-object append. `navItems` and `isPathActive()` derive from it.
  The array is typed so the nav guarantee is structural rather than a convention:
  `NavRoute` requires an `icon`, `DetailRoute` requires `nav: false` and forbids one, and
  `navItems` narrows through a type predicate. `group` is declared but unused — Part G2
  collapses the flat button row into dropdowns and derives them from it, which should be a
  render-site change rather than another list rewrite.
- **`frontend/src/App.tsx`** — 199 → 167 lines; 16 imports dropped. Keeps the wordmark, the
  per-button neon treatment, the Sidekick and theme toggles, the hide-not-unmount fullscreen
  container, and the `not_provisioned` early return (#126).
- **`frontend/src/navigation.test.tsx` (new)** — 12 tests: no duplicate paths, `/` stays the
  index, the hidden set is exactly the two drill-down routes, nav-bar contents and ordering,
  no parameterized path in the bar, and the `'/'` guard in `isPathActive` (without it,
  `startsWith` lights up Portfolio on every page).
- **`tests/test_schema_parity.py`** — `test_migration_versions_are_unique`. Two branches
  both numbering their migration V7 is the collision git allows silently: the merge yields
  two V7 files rather than a conflict, and Flyway only refuses at rollout time, against a
  deployed database. It lands in `MigrationOrderTests` because that class is pure and
  already runs in the `gate` job without a database.
- **`docs/proposals/legacy-report-retirement-plan.md`** — the pending Part H1 corrections:
  the migration renumbered to `V7__plan_owner.sql` / `V8__close_orphan_plans.sql`, and the
  #165 escalation marked resolved now that only Flyway executes DDL on deployed databases.
  What survives is narrower — `QUANTCORE_SCHEMA_MODE=create` stops being trivially safe once
  a `DROP` lives in `_SCHEMA`, which makes the two statements' adjacency and ordering
  load-bearing. Also updates the hot-files table and fills in the PR 0 checkpoint row.

## Behaviour

Unchanged. Same routes, labels, icons, order, and styling.

## Verification

- `npx tsc -b --noEmit` — clean
- `npx vitest run --coverage` — 69 files / 454 tests pass; 89.75 lines / 87.74 statements /
  87.63 functions / 71.06 branches, clearing the existing 89/87/86/70 floors. Floors are
  **left unraised** — mitigation 2 raises them in the last frontend PR of the series, so the
  earlier ones only have to clear them.
- `python -m unittest discover -s tests -t .` — 1243 tests OK (skipped=5)
- The migration guard was confirmed to fire: planting `db/migrations/V6__collide.sql`
  produced `AssertionError: {6: ['V6__collide.sql', 'V6__parity_backfill.sql']} != {}`, then
  the file was deleted and the directory verified back to V2–V6.
- Browser check against the dev server: the seven nav buttons render unchanged with
  Portfolio active, and `/plans/1` renders `PlanDetailPage` with **Plans** active — proving
  the `nav: false` drill-down route still resolves.

No schema change ships in this PR, so nothing to migrate before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)