### PR TITLE
fix: diagnose the lean import smoke's failures instead of assuming a missing module

### DIFF
--- a/scripts/ci_lean_import_smoke.py
+++ b/scripts/ci_lean_import_smoke.py
@@ -51,7 +51,7 @@ def module_names() -> list[str]:
 
 
 def main() -> int:
-    failures: list[tuple[str, str]] = []
+    failures: list[tuple[str, BaseException, str]] = []
     skipped: list[tuple[str, str]] = []
 
     names = module_names()
@@ -61,24 +61,38 @@ def main() -> int:
         except unittest.SkipTest as exc:
             # A guarded import declaring a report-only dependency. Sanctioned.
             skipped.append((name, str(exc)))
-        except BaseException:  # noqa: BLE001 - a bare SystemExit here is still a failure
-            failures.append((name, traceback.format_exc()))
+        except BaseException as exc:  # noqa: BLE001 - a bare SystemExit is still a failure
+            failures.append((name, exc, traceback.format_exc()))
 
     for name, reason in skipped:
         print(f"SKIP {name}: {reason}")
-    for name, tb in failures:
+    for name, _, tb in failures:
         print(f"\nFAIL {name}\n{tb}", file=sys.stderr)
 
     print(
         f"\nlean import smoke: {len(names)} modules, "
         f"{len(failures)} failed, {len(skipped)} skipped"
     )
-    if failures:
+
+    # Diagnose, don't just fail. A module that imports something outside the lean set
+    # and a job whose Postgres service is unreachable both land here, and pointing the
+    # second one at requirements-base.txt would send the reader somewhere useless:
+    # api/main.py builds the app at import time, so a DB problem surfaces as an import
+    # failure without being one.
+    if any(isinstance(exc, ImportError) for _, exc, _ in failures):
         print(
             "A module above cannot be imported on requirements-base.txt — the lean set "
             "the containers ship and prod-rollout.yml tests against. Either move the "
             "dependency into requirements-base.txt deliberately, or guard the import "
             "(see tests/test_generate_portfolio_report.py).",
+            file=sys.stderr,
+        )
+    elif failures:
+        print(
+            "Nothing above failed on a missing module, so this is not a lean-install "
+            "problem — read the tracebacks. A connection error is the environment, not "
+            "the dependency set: importing api.main runs create_app() -> ensure_schema(), "
+            "which needs the job's Postgres service reachable at QUANTCORE_DB_DSN.",
             file=sys.stderr,
         )
     return 1 if failures else 0


### PR DESCRIPTION
Follow-up to #191, which merged 41 seconds before this commit was pushed — so it missed the train
and never got a CI run of its own (the `pull_request` trigger was gone by the time the branch moved).
The branch is reused as-is, one commit ahead of `main`: exactly one file, no cherry-pick.

## What this fixes

`scripts/ci_lean_import_smoke.py` printed the same trailing hint on *every* failure, blaming
`requirements-base.txt`:

> A module above cannot be imported on requirements-base.txt — the lean set the containers ship …

But importing `api.main` builds the app at module level (`create_app()` → `ensure_schema()` →
`psycopg2.connect`), so an unreachable Postgres service surfaces as an import failure **without being
one** — and the hint would then send the reader to the dependency set when the problem was the
environment. The gate was correct (a DB failure is red either way, never a silent pass); it was the
diagnosis that was wrong.

Now it branches on whether any failure was an `ImportError`. The lean-install hint prints only when
something actually failed on a missing module; otherwise:

> Nothing above failed on a missing module, so this is not a lean-install problem — read the
> tracebacks. A connection error is the environment, not the dependency set: importing api.main runs
> create_app() -> ensure_schema(), which needs the job's Postgres service reachable at
> QUANTCORE_DB_DSN.

## Where it came from

The review of #191 flagged the `lean-import` job's DSN as mismatched against the service's
`POSTGRES_PASSWORD`. It isn't — both are `quantcore`, it's the same pair the `gate` job has used for
months, and the job could not have gone green otherwise, since `api.main`'s import performs a real
authenticated connection. Full rebuttal in
https://github.com/JohnFunkCode/StockPortfolioManager/pull/191#issuecomment-5255901754.

The finding was wrong about the credentials but right that this gate could misreport. This is that
part.

## Verification

Locally, all four paths:

| Case | Result |
|---|---|
| Full deps | `86 modules, 0 failed, 0 skipped`, exit 0 |
| matplotlib/jinja2/boto3 blocked | `0 failed, 1 skipped`, exit 0 |
| A lean-set module blocked (`yaml`) | `24 failed`, lean-install hint, exit 1 |
| Unreachable database | `8 failed`, environment hint, exit 1 |

No docs change: the `CLAUDE.md` paragraph describing the `lean-import` job merged with #191 and
still holds — this changes only what the script says when it fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
