### PR TITLE
fix: handle unavailable harvest volatility

### DIFF
--- a/quantcore/repositories/harvester_repository.py
+++ b/quantcore/repositories/harvester_repository.py
@@ -452,6 +452,14 @@ class HarvesterPlanDB:
 
                 shares_initial = int(forward_plan["s0"])
                 v0_floor = float(forward_plan["V0"])
+                # The planner leaves annual_vol unset when a caller supplies a
+                # fixed H (or when there are too few usable returns to measure
+                # volatility). The persisted column is required and this value
+                # is informational in that case, so keep the plan buildable
+                # with an explicit zero rather than float(None).
+                annual_vol = forward_plan["annual_vol"]
+                if annual_vol is None:
+                    annual_vol = 0.0
 
                 cur = conn.execute(
                     """
@@ -489,7 +497,7 @@ class HarvesterPlanDB:
                         "history_end_date": history_end_date,
                         "history_window_days": params.history_window_days,
                         "r_daily": float(forward_plan["r_daily"]),
-                        "annual_vol": float(forward_plan["annual_vol"]),
+                        "annual_vol": float(annual_vol),
                         "h_threshold": float(forward_plan["H"]),
                         "n_iterations": int(forward_plan["n_iterations"]),
                         "supersedes_instance_id": supersedes,

--- a/tests/test_harvester_repository_db.py
+++ b/tests/test_harvester_repository_db.py
@@ -7,6 +7,7 @@ import os
 import unittest
 from contextlib import closing
 from pathlib import Path
+from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
@@ -79,6 +80,45 @@ class HarvesterRepoTest(unittest.TestCase):
         # H respects the configured bounds.
         self.assertGreaterEqual(float(plan["H"]), 0.05)
         self.assertLessEqual(float(plan["H"]), 0.30)
+
+    def test_build_plan_persists_zero_when_annual_volatility_is_unavailable(self):
+        # A fixed-H/short-history planner result can legitimately omit the
+        # informational volatility value. The required DB column must not turn
+        # that into float(None).
+        forward_plan = {
+            "s0": 10,
+            "P_current": 100.0,
+            "r_daily": 0.001,
+            "H": 0.05,
+            "annual_vol": None,
+            "V0": 1000.0,
+            "n_iterations": 1,
+            "ladder": [{
+                "harvest": 1,
+                "price_target": 105.0,
+                "shares_before": 10,
+                "shares_sold": 1,
+                "shares_after": 9,
+                "expected_days_from_now": None,
+                "gross_harvest": 105.0,
+                "cumulative_harvest": 105.0,
+                "remaining_value": 945.0,
+                "total_wealth": 1050.0,
+                "total_return_vs_initial": 0.05,
+            }],
+        }
+        with patch(
+            "quantcore.repositories.harvester_repository.design_forward_ladder_from_history",
+            return_value=forward_plan,
+        ):
+            plan = self.build()
+
+        with closing(get_connection()) as conn:
+            row = conn.execute(
+                "SELECT annual_vol FROM plan_instances WHERE instance_id = %s",
+                (plan["instance_id"],),
+            ).fetchone()
+        self.assertEqual(float(row["annual_vol"]), 0.0)
 
     def test_rebuild_supersedes_previous_active_plan(self):
         first = self.build()


### PR DESCRIPTION
## Summary
- Prevent plan creation from failing when the planner returns `annual_vol=None`.
- Persist an explicit `0.0` for the required informational volatility column.
- Add a regression test covering the None-to-float failure.

## Validation
- Focused PostgreSQL-backed regression test passes.
- `git diff --check` passes.