### PR TITLE
fix: Create Plan died on float(None) when the read window outran the fetch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,24 @@ All persistence is consolidated into a single **QuantCore** PostgreSQL database,
 
 All repositories under `quantcore/repositories/` and the REST API (`api/main.py`) use the shared factory instead of managing individual database connections.
 
+**`ohlcv` has two writers, and they disagree about `adj_close`.** `OhlcvRepository` (the prices
+cache) fetches with `auto_adjust=True`, so the adjustment is already baked into `close` and it
+writes `adj_close = NULL`; `HarvesterPlanDB.build_plan` fetches with `auto_adjust=False,
+include_adj_close=True` and writes a real adjusted close for the same `(symbol, '1d', ts)` rows.
+Two rules follow, and both exist because breaking either produced the same crash — `float(None)`
+escaping as a bare `TypeError` into the Create Plan dialog:
+
+- **A price refresh may fill `adj_close`, never blank it.** `OhlcvRepository`'s upsert uses
+  `adj_close = COALESCE(EXCLUDED.adj_close, ohlcv.adj_close)`; with plain `EXCLUDED` a routine
+  symbol lookup silently destroyed every adjusted close the harvester had computed.
+- **A window measured in bars must be fetched in trading days.** `PlanBuildParams.history_window_days`
+  is a row count (`LIMIT history_window_days`), so `HarvesterService.build_plan` scales it by
+  `365/252` before calling `fetch_history`, which takes calendar days. The old `max(n + 60, 420)`
+  covered ~288 sessions of a 360-bar read, and the shortfall was served by whatever the prices cache
+  had left there. When a gap survives anyway, the repository raises a `RuntimeError` naming it
+  (→ 422) rather than substituting `close` — an unadjusted bar beside adjusted ones is a fake step
+  that inflates the volatility sizing the ladder.
+
 **Migrating from a legacy SQLite database:** `scripts/migrate_sqlite_to_postgres.py` performs a one-shot copy of an existing `quantcore.sqlite` file into PostgreSQL — it initializes the schema, migrates all 16 tables in FK-safe order via batched `execute_values()` inserts, resets `SERIAL` sequences, and verifies row counts. Run it with `--sqlite <path>` and `--dsn <postgresql-uri>`.
 
 ### Services Layer (`quantcore/`)

--- a/quantcore/repositories/harvester_repository.py
+++ b/quantcore/repositories/harvester_repository.py
@@ -329,25 +329,34 @@ class HarvesterPlanDB:
         if bars.empty:
             raise RuntimeError(f"No price history supplied for {symbol}")
 
+        # One executemany, not a row-at-a-time loop: conn.executemany() pages
+        # through psycopg2's execute_batch, so ~580 daily bars cost ~2 round
+        # trips instead of 580. Through the Cloud SQL auth proxy (~90ms RTT)
+        # that is the difference between a minute of Create Plan and a second.
+        # execute_batch sends separate statements per page, which is what keeps
+        # the ON CONFLICT safe — folded into one multi-VALUES insert instead, a
+        # repeated bar_date would fail with "cannot affect row a second time".
+        ingested_at = int(time())
+        bar_rows = [
+            {
+                "symbol": symbol,
+                # Convert YYYY-MM-DD string to Unix timestamp (midnight UTC)
+                "ts": int(pd.to_datetime(r["bar_date"]).timestamp()),
+                "open": float(r["Open"]) if pd.notna(r["Open"]) else None,
+                "high": float(r["High"]) if pd.notna(r["High"]) else None,
+                "low": float(r["Low"]) if pd.notna(r["Low"]) else None,
+                "close": float(r["Close"]),
+                "adj_close": float(r["Adj Close"]),
+                "volume": float(r["Volume"]) if pd.notna(r["Volume"]) else None,
+                "data_vendor": "yfinance",
+                "ingested_at": ingested_at,
+            }
+            for _, r in bars.iterrows()
+        ]
+
         with closing(get_connection()) as conn:
             try:
