### PR TITLE
fix: stop returning the database DSN from cache_stats (#179)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,7 +225,12 @@ Anthropic API key; the backend never holds a usable key at rest.
   SSE from Anthropic back through the chain.
 - **Never-log policy (enforced by tests):** no API keys, `Authorization` headers, envelopes,
   decrypted payloads, request bodies, or exception dumps containing credentials may reach any log
-  or print. Any new failure path must add the corresponding log assertion.
+  or print. Any new failure path must add the corresponding log assertion. The **database DSN**
+  counts as a credential — it carries the password — and the policy covers API/MCP **responses**,
+  not just logs: name a database with `quantcore.db.describe_dsn()` (`host:port/name`), never with
+  the DSN. `tests/test_dsn_redaction.py` guards the case that got through
+  (`cache_stats()` returned the DSN as `db_path` all the way out to the `get_cache_stats` MCP
+  tool).
 - **Auth layers:** keyproxy is **IAM-locked on Cloud Run** (`--no-allow-unauthenticated`;
   `run.invoker` only for `quantcore-run@`; the api attaches a Google ID token in
   `X-Serverless-Authorization`) and runs as dedicated SA `keyproxy-runtime@` (zero project roles,

--- a/docs/FUNDAMENTALS_CACHE_IMPLEMENTATION.md
+++ b/docs/FUNDAMENTALS_CACHE_IMPLEMENTATION.md
@@ -80,7 +80,9 @@ Surfaces stocks with earnings within N days. Days-to-earnings recomputed at quer
 Respects TTL by default; can include stale entries if flagged explicitly.
 
 #### `get_cache_stats()`
-Inventory of what's cached: symbol counts, date ranges, DB file size per data type.
+Inventory of what's cached: symbol counts and date ranges per data type, plus a `database`
+identifier (`host:port/name` via `quantcore.db.describe_dsn()`). Never the DSN — it holds the
+password, and this dict is returned verbatim to REST and MCP callers.
 
 #### `get_sector_fundamental_breakdown(sector=None, top_n=5)`
 Groups cached scores by sector. Returns top N per sector or single sector if specified.

--- a/fastMCPTest/company_fundamentals_server.py
+++ b/fastMCPTest/company_fundamentals_server.py
@@ -202,8 +202,9 @@ def get_upcoming_earnings(days: int = 14, include_stale: bool = False) -> dict:
 def get_cache_stats() -> dict:
     """Return a summary of what is stored in the fundamentals cache.
 
-    Reports symbol counts, date ranges, and DB file size per data type.
-    Zero network calls — reads only from the local SQLite database.
+    Reports symbol counts and date ranges per data type, plus a `database`
+    identifier (host:port/name — never credentials). Zero market-data calls;
+    reads only the QuantCore database.
     """
     return rest_client.get("/api/securities/fundamentals/cache-stats")
 

--- a/quantcore/db.py
+++ b/quantcore/db.py
@@ -4,6 +4,7 @@ import os
 import re
 import threading
 from pathlib import Path
+from urllib.parse import urlparse
 
 import psycopg2
 import psycopg2.extras
@@ -692,6 +693,36 @@ def ensure_schema(dsn: str = None) -> None:
         # init_schema() records it too; recorded here as well so the
         # once-per-process gate holds however init_schema is reached.
         _schema_ready_dsns.add(target_dsn)
+
+
+def describe_dsn(dsn: str = None) -> str:
+    """Return a non-secret identifier for a DSN: ``host:port/database``.
+
+    A DSN carries the password, so it must never reach a log line or an API
+    response (the never-log policy in CLAUDE.md). This is what to name a
+    database with instead — enough to tell test from prod, nothing more.
+
+    Anything that isn't a recognizable ``postgresql://`` URL returns
+    ``"unknown"`` rather than being echoed back: the libpq keyword form
+    (``host=... password=...``) would otherwise leak the very thing this
+    exists to strip.
+    """
+    try:
+        parsed = urlparse(dsn or DB_DSN)
+        if parsed.scheme not in ("postgresql", "postgres"):
+            return "unknown"
+        host, port = parsed.hostname, parsed.port
+    except ValueError:
+        # A malformed netloc (e.g. a non-numeric port) — say nothing rather
+        # than fall back to any part of the raw string.
+        return "unknown"
+    database = (parsed.path or "").lstrip("/")
+    if not host and not database:
+        return "unknown"
+    where = host or "unknown-host"
+    if port:
+        where = f"{where}:{port}"
+    return f"{where}/{database}" if database else where
 
 
 def get_connection() -> _PGConn:

--- a/quantcore/repositories/fundamentals_repository.py
+++ b/quantcore/repositories/fundamentals_repository.py
@@ -18,7 +18,7 @@ from typing import Any
 
 import psycopg2
 
-from quantcore.db import get_connection, DB_DSN
+from quantcore.db import get_connection, describe_dsn
 
 logger = logging.getLogger(__name__)
 
@@ -251,10 +251,13 @@ def cache_get_all_latest(data_type: str) -> list[dict]:
 
 def cache_stats() -> dict:
     """
-    Return cache inventory: symbol counts, date ranges, and DB size per data_type.
+    Return cache inventory: symbol counts and date ranges per data_type.
 
     Returns:
-        Dict with data_types list and db_size_bytes
+        Dict with a ``data_types`` list and ``database`` — the host:port/name
+        identifier from quantcore.db.describe_dsn(). Never the DSN itself:
+        this dict is returned verbatim to REST and MCP callers, and the DSN
+        carries the password.
     """
 
     try:
@@ -286,14 +289,14 @@ def cache_stats() -> dict:
                 })
 
             return {
-                "db_path": DB_DSN,
+                "database": describe_dsn(),
                 "data_types": data_types,
             }
 
     except psycopg2.Error as e:
         logger.error(f"Error reading cache stats: {e}")
         return {
-            "db_path": DB_DSN,
+            "database": describe_dsn(),
             "data_types": [],
             "error": str(e),
         }

