### PR TITLE
test: cover the paths #186 merged with a red diff-coverage gate

### DIFF
--- a/docs/proposals/legacy-report-retirement-plan.md
+++ b/docs/proposals/legacy-report-retirement-plan.md
@@ -1211,6 +1211,25 @@ the page at the first `tagFilter.length`. Validate the shape (`Array.isArray` pl
 type), and treat "valid JSON, wrong shape" as its own test case rather than assuming the corrupt-
 text case covers it.
 
+**A near-duplicate method makes the diff blame you for its neighbour's uncovered lines.** #186
+merged with the `gate` job red — `diff-cover` at 81% against an 85% floor — naming
+`quantcore/repositories/watchlist_repository.py:202-206`, which is the *tail of `set_currency`*, a
+method that landed in #184 and is untouched by this PR. The first instinct, that the reviewer's
+diff base was stale, was wrong: `git diff -U0` reports the hunk as `@@ -195,0 +202,22 @@`, because
+the new `set_tags` is textually near-identical to `set_currency` and git anchored the insertion
+*early* — marking `set_currency`'s tail plus `set_tags`'s head as added, and treating `set_tags`'s
+own tail as unchanged context. The line numbers are real, the attribution is an artifact, and the
+gate is right to fail either way: neither rollback arm had a test, and `set_currency` had no direct
+repository test at all (only a fake in `tests/test_watchlist_service.py`). The lesson is not to
+argue with the gate when a diff looks misattributed — write the missing test for whichever body the
+lines belong to, since a method worth copying is a method worth covering.
+
+The other thing that run surfaced: **`WatchlistPage.test.tsx`'s tag-editor saves timed out under
+full-suite CPU contention while passing in isolation.** The cause was waiting on the MUI dialog's
+*removal* at the default 1s timeout — an exit transition, not the behaviour under test. Wait on the
+PATCH going out, which settles immediately, and give the transition its own generous timeout
+afterwards.
+
 Three smaller traps in the same suite, all of them the kind that make a correct assertion fail:
 
 1. **DataGrid emits `onSortModelChange` during mount normalization**, so `localStorage` already