-                for _, r in bars.iterrows():
-                    # Convert YYYY-MM-DD string to Unix timestamp (midnight UTC)
-                    bar_date_dt = pd.to_datetime(r["bar_date"])
-                    ts = int(bar_date_dt.timestamp())
-
-                    conn.execute(SQL_UPSERT_DAILY_BAR, {
-                        "symbol": symbol,
-                        "ts": ts,
-                        "open": float(r["Open"]) if pd.notna(r["Open"]) else None,
-                        "high": float(r["High"]) if pd.notna(r["High"]) else None,
-                        "low": float(r["Low"]) if pd.notna(r["Low"]) else None,
-                        "close": float(r["Close"]),
-                        "adj_close": float(r["Adj Close"]),
-                        "volume": float(r["Volume"]) if pd.notna(r["Volume"]) else None,
-                        "data_vendor": "yfinance",
-                        "ingested_at": int(time()),
-                    })
+                conn.executemany(SQL_UPSERT_DAILY_BAR, bar_rows)
                 conn.commit()
             except Exception:
                 conn.rollback()
@@ -371,6 +380,28 @@ class HarvesterPlanDB:
 
         # Reverse to chronological order
         prices_rows = list(reversed(prices_rows))
+
+        # `ohlcv` has two writers with different `adj_close` semantics: the
+        # block above stores a real adjusted close, while OhlcvRepository (the
+        # prices cache) fetches with auto_adjust=True and stores NULL. A read
+        # window wider than what the caller managed to fetch therefore lands on
+        # rows with no adjusted close. Say so, rather than letting float(None)
+        # escape as a bare TypeError into the Create Plan dialog — and do NOT
+        # substitute `close`, because splicing raw closes onto adjusted ones
+        # puts a fake step at the boundary and inflates the volatility that
+        # sizes the whole ladder.
+        gaps = [r for r in prices_rows if r["adj_close"] is None]
+        if gaps:
+            oldest = datetime.fromtimestamp(
+                gaps[0]["ts"], tz=timezone.utc
+            ).strftime("%Y-%m-%d")
+            raise RuntimeError(
+                f"Cannot build a plan for {symbol}: {len(gaps)} of the "
+                f"{len(prices_rows)} bars in the {params.history_window_days}-bar "
+                f"history window have no adjusted close (oldest {oldest}). "
+                "Fetch a longer price history, or lower history_window_days."
+            )
+
         prices_adj = [float(r["adj_close"]) for r in prices_rows]
         prices_close = [float(r["close"]) for r in prices_rows]
 

--- a/quantcore/repositories/ohlcv_repository.py
+++ b/quantcore/repositories/ohlcv_repository.py
@@ -198,7 +198,13 @@ def _store_bars(symbol: str, interval: str, df: pd.DataFrame) -> None:
                 close       = EXCLUDED.close,
                 volume      = EXCLUDED.volume,
                 status      = EXCLUDED.status,
