### PR TITLE
docs: record the DSN leak's resolution in the PR 1 notes (#179)

### DIFF
--- a/docs/proposals/legacy-report-retirement-plan.md
+++ b/docs/proposals/legacy-report-retirement-plan.md
@@ -1154,3 +1154,19 @@ a path assumption is portable** — CI has the most conventional layout there is
 `FundamentalsService.get_cache_stats()` passes it straight through to the `get_cache_stats` MCP
 tool, so a password-bearing DSN is reachable from any AI client holding a token. Out of scope for
 this PR; needs its own issue.
+
+**Resolved** as [#179](https://github.com/JohnFunkCode/StockPortfolioManager/issues/179), fixed in
+[#180](https://github.com/JohnFunkCode/StockPortfolioManager/pull/180) (`295f5b8`). `quantcore/db.py`
+gained `describe_dsn()` → `host:port/database`, and `cache_stats()` returns that as `database` on
+both paths; the `db_path` key is gone, having had no consumer. Two things worth carrying forward
+from that fix:
+
+1. **The never-log policy didn't cover this case, and now says so.** It was written for logs, about
+   API keys and envelopes — so a DSN in a *response* fell outside both halves of what it named.
+   `CLAUDE.md` now states that the DSN counts as a credential and that the policy covers API/MCP
+   responses, not just log lines.
+2. **"No substring of the password" is not a testable assertion against CI's DSN**, where user,
+   password and database name are all `quantcore` — a correctly redacted `host:port/quantcore`
+   trips it. `tests/test_dsn_redaction.py` therefore checks the password substring offline against
+   a synthetic DSN, and `tests/test_repositories_db.py` checks *structure* (no `://`, no `@`, no
+   `user:`) against the live one. Any future redaction guard needs the same split.


### PR DESCRIPTION
Docs-only. Closes the loop left open in PR 1's notes.

The "Notes from PR 1" section in `docs/proposals/legacy-report-retirement-plan.md` recorded the
fundamentals-repository DSN leak as *"out of scope for this PR; needs its own issue"*. It got one —
#179 — and the fix landed in #180 (`295f5b8`). The note now says so.

**Appended rather than rewritten**, deliberately: the "found while reading, not fixed here" record
is the useful part of a notes section, and editing it to look like the leak was handled in PR 1
would erase how it was actually found.

Beyond the bare link, the note carries the two things from that fix that aren't visible from its
diff:

1. **The never-log policy didn't cover the case.** It was written about logs, and about API keys and
   envelopes — so a DSN in a *response* fell outside both halves of what it named. That's the whole
   reason the leak read as acceptable to everyone who walked past it, and why #180 widened the
   policy wording rather than only patching the one function.
2. **"Assert the password doesn't appear in the output" is untestable against CI's DSN**, where
   user, password and database name are all `quantcore` — a correctly redacted `host:port/quantcore`
   trips the assertion. Hence the split guard: password substring offline against a synthetic DSN
   (`tests/test_dsn_redaction.py`), structure — no `://`, no `@`, no `user:` — against the live one
   (`tests/test_repositories_db.py`). Any future redaction guard needs the same split.

No code, no schema, no route change, so nothing to migrate and no OpenAPI surface diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