--- a/frontend/src/components/watchlist/WatchlistPage.test.tsx
+++ b/frontend/src/components/watchlist/WatchlistPage.test.tsx
@@ -360,6 +360,22 @@ describe('WatchlistPage', () => {
   });
 
   describe('tag editor', () => {
+    /** Waits for the save to land and returns the PATCH that was issued.
+     *
+     * The dialog unmounts behind a MUI exit transition, so waiting on its
+     * removal at the default 1s timeout is timing-sensitive: this test timed
+     * out in a full-suite run and passed in isolation. Assert on the PATCH
+     * first — that is the behaviour under test and it settles as soon as the
+     * request goes out — and give the transition room to finish afterwards.
+     */
+    async function savedPatch(api: MockedApi) {
+      await waitFor(() =>
+        expect(api.calls.some(([, init]) => init?.method === 'PATCH')).toBe(true),
+      );
+      await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull(), { timeout: 5000 });
+      return api.calls.find(([, init]) => init?.method === 'PATCH')!;
+    }
+
     it('PATCHes the whole chip set, including a newly added chip', async () => {
       const api = await mount([['/api/watchlist/INTC', { symbol: 'INTC', tags: ['chips', 'ai'] }]]);
       fireEvent.click(screen.getByRole('button', { name: 'Edit tags for INTC' }));
@@ -369,8 +385,7 @@ describe('WatchlistPage', () => {
       fireEvent.keyDown(input, { key: 'Enter' });
       fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
-      await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
-      const patch = api.calls.find(([, init]) => init?.method === 'PATCH')!;
+      const patch = await savedPatch(api);
       expect(patch[0]).toContain('/api/watchlist/INTC');
       expect(JSON.parse(String(patch[1]?.body))).toEqual({ tags: ['chips', 'ai'] });
     });
@@ -388,8 +403,7 @@ describe('WatchlistPage', () => {
       ).toBeInTheDocument();
 
       fireEvent.click(screen.getByRole('button', { name: 'Save' }));
-      await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
-      const patch = api.calls.find(([, init]) => init?.method === 'PATCH')!;
+      const patch = await savedPatch(api);
       expect(JSON.parse(String(patch[1]?.body))).toEqual({ tags: [] });
     });
 

--- a/tests/test_api_smoke.py
+++ b/tests/test_api_smoke.py
@@ -394,6 +394,16 @@ class ApiSmokeTest(unittest.TestCase):
         self.assertEqual(resp.status_code, 404)
         self.assertEqual(resp.json(), {"error": "ZZNOSUCH not found in watchlist"})
 
+    def test_patch_blank_watchlist_symbol_returns_400(self):
+        """A whitespace-only ticker reaches the route and strips to nothing, so
+        `WatchlistService.set_tags` raises and the route answers 400 — not the
+        404 a missing symbol gets. Distinct because a blank ticker is a
+        malformed request, not a lookup that came up empty.
+        """
+        resp = self.client.patch("/api/watchlist/%20", json={"tags": ["ai"]})
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.json(), {"error": "symbol is required"})
+
     def test_remove_missing_watchlist_symbol_returns_404(self):
         resp = self.client.delete("/api/watchlist/ZZNOSUCH")
         self.assertEqual(resp.status_code, 404)

--- a/tests/test_watchlist_repository.py
+++ b/tests/test_watchlist_repository.py
@@ -16,13 +16,30 @@ synthetic symbols, so they do not need the real rows present in between.
 """
 import unittest
 from contextlib import closing
+from unittest.mock import patch
 
 from quantcore.db_safety import assert_not_production  # noqa: E402
 
 assert_not_production()
 
 from quantcore.db import get_connection  # noqa: E402
+from quantcore.repositories import watchlist_repository  # noqa: E402
 from quantcore.repositories.watchlist_repository import WatchlistRepository  # noqa: E402
+
+# Well-formed enough to bind the same parameters, guaranteed to fail in the
+# database — the way to reach the writers' except/rollback/raise arm without
+# faking the connection out from under the SQL under test.
+BROKEN_TAGS_SQL = """
+UPDATE watchlist
+SET tags = :tags
+WHERE symbol_id = (SELECT no_such_column FROM symbols WHERE ticker = :ticker);
+"""
+
+BROKEN_CURRENCY_SQL = """
+UPDATE watchlist
+SET currency = :currency
+WHERE symbol_id = (SELECT no_such_column FROM symbols WHERE ticker = :ticker);
+"""
 
 # Synthetic symbols that won't collide with anything real.
 SYMBOL = "ZZWL1"
@@ -125,6 +142,54 @@ class WatchlistRepositoryTest(unittest.TestCase):
 
     def test_set_tags_on_an_unwatched_symbol_returns_zero(self):
         self.assertEqual(self.repo.set_tags("ZZNOSUCH", ["ai"]), 0)
+
+    def test_set_currency_replaces_only_the_currency(self):
+        """`set_currency` had no direct test until now — it was exercised only
+        through a fake in the service tests, so the real SQL was never run.
+        It is what `scripts/repair_watchlist_currency.py` drives over rows
+        seeded from watchlist.yaml with a wrong currency.
+        """
+        self.repo.add_entry(SYMBOL, name="Test Co", currency="USD", tags=["ai"])
+
+        self.assertEqual(self.repo.set_currency(SYMBOL, "sek"), 1)
+
+        [entry] = [e for e in self.repo.list_entries() if e["symbol"] == SYMBOL]
+        self.assertEqual(entry["currency"], "SEK", "stored upper-cased")
+        self.assertEqual(entry["name"], "Test Co")
+        self.assertEqual(entry["tags"], ["ai"])
+
+    def test_set_currency_on_an_unwatched_symbol_returns_zero(self):
+        self.assertEqual(self.repo.set_currency("ZZNOSUCH", "USD"), 0)
+
+    # -- the rollback paths -------------------------------------------------
+    # Both writers wrap their statement in try/except/rollback/raise. The
+    # property worth pinning is that a failing statement propagates rather
+    # than being swallowed into a 0-rows-updated return, which a caller would
+    # read as "symbol not watched" and answer 404 to.
+
+    def test_set_tags_propagates_a_failed_statement_and_writes_nothing(self):
+        self.repo.add_entry(SYMBOL, name="Test Co", tags=["ai"])
+
+        with patch.object(watchlist_repository, "SQL_UPDATE_TAGS", BROKEN_TAGS_SQL):
+            with self.assertRaises(Exception):
+                self.repo.set_tags(SYMBOL, ["value"])
+
+        [entry] = [e for e in self.repo.list_entries() if e["symbol"] == SYMBOL]
+        self.assertEqual(entry["tags"], ["ai"], "the failed write left the row alone")
+        self.assertEqual(self.repo.set_tags(SYMBOL, ["value"]), 1,
+                         "the repository still works after a rolled-back failure")
+
+    def test_set_currency_propagates_a_failed_statement_and_writes_nothing(self):
+        self.repo.add_entry(SYMBOL, name="Test Co", currency="USD")
+
+        with patch.object(watchlist_repository, "SQL_UPDATE_CURRENCY",
+                          BROKEN_CURRENCY_SQL):
+            with self.assertRaises(Exception):
+                self.repo.set_currency(SYMBOL, "SEK")
+
+        [entry] = [e for e in self.repo.list_entries() if e["symbol"] == SYMBOL]
+        self.assertEqual(entry["currency"], "USD")
+        self.assertEqual(self.repo.set_currency(SYMBOL, "SEK"), 1)
 
     def test_remove_missing_symbol_returns_zero(self):
         self.assertEqual(self.repo.remove_entry("ZZNOSUCH"), 0)


### PR DESCRIPTION
Follow-up to #186, which merged with the `gate` job red — `diff-cover` at **81%** against an 85% floor, over seven lines:

```
api/routers/portfolio.py (80.0%): Missing lines 329-330
quantcore/repositories/watchlist_repository.py (54.5%): Missing lines 202-206
Total: 37 lines / Missing: 7 / Coverage: 81%
```

Tests only — no production code changes.

## Why the repository lines look misattributed (and why it doesn't matter)

Lines 202-206 are the tail of `set_currency`, which landed in #184 and #186 never touched. The tempting conclusion is that the reviewer's diff base was stale. It wasn't: `git diff -U0` reports the hunk as `@@ -195,0 +202,22 @@`, because the new `set_tags` is textually near-identical to `set_currency`, so git anchored the insertion *early* — marking `set_currency`'s tail plus `set_tags`'s head as added, and treating `set_tags`'s own tail as unchanged context.

The line numbers are real, the attribution is an artifact, and the gate is right either way: neither writer's rollback arm had a test, and `set_currency` had **no direct repository test at all** — the only `set_currency` in `tests/` was a fake in `test_watchlist_service.py`, so the real SQL had never run.

## What's here

- **`tests/test_api_smoke.py`** — `PATCH /api/watchlist/%20` strips to an empty symbol, so `WatchlistService.set_tags` raises and the route answers **400**, not the 404 a missing symbol gets. Closes `portfolio.py:329-330`.
- **`tests/test_watchlist_repository.py`** — `set_currency` round-trip (upper-cases the value, leaves name and tags alone), unwatched-returns-zero, and forced-failure rollback tests for **both** writers. The rollback tests swap in SQL that binds the same parameters against a missing column, reaching `except/rollback/raise` through the real connection rather than faking it out; each asserts the row is untouched *and* that the repository still works on the next call. Closes `watchlist_repository.py:202-206`.
- **`WatchlistPage.test.tsx`** — the tag-editor saves waited on the MUI dialog's *exit transition* at the default 1s timeout, which **timed out in a full-suite run while passing in isolation**. New `savedPatch()` helper waits on the PATCH going out (the behaviour under test, which settles immediately), then gives the transition its own 5s.
- **`docs/proposals/legacy-report-retirement-plan.md`** — both gotchas recorded in the PR 4 notes.

## Verification

Re-running the exact 37-line diff that failed CI:

```
Diff: a19e607...HEAD
api/routers/portfolio.py (100%)
quantcore/repositories/watchlist_repository.py (100%)
Total: 37 lines / Missing: 0 / Coverage: 100%
```

Backend suite green against the test database. Frontend **535/535 across 75 files**, `tsc --noEmit` clean, coverage 90.34 lines / 88.35 statements / 88.28 functions / 72.02 branches — unchanged, and the vitest floors are deliberately **not** raised (that's Part G / PR 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