-                adj_close   = EXCLUDED.adj_close,
+                -- COALESCE, not EXCLUDED: this writer fetches with
+                -- auto_adjust=True and has no adjusted close to offer, but it
+                -- is not the only writer of `ohlcv`. The harvester's plan
+                -- build stores a real `adj_close` for the same rows, and
+                -- overwriting that with NULL destroys data a price refresh
+                -- never had. Only fill the column, never blank it.
+                adj_close   = COALESCE(EXCLUDED.adj_close, ohlcv.adj_close),
                 data_vendor = EXCLUDED.data_vendor,
                 ingested_at = EXCLUDED.ingested_at
             """,

--- a/quantcore/services/harvester.py
+++ b/quantcore/services/harvester.py
@@ -65,7 +65,15 @@ class HarvesterService:
     ) -> Dict[str, Any]:
         symbol = symbol.upper().strip()
         self._require_open_lot(symbol, owner=owner)
-        days = max(params.history_window_days + 60, 420)
+        # `history_window_days` is a count of *bars* — the repository reads the
+        # plan's history back as `LIMIT history_window_days` rows — but
+        # `fetch_history` takes *calendar* days. Asking for 420 calendar days
+        # to satisfy a 360-row read buys ~288 sessions and leaves the oldest
+        # ~72 rows of the read window to whatever else has written `ohlcv`;
+        # the prices cache writes `adj_close = NULL` there, which used to
+        # surface as `float() argument must be ... not 'NoneType'`. ~252
+        # sessions a year, so scale by 365/252 and keep the old +60 slack.
+        days = max(int(params.history_window_days * 365 / 252) + 60, 420)
         bars = self._yf.fetch_history(
             symbol, "1d", days, auto_adjust=False, include_adj_close=True
         )

--- a/tests/test_harvester_fetch_seam.py
+++ b/tests/test_harvester_fetch_seam.py
@@ -48,6 +48,27 @@ class TestBuildPlanFetchSeam(unittest.TestCase):
         self.assertIn("bars", repo_kwargs)
         self.assertIn("Adj Close", repo_kwargs["bars"].columns)
 
+    def test_the_fetch_span_covers_the_read_window_in_trading_days(self):
+        # The defect this pins: history_window_days counts *bars* (the
+        # repository reads back LIMIT history_window_days rows) but
+        # fetch_history takes *calendar* days. 420 calendar days buys ~288
+        # sessions, so the oldest ~72 rows of a 360-bar window came from
+        # whatever else had written ohlcv — the prices cache, with
+        # adj_close = NULL — and the build died on float(None).
+        self.gateway.fetch_history.return_value = bars_df()
+        params = PlanBuildParams()
+        self.service.build_plan(
+            symbol="INTC", template_name="t", params=params, owner="john"
+        )
+        requested_calendar_days = self.gateway.fetch_history.call_args[0][2]
+        end = pd.Timestamp("2026-08-11")
+        sessions = len(
+            pd.bdate_range(
+                start=end - pd.Timedelta(days=requested_calendar_days), end=end
+            )
+        )
+        self.assertGreaterEqual(sessions, params.history_window_days)
+
     def test_missing_adj_close_falls_back_to_close(self):
         self.gateway.fetch_history.return_value = bars_df(include_adj=False)
         self.service.build_plan(

--- a/tests/test_harvester_repository_db.py
+++ b/tests/test_harvester_repository_db.py
@@ -43,7 +43,14 @@ def bars(n=500, start=50.0, end=150.0):
     )
 
 
-class HarvesterRepoTest(unittest.TestCase):
+class HarvesterRepoFixture:
+    """A clean symbol/template, and the one call that builds a plan on it.
+
+    Deliberately **not** a TestCase: a suite that needs only the fixture must be
+    able to take it without also inheriting — and so rerunning — another suite's
+    test methods.
+    """
+
     def setUp(self):
         self._purge()
         self.addCleanup(self._purge)
@@ -66,6 +73,8 @@ class HarvesterRepoTest(unittest.TestCase):
             owner=owner,
         )
 
+
+class HarvesterRepoTest(HarvesterRepoFixture, unittest.TestCase):
     # -- build_plan ---------------------------------------------------------
 
     def test_build_plan_creates_instance_and_ladder(self):
@@ -413,9 +422,10 @@ class HarvesterOwnerIsolationTest(HarvesterRepoTest):
         )
 
 
-# A sibling of HarvesterRepoTest rather than a member of it: the two scan/owner
-# suites above *subclass* the base, so a case added there runs three times.
-class HarvesterAdjCloseGapTest(HarvesterRepoTest):
+# Takes the fixture, not HarvesterRepoTest: added to that class these two cases
+# would run three times (the scan and owner suites subclass it), and subclassing
+# it here would instead rerun its whole suite under this name.
+class HarvesterAdjCloseGapTest(HarvesterRepoFixture, unittest.TestCase):
     """A read window that reaches rows the fetch never covered (issue: the
     Create Plan dialog died on `float() argument must be ... not 'NoneType'`).
     """

--- a/tests/test_harvester_repository_db.py
+++ b/tests/test_harvester_repository_db.py
@@ -411,3 +411,57 @@ class HarvesterOwnerIsolationTest(HarvesterRepoTest):
             self.db.get_plan_by_id(self.theirs["instance_id"], owner=OTHER)["status"],
             "SUPERSEDED",
         )
+
+
+# A sibling of HarvesterRepoTest rather than a member of it: the two scan/owner
+# suites above *subclass* the base, so a case added there runs three times.
+class HarvesterAdjCloseGapTest(HarvesterRepoTest):
+    """A read window that reaches rows the fetch never covered (issue: the
+    Create Plan dialog died on `float() argument must be ... not 'NoneType'`).
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.addCleanup(self._purge_bars)
+        self._purge_bars()
+
+    def _purge_bars(self):
+        with closing(get_connection()) as conn:
+            conn.execute(
+                "DELETE FROM ohlcv WHERE symbol = %s AND interval = '1d'", (SYM,)
+            )
+            conn.commit()
+
+    def _seed_unadjusted_rows(self, n=40, first_date="2024-01-02"):
+        """Rows as the prices cache writes them: a close, and adj_close NULL.
+
+        Older than anything `bars()` supplies, so they only enter the picture
+        when the read window is wider than the fetch reached.
+        """
+        with closing(get_connection()) as conn:
+            for day in pd.bdate_range(start=first_date, periods=n):
+                conn.execute(
+                    "INSERT INTO ohlcv (symbol, interval, ts, open, high, low, "
+                    "close, volume, status, adj_close, data_vendor, ingested_at) "
+                    "VALUES (%s,'1d',%s,%s,%s,%s,%s,%s,'CLOSED',NULL,'yfinance',0) "
+                    "ON CONFLICT (symbol, interval, ts) DO NOTHING",
+                    (SYM, int(day.timestamp()), 10.0, 10.5, 9.5, 10.0, 1_000_000),
+                )
+            conn.commit()
+
+    def test_a_read_window_reaching_unadjusted_rows_says_so(self):
+        # Splicing `close` in instead would be worse than useless: an
+        # unadjusted bar next to adjusted ones is a fake step, and it inflates
+        # the volatility that sizes the whole ladder. So this must be a legible
+        # refusal — which POST /api/plans already maps to 422.
+        self._seed_unadjusted_rows()
+        with self.assertRaises(RuntimeError) as ctx:
+            self.build(history_window_days=520)      # bars() supplies only 500
+        message = str(ctx.exception)
+        self.assertIn("adjusted close", message)
+        self.assertIn(SYM, message)
+
+    def test_unadjusted_rows_outside_the_window_are_harmless(self):
+        self._seed_unadjusted_rows()
+        plan = self.build(history_window_days=360)
+        self.assertIn("instance_id", plan)