--- a/tests/test_dsn_redaction.py
+++ b/tests/test_dsn_redaction.py
@@ -1,0 +1,114 @@
+"""The DSN never leaves the process (issue #179).
+
+``cache_stats()`` used to return ``{"db_path": DB_DSN, ...}`` — and that dict
+travels verbatim through FundamentalsService → ``GET
+/api/securities/fundamentals/cache-stats`` → the ``get_cache_stats`` MCP tool,
+so any client holding a token could read the production database password.
+These tests pin the redaction (``quantcore.db.describe_dsn``) and both return
+paths of ``cache_stats()``, so the field cannot come back.
+
+Fully offline: the DSN is patched to a synthetic one whose password is a
+distinctive string, and the connection is faked. CI's real test DSN has
+``quantcore`` as user, password *and* database name, which makes a substring
+assertion against it meaningless.
+"""
+import json
+import unittest
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import psycopg2
+
+from quantcore import db
+from quantcore.repositories import fundamentals_repository as fr
+
+SECRET = "sup3r-s3cret-pw"
+FAKE_DSN = f"postgresql://dbadmin:{SECRET}@10.1.2.3:5432/quantcore"
+
+
+class TestDescribeDsn(unittest.TestCase):
+    def test_strips_user_and_password(self):
+        described = db.describe_dsn(FAKE_DSN)
+        self.assertEqual(described, "10.1.2.3:5432/quantcore")
+        self.assertNotIn(SECRET, described)
+        self.assertNotIn("dbadmin", described)
+
+    def test_defaults_to_the_module_dsn(self):
+        with patch.object(db, "DB_DSN", FAKE_DSN):
+            self.assertEqual(db.describe_dsn(), "10.1.2.3:5432/quantcore")
+
+    def test_omits_the_port_when_the_dsn_does(self):
+        self.assertEqual(
+            db.describe_dsn("postgresql://u:p@cloudsql-proxy/quantcore"),
+            "cloudsql-proxy/quantcore",
+        )
+
+    def test_postgres_scheme_alias(self):
+        self.assertEqual(
+            db.describe_dsn("postgres://u:p@localhost:5433/prod"),
+            "localhost:5433/prod",
+        )
+
+    def test_keyword_form_dsn_is_not_echoed(self):
+        # libpq's keyword form has no URL structure to strip, so echoing any
+        # part of it back would leak the password sitting in the middle.
+        described = db.describe_dsn(f"host=10.1.2.3 dbname=quantcore password={SECRET}")
+        self.assertEqual(described, "unknown")
+
+    def test_unparseable_dsn_is_not_echoed(self):
+        # An empty string is not in this list: it takes the DB_DSN default,
+        # which is itself redacted.
+        for junk in ("   ", "not a dsn at all", "mysql://u:p@host/db",
+                     "postgresql://u:p@host:notaport/db"):
+            self.assertEqual(db.describe_dsn(junk), "unknown", junk)
+
+
+@contextmanager
+def fake_connection(rows):
+    """Stand in for get_connection(): one cursor returning `rows`."""
+
+    class Cursor:
+        def fetchall(self):
+            return rows
+
+    class Conn:
+        def execute(self, *_args, **_kwargs):
+            return Cursor()
+
+        def close(self):
+            pass
+
+    with patch.object(fr, "get_connection", return_value=Conn()):
+        yield
+
+
+class TestCacheStatsLeaksNothing(unittest.TestCase):
+    def assert_no_credentials(self, stats):
+        blob = json.dumps(stats)
+        self.assertNotIn(SECRET, blob)
+        self.assertNotIn("dbadmin", blob)
+        self.assertNotIn(FAKE_DSN, blob)
+        self.assertNotIn("://", blob)
+        self.assertNotIn("db_path", stats)
+        self.assertEqual(stats["database"], "10.1.2.3:5432/quantcore")
+
+    def test_success_path(self):
+        with patch.object(db, "DB_DSN", FAKE_DSN):
+            with fake_connection([("fundamental_score", 3, 1750000000, 1755000000)]):
+                stats = fr.cache_stats()
+        self.assertEqual(len(stats["data_types"]), 1)
+        self.assert_no_credentials(stats)
+
+    def test_error_path(self):
+        # The path that reports a database failure is exactly where an
+        # "informative" DSN is most tempting.
+        with patch.object(db, "DB_DSN", FAKE_DSN):
+            with patch.object(fr, "get_connection", side_effect=psycopg2.Error("boom")):
+                stats = fr.cache_stats()
+        self.assertEqual(stats["data_types"], [])
+        self.assertIn("error", stats)
+        self.assert_no_credentials(stats)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_repositories_db.py
+++ b/tests/test_repositories_db.py
@@ -2,11 +2,13 @@
 coverage (85%-campaign): FundamentalsRepository, NewsStore,
 OptionsPositionStore, and the OhlcvRepository facade. Test database only.
 """
+import json
 import os
 import unittest
 from contextlib import closing
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
+from urllib.parse import urlparse
 
 import pandas as pd
 
@@ -75,6 +77,21 @@ class TestFundamentalsRepository(RepoTestBase):
         stats = self.repo.stats()
         self.assertIn("data_types", stats)
         self.assertGreater(self.repo.ttl_seconds(), 0)
+
+    def test_stats_carries_no_credentials_from_the_real_dsn(self):
+        # stats() is returned verbatim to REST and MCP callers, so nothing
+        # derived from the live DSN may appear in it. tests/test_dsn_redaction.py
+        # covers the password substring against a synthetic DSN — this is the
+        # same assertion against whatever this process is actually connected to.
+        dsn = os.environ["QUANTCORE_DB_DSN"]
+        parsed = urlparse(dsn)
+        blob = json.dumps(self.repo.stats())
+        self.assertNotIn("db_path", blob)
+        self.assertNotIn(dsn, blob)
+        self.assertNotIn("://", blob)
+        if parsed.username:
+            self.assertNotIn(f"{parsed.username}:", blob)   # userinfo pair
+        self.assertNotIn("@", blob)
 
 
 def article(i, published_days_ago=0.5):


### PR DESCRIPTION
Fixes #179.

## The leak

`cache_stats()` returned the full `QUANTCORE_DB_DSN` — password included — as `"db_path"`, on
**both** its success path and its `psycopg2.Error` path. That dict is not internal; it travels
verbatim:

```
cache_stats()                                     quantcore/repositories/fundamentals_repository.py
  → FundamentalsService.get_cache_stats()         quantcore/services/fundamentals.py  (bare passthrough)
  → GET /api/securities/fundamentals/cache-stats  api/routers/fundamentals.py  (no response_model)
  → get_cache_stats MCP tool                      fastMCPTest/company_fundamentals_server.py
```

So any client holding a valid `QUANTCORE_MCP_TOKEN` could read the credentials of whichever
database the wrapper points at — prod, per `.mcp.json`. Found by inspection during #147 PR 1; no
known misuse. Whether that warrants a DSN rotation is your call — the field has been reachable by
every token holder for as long as the endpoint has existed.

## The fix

- **`quantcore/db.py`** gains `describe_dsn()` → `host:port/database`: one home for what may be
  said about a DSN out loud. Anything that isn't a recognizable `postgresql://` URL returns
  `"unknown"` rather than being echoed — libpq's keyword form (`host=… password=…`) has no URL
  structure to strip safely, and a non-numeric port raises from `urlparse`, so that's caught too.
- **`cache_stats()`** returns `"database": describe_dsn()` on both paths, and no longer imports
  `DB_DSN` at all. The key is **renamed** rather than redacted in place: nothing consumes `db_path`
  (checked `frontend/`, `api/routers/`, `fastMCPTest/`, the tests and the docs), and the name was a
  leftover from the SQLite era.
- **`CLAUDE.md`**'s never-log policy is widened to say the DSN counts as a credential and that the
  policy covers API/MCP **responses**, not just logs. Neither was previously stated — that is how
  this got through.
- Stale docs corrected while in there: the MCP tool description and
  `docs/FUNDAMENTALS_CACHE_IMPLEMENTATION.md` both still claimed "DB file size" and "the local
  SQLite database".

## Tests

`tests/test_dsn_redaction.py` (new, 8 tests, fully offline) pins `describe_dsn()` and both return
paths of `cache_stats()` against a synthetic DSN whose password is a distinctive string, with the
connection faked. `tests/test_repositories_db.py` adds the same check structurally (no `db_path`,
no `://`, no `@`, no `user:`) against whatever database that process is really connected to.

One deliberate deviation from "assert no substring of the DSN's password": that is unsatisfiable
against CI's DSN, where password, user and database name are all `quantcore` — a correctly redacted
`host:port/quantcore` would trip it. Hence the split: password substring offline against a
synthetic DSN, structure against the live one.

**Verified:**

- `tests.test_dsn_redaction` — 8 tests, OK (offline, no database needed).
- `tests.test_dsn_redaction` + `tests.test_repositories_db` against the test database — 32 tests, OK.
- `tests.test_fundamentals_service`, `tests.test_mcp_seam`, `tests.test_architecture_guards` — 84
  tests, OK (the mocked-repo passthrough test is unaffected by the key rename).
- Sensitivity check: feeding the pre-fix shape `{"db_path": DSN, …}` into the new assertion helper
  fails on the password substring first, so the guard is not decorative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
