### PR TITLE
fix: Watchlist actions column was unreachable behind a double scrollbar

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -26,6 +26,15 @@ function Layout() {
             minWidth: 0,
             minHeight: 0,
             overflowY: 'auto',
+            // CSS coerces a lone overflowY: 'auto' into overflowX: 'auto' too
+            // (the "auto -> auto" overflow rule), which put a second,
+            // easy-to-miss horizontal scrollbar on this Container itself
+            // whenever a page's content (e.g. the Watchlist DataGrid) ran
+            // wider than the maxWidth="xl" cap — on top of the DataGrid's
+            // own internal horizontal scrollbar. Pin it shut; components
+            // that need horizontal scroll (like DataGrid) already manage
+            // their own.
+            overflowX: 'hidden',
             display: chatFullscreen ? 'none' : 'block',
           }}
         >

--- a/frontend/src/components/watchlist/WatchlistPage.tsx
+++ b/frontend/src/components/watchlist/WatchlistPage.tsx
@@ -261,7 +261,7 @@ export default function WatchlistPage() {
     {
       field: 'price',
       headerName: 'Price',
-      width: 110,
+      width: 100,
       type: 'number',
       renderCell: (p: GridRenderCellParams<WatchlistFundamentalsRow, number | null>) => (
         <Typography variant="body2">
@@ -272,7 +272,7 @@ export default function WatchlistPage() {
     {
       field: 'return_5d',
       headerName: '5d',
-      width: 80,
+      width: 70,
       type: 'number',
       renderCell: (p: GridRenderCellParams<WatchlistFundamentalsRow, number | null>) => (
         <ReturnCell value={p.value} />
@@ -281,7 +281,7 @@ export default function WatchlistPage() {
     {
       field: 'return_30d',
       headerName: '30d',
-      width: 80,
+      width: 70,
       type: 'number',
       renderCell: (p: GridRenderCellParams<WatchlistFundamentalsRow, number | null>) => (
         <ReturnCell value={p.value} />
@@ -290,7 +290,7 @@ export default function WatchlistPage() {
     {
       field: 'return_60d',
       headerName: '60d',
-      width: 80,
+      width: 70,
       type: 'number',
       renderCell: (p: GridRenderCellParams<WatchlistFundamentalsRow, number | null>) => (
         <ReturnCell value={p.value} />
@@ -299,7 +299,7 @@ export default function WatchlistPage() {
     {
       field: 'return_ytd',
       headerName: 'YTD',
-      width: 80,
+      width: 70,
       type: 'number',
       renderCell: (p: GridRenderCellParams<WatchlistFundamentalsRow, number | null>) => (
         <ReturnCell value={p.value} />
@@ -308,7 +308,7 @@ export default function WatchlistPage() {
     {
       field: 'return_1y',
       headerName: '1y',
-      width: 80,
+      width: 70,
       type: 'number',
       renderCell: (p: GridRenderCellParams<WatchlistFundamentalsRow, number | null>) => (
         <ReturnCell value={p.value} />
@@ -317,7 +317,7 @@ export default function WatchlistPage() {
     {
       field: 'composite_score',
       headerName: 'Score',
-      width: 110,
+      width: 92,
       type: 'number',
       getSortComparator: scoreThenReturn,
       renderCell: (p: GridRenderCellParams<WatchlistFundamentalsRow, number | null>) => {
@@ -338,7 +338,7 @@ export default function WatchlistPage() {
         );
       },
     },
-    { field: 'sector', headerName: 'Sector', width: 150 },
+    { field: 'sector', headerName: 'Sector', width: 120 },
     {
       field: 'market_cap_usd',
       headerName: 'Cap (USD)',
@@ -357,7 +357,7 @@ export default function WatchlistPage() {
     {
       field: 'market_cap',
       headerName: 'Cap (native)',
-      width: 130,
+      width: 112,
       // Deliberately not sortable: the values are in different currencies, so
       // ordering them ranks exchange rates rather than companies.
       sortable: false,
@@ -370,7 +370,7 @@ export default function WatchlistPage() {
     {
       field: 'fundamentals_age_hours',
       headerName: 'Cached',
-      width: 100,
+      width: 86,
       type: 'number',
       getSortComparator: nullsLast,
       renderCell: (p: GridRenderCellParams<WatchlistFundamentalsRow, number | null>) => {
@@ -399,7 +399,7 @@ export default function WatchlistPage() {
       field: 'tags',
       headerName: 'Tags',
       flex: 1,
-      minWidth: 180,
+      minWidth: 150,
       sortable: false,
       renderCell: (p: GridRenderCellParams<WatchlistFundamentalsRow, string[]>) => (
         <Stack


### PR DESCRIPTION
## Problem

The Watchlist page's per-row "Edit tags" pencil and "Remove from watchlist" icons (the `_actions` column, rightmost in the grid) were effectively unreachable, even when maximizing the browser window.

## Root cause

Two compounding issues:

1. **`maxWidth="xl"` cap** — the page `Container` in `App.tsx` caps content at 1536px regardless of how wide the browser window is, so widening the window didn't help.
2. **Duplicate horizontal scrollbar** — a prior change (`4d3438e`) added `overflowY: 'auto'` to that same `Container` to let the Sidekick chat scroll independently, but left `overflowX` unset. CSS's overflow auto-coercion rule then computed `overflowX` as `auto` too, producing a second, easy-to-miss horizontal scrollbar on the *page* itself — layered on top of the DataGrid's own internal horizontal scrollbar. Between the two, the actions column at the far right was hard to discover.
3. On top of both, the Watchlist's 15 columns summed to more width than the grid had available even at the `xl` cap, so the actions column was clipped by default.

## Fix

- `App.tsx`: pin `overflowX: 'hidden'` on the page Container — leaves exactly one horizontal scrollbar (the DataGrid's own).
- `WatchlistPage.tsx`: trim several column widths (price, the five return-% columns, score, sector, native cap, cached-age, tags `minWidth`) so the total column width fits within the `maxWidth="xl"` cap — no scrolling needed at a normal/maximized window.

Column pinning (MUI DataGrid Pro) was considered as a permanent guarantee but isn't available in the Community edition this project uses.

## Verification

Tested in-browser with a throwaway local mock of `/api/watchlist/fundamentals` so real rows render (the empty-table state was found to make MUI DataGrid mis-report its own scroll-needed state — a red herring, not a real bug):

- At 1920×1080: `_actions` column's right edge sits exactly at the grid's right edge — fully visible, zero scrolling needed.
- At a narrower 1024px window: the grid's single horizontal scrollbar is present and functional; scrolling right reaches the pencil/delete icons and the tag editor opens correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)