--- a/tests/test_repositories_db.py
+++ b/tests/test_repositories_db.py
@@ -239,6 +239,33 @@ class TestOhlcvRepositoryFacade(RepoTestBase):
         self.assertIsNotNone(ts)
         self.assertFalse(self.repo.has_open_bar(SYM, "1d"))  # all bars days old
 
+    def test_a_price_refresh_never_blanks_an_adjusted_close(self):
+        # `ohlcv` has two writers. This one fetches with auto_adjust=True and
+        # has no adjusted close to offer; the harvester's plan build writes a
+        # real one for the same rows. When its ON CONFLICT set
+        # adj_close = EXCLUDED.adj_close, any price lookup wiped those values
+        # back to NULL, and the next plan build hit float(None) — the reported
+        # "float() argument must be ... not 'NoneType'".
+        self.repo.store_bars(SYM, "1d", bars_df())
+        ts = self.repo.latest_closed_ts(SYM, "1d")
+        with closing(get_connection()) as conn:
+            conn.execute(
+                "UPDATE ohlcv SET adj_close = 123.45 "
+                "WHERE symbol = %s AND interval = '1d' AND ts = %s",
+                (SYM, ts),
+            )
+            conn.commit()
+
+        self.repo.store_bars(SYM, "1d", bars_df())   # a routine price refresh
+
+        with closing(get_connection()) as conn:
+            kept = conn.execute(
+                "SELECT adj_close FROM ohlcv "
+                "WHERE symbol = %s AND interval = '1d' AND ts = %s",
+                (SYM, ts),
+            ).fetchone()["adj_close"]
+        self.assertAlmostEqual(float(kept), 123.45, places=2)
+
     def test_daily_bars_for_symbols(self):
         self.repo.store_bars(SYM, "1d", bars_df())
         rows = self.repo.daily_bars_for_symbols([SYM])


### PR DESCRIPTION
## The bug

Create Plan failed with `float() argument must be a string or a real number, not 'NoneType'` — from the Portfolio page and the Plans page alike, since both post to the same route.

