### PR TITLE
fix: compute the OHLCV cache cutoff in UTC, not local time

### DIFF
--- a/quantcore/repositories/ohlcv_repository.py
+++ b/quantcore/repositories/ohlcv_repository.py
@@ -57,6 +57,17 @@ class OHLCV:
 # ohlcv and fetch_log tables are in the unified database
 
 
+def _utc_now() -> datetime.datetime:
+    """Timezone-aware "now" in UTC.
+
+    Everything in this module that reaches epoch seconds goes through here.
+    ``datetime.utcnow()`` returns a *naive* datetime carrying UTC's value with
+    no tzinfo, and ``.timestamp()`` then assumes local time — so the pair reads
+    correctly and computes wrong by the machine's UTC offset.
+    """
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
 # ---------------------------------------------------------------------------
 # Bar classification (persistence semantics; clock logic in analytics.market_time)
 # ---------------------------------------------------------------------------
@@ -199,7 +210,7 @@ def _store_bars(symbol: str, interval: str, df: pd.DataFrame) -> None:
             INSERT INTO fetch_log (symbol, interval, fetched_at) VALUES (%s,%s,%s)
             ON CONFLICT (symbol, interval) DO UPDATE SET fetched_at = EXCLUDED.fetched_at
             """,
-            (symbol, interval, int(datetime.datetime.utcnow().timestamp())),
+            (symbol, interval, int(_utc_now().timestamp())),
         )
         conn.commit()
 
@@ -209,8 +220,12 @@ def _query_cache(symbol: str, interval: str, days: int) -> pd.DataFrame:
     Return cached bars as a DataFrame (columns: Open, High, Low, Close, Volume).
     GAP bars are excluded; CORRECTED bars are included.
     """
+    # Aware, not naive: .timestamp() on a naive datetime interprets it as *local*
+    # time, so utcnow().timestamp() lands the cutoff a whole UTC offset away from
+    # where it belongs — six hours late in US/Mountain, six hours early the other
+    # way. Bars ts is epoch seconds, so the skew silently trims or pads the window.
     cutoff = int(
-        (datetime.datetime.utcnow() - datetime.timedelta(days=days)).timestamp()
+        (_utc_now() - datetime.timedelta(days=days)).timestamp()
     )
     with closing(get_connection()) as conn:
         rows = conn.execute(

--- a/tests/test_repositories_db.py
+++ b/tests/test_repositories_db.py
@@ -19,7 +19,7 @@ assert_not_production()
 from quantcore.db import get_connection  # noqa: E402
 from quantcore.repositories.fundamentals_repository import FundamentalsRepository  # noqa: E402
 from quantcore.repositories.news_repository import NewsStore  # noqa: E402
-from quantcore.repositories.ohlcv_repository import OhlcvRepository  # noqa: E402
+from quantcore.repositories.ohlcv_repository import OhlcvRepository, _utc_now  # noqa: E402
 from quantcore.repositories.options_position_repository import OptionsPositionStore  # noqa: E402
 from quantcore.repositories.user_settings_repository import UserSettingsRepository  # noqa: E402
 
@@ -193,8 +193,14 @@ class TestOptionsPositionStore(RepoTestBase):
 
 
 def bars_df(n=5, start_price=100.0):
-    # Fixed past business days: deterministic, and always CLOSED bars.
-    idx = pd.bdate_range(end="2026-07-17", periods=n, tz="UTC")
+    # Recent past business days: always CLOSED bars, and always inside the
+    # `days=30` window `get_bars` reads. Anchored to today rather than to a
+    # fixed date: the old `end="2026-07-17"` aged out of that window on
+    # 2026-08-11 and failed with no code change behind it, which is the least
+    # useful kind of red build. Three business days back keeps every bar off
+    # the current session, so they classify CLOSED.
+    end = pd.Timestamp.now(tz="UTC").normalize() - pd.offsets.BDay(3)
+    idx = pd.bdate_range(end=end, periods=n, tz="UTC")
     prices = [start_price + i for i in range(n)]
     return pd.DataFrame(
         {"Open": prices, "High": [p + 1 for p in prices],
@@ -208,6 +214,16 @@ class TestOhlcvRepositoryFacade(RepoTestBase):
     def setUp(self):
         super().setUp()
         self.repo = OhlcvRepository()
+
+    def test_utc_now_is_timezone_aware(self):
+        # The guard on the actual defect. Every epoch-seconds value this module
+        # writes or compares goes through _utc_now(), and a naive datetime's
+        # .timestamp() is read as local time — so reverting to utcnow() would
+        # shift the cutoff by the machine's UTC offset. That skew is invisible
+        # in CI, which runs in UTC; this assertion is not.
+        now = _utc_now()
+        self.assertIsNotNone(now.tzinfo)
+        self.assertEqual(now.utcoffset(), timedelta(0))
 
     def test_store_and_read_back(self):
         self.assertEqual(self.repo.count_cached(SYM, "1d"), 0)


### PR DESCRIPTION
## The defect

`_query_cache` built its cutoff with `datetime.utcnow().timestamp()`.

`utcnow()` returns a **naive** datetime carrying UTC's value with no `tzinfo`, and `.timestamp()`
then interprets it as **local** time. The pair reads correctly and computes wrong by the machine's
UTC offset — six hours late on a US/Mountain box, six hours early east of UTC. `ohlcv.ts` is epoch
seconds, so the skew silently trims or pads the window every caller asked for.

The same call also wrote `fetch_log.fetched_at`, which matters as much and is easier to miss: every
staleness comparison against that column was off by the offset of whichever machine last wrote it.
Both now go through one `_utc_now()` helper.

## How it surfaced

`tests/test_repositories_db.py::TestOhlcvRepositoryFacade::test_store_and_read_back` stored a
fixture pinned to `bdate_range(end="2026-07-17", periods=5)` and read it back with `days=30` — a
fixed date against a moving window. It aged out on **2026-08-11**:

```
AssertionError: 4 != 5
```

A red build with no code change behind it, which is the least useful kind. Worth being precise
about the two clocks involved, because they are not the same deadline:

- **Locally (UTC−6)** it broke on 2026-08-11, ~6 hours early, because of the bug above.
- **In CI (UTC)** the window passes `2026-07-13 00:00 UTC` at **2026-08-12 00:00 UTC** regardless of
  the bug — so it would have gone red on every PR from that moment.

The fixture is now anchored three business days before today, which keeps the bars both CLOSED
(off the current session) and inside the `days=30` window permanently.

## Why the extra test

Fixing the fixture alone makes the suite green while leaving the actual defect unguarded — the test
would pass either way. `test_utc_now_is_timezone_aware` pins the helper instead. The six-hour skew
is invisible on a UTC runner, so a test that tried to catch the skew directly would be a no-op in
CI; that the helper stays **aware** is something a UTC runner can check.

## Verification

| Suite | Result |
|---|---|
| `tests.test_repositories_db` | **25 tests, OK** — including the previously failing case |
| `test_prices_service`, `test_prices_history_policy`, `test_price_freshness`, `test_options_service`, `test_recommendations_service` (the modules consuming the OHLCV repo or `fetch_log`) | **105 tests, OK** |

## Noted, not touched

`quantcore/services/prices.py:151` uses the deprecated `utcfromtimestamp()`. That one is *correct* —
it reads an epoch value as UTC — so it is a deprecation warning rather than an instance of this bug,
and it is out of scope here.

## Scope

Deliberately small and standalone: this blocks CI for every open PR from 2026-08-12 UTC, and it has
nothing to do with the #147 Part H work it was found alongside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