## Root cause

`PlanBuildParams.history_window_days` (default 360) is a count of **bars** — the repository reads the history back as `LIMIT history_window_days` rows — but the fetch converted it to **calendar** days (`max(n + 60, 420)`). 420 calendar days buys ~288 sessions, so the oldest ~72 rows of a 360-bar window were never written by the harvester.

They were served instead by the *other* writer of `ohlcv`. `OhlcvRepository` (the prices cache) fetches with `auto_adjust=True`, has no adjusted close to offer, and wrote `adj_close = NULL` — and its `ON CONFLICT … adj_close = EXCLUDED.adj_close` also erased values the harvester had already computed for the same rows.

Measured on the test database, to the day:

| | |
|---|---|
| GLW read window | `2025-03-06 .. 2026-08-11` (360 rows) |
| NULL `adj_close` rows | 72, spanning `2025-03-06 … 2025-06-17` — all the oldest |
| first real `adj_close` | index 72 = `2025-06-18` |
| 420 calendar days ago | `2025-06-18` |

Blast radius: 254 symbols have 1d history, 248 have ≥360 rows, and all 248 had rows older than the 420-day fetch reach. Create Plan was broken for essentially every symbol with cached history. Prod runs the same code with the same nightly warming, so assume the same exposure there.

## The fix — three layers, because the middle one can still fail

1. **Fetch the span in trading days.** `HarvesterService.build_plan` scales `history_window_days` by `365/252` before calling `fetch_history`, keeping the old `+60` slack. 360 bars → 581 calendar days ≈ 398 sessions.
2. **A price refresh may fill `adj_close`, never blank it.** `OhlcvRepository`'s upsert becomes `adj_close = COALESCE(EXCLUDED.adj_close, ohlcv.adj_close)`. A tree-wide grep confirms `HarvesterPlanDB.build_plan` is the only consumer of the column, so nothing depended on the nulling.
3. **When a gap survives anyway, say so loudly.** `HarvesterPlanDB.build_plan` raises a `RuntimeError` naming the symbol, the gap count and the oldest date — which `POST /api/plans` already maps to **422** — rather than substituting `close`. Splicing an unadjusted bar in beside adjusted ones is a fake step that inflates the volatility sizing the whole ladder; a legible refusal beats a plausible wrong ladder.

## Also, adjacent (requested in review of the diagnosis)

The bar insert was ~580 single-row round trips. Now one `conn.executemany`, which pages through `psycopg2.extras.execute_batch` — deliberately *not* folded into one multi-VALUES insert, since a repeated `bar_date` would then fail `cannot affect row a second time` against the `ON CONFLICT`. Through the Cloud SQL auth proxy that is the difference between a minute of Create Plan and a second.

## Verification

- `Ran 91 tests in 408.321s — OK` across `test_harvester_fetch_seam`, `test_harvester_repository_db`, `test_repositories_db`, `test_harvester_service`.
- Four new regression cases: the fetch span covers the read window in business days; a read window reaching unadjusted rows raises rather than crashes; unadjusted rows *outside* the window stay harmless; a price refresh never blanks an adjusted close. The two DB-backed ones live in their own `HarvesterAdjCloseGapTest` sibling class — added to `HarvesterRepoTest` they would have run three times, since two suites subclass it.
- **End to end against the test database via the call that failed:** `POST /api/plans` → **201** for GLW (`instance_id 2554`, 4 ascending rungs 206.95/236.51/275.93/331.12) and TER, in 3.2s including the yfinance fetch. `GET /api/plans` reads both back with `in_portfolio: true`. Post-fix coverage: 553 bars, 398 with a real `adj_close`, so the 360-bar window sits inside it with ~38 bars of slack.
- No MCP surface exposes plans (`grep -rln "plans" fastMCPTest/*.py` is empty), so REST and the UI are the only callers — nothing else to exercise.

## Docs

`CLAUDE.md` gains a block under the unified-database section: `ohlcv` has two writers and they disagree about `adj_close`; a refresh may fill it but never blank it; a window measured in bars must be fetched in trading days.

No schema change — `adj_close` was already nullable — so no migration, no `_SCHEMA` edit, no snapshot update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
