### PR TITLE
Close the Sidekick tool gap, and fix the docs that hid it (#208)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -446,7 +446,10 @@ analysis on test, treat prod as read-only" operating rule — now that changes s
 (`deploy.yml` → test, `prod-rollout.yml` → prod), prod is the live system everyone reads from. The
 deployed `quantui` UI and the `.mcp.json` AI-client remotes both already target prod.
 
-The 5 remote MCP servers in `.mcp.json` send `Authorization: Bearer ${QUANTCORE_MCP_TOKEN}`, which
+The 7 remote MCP servers in `.mcp.json` (stock-price, company-fundamentals, options-analysis,
+portfolio, arbitrage, news-sentiment, market-analysis — carrying **62 tools**; count them with the
+**anchored** `grep -c "^@mcp.tool" fastMCPTest/*.py`, since the unanchored form counts a mention
+inside `options_analysis.py`'s module docstring) send `Authorization: Bearer ${QUANTCORE_MCP_TOKEN}`, which
 the wrappers forward unchanged to `quantcore-api` (identity passthrough → the legacy HS256
 service-token path in the now dual-mode `api/auth.py`). So real analysis requires `QUANTCORE_MCP_TOKEN` to be a valid prod JWT in the
 environment Claude Code launches from; if it's unset, every data tool returns `401: … Not enough

--- a/api/auth.py
+++ b/api/auth.py
@@ -263,3 +263,39 @@ def require_owner(principal: Principal = Depends(require_principal)) -> str:
             datetime.now(timezone.utc).isoformat(),
         )
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="not_provisioned")
+
+
+def resolve_owner_or_none(principal: Principal) -> str | None:
+    """Resolve a principal to its canonical owner, or ``None`` if unmapped.
+
+    The soft sibling of :func:`require_owner`, for a request that is only
+    *partly* owner-scoped. A Sidekick chat turn serves many tools, most of which
+    read nobody's private data; 403-ing the whole turn because the caller's
+    portfolio identity is unprovisioned would kill ``get_stock_price`` along with
+    ``get_portfolio_summary``. So the resolution is soft here and the *tool call*
+    fails closed instead (``ChatService`` refuses to touch ``PortfolioService``
+    with a ``None`` owner) — the degrade is per capability, not per request.
+
+    Not a ``Depends``: it takes the principal a route has already resolved, so a
+    route can thread the answer into a context object rather than a parameter.
+
+    Every other property of ``require_owner`` is deliberately identical — the
+    local exemption, and above all **never auto-provisioning** (issue #126
+    decision #2). Softening the failure must not soften the mapping rule; the
+    only difference is that the caller gets to decide what the miss costs. The
+    security event is logged under a **distinct** name so the soft path stays
+    separable from the hard 403 in monitoring.
+    """
+    if principal.is_local:
+        return "john"
+
+    try:
+        return get_services().identity.resolve_owner(principal.owner)
+    except UnknownIdentityError:
+        # Identity only — never the token, header, or raw claims.
+        _security_logger.warning(
+            "SECURITY unmapped_principal_soft identity=%s at=%s",
+            principal.owner,
+            datetime.now(timezone.utc).isoformat(),
+        )
+        return None

--- a/api/routers/arbitrage.py
+++ b/api/routers/arbitrage.py
@@ -20,14 +20,19 @@ from typing import Optional
 
 from fastapi import APIRouter, HTTPException, Query
 
+from quantcore.services.arbitrage import (  # noqa: F401  (re-exported for callers/tests)
+    MAX_DISCOVER_REFERENCES,
+    MAX_DISCOVER_SYMBOLS,
+)
+
 from ..deps import services
 from ..json_response import QuantCoreJSONResponse
 
 router = APIRouter(prefix="/api/arbitrage", tags=["arbitrage"])
 
-# Each swept symbol costs a history fetch plus a ticker_info lookup.
-MAX_DISCOVER_SYMBOLS = 25
-MAX_DISCOVER_REFERENCES = 10
+# Each swept symbol costs a history fetch plus a ticker_info lookup. The
+# numbers live on the service module so this route and the Sidekick tool
+# handler share one definition (issue #208).
 
 # Below ~30 daily bars the service reports "no price history" anyway; the
 # ceiling is a sanity bound, well past the gateway's 730-day fetch cap.

--- a/api/routers/chat.py
+++ b/api/routers/chat.py
@@ -9,6 +9,11 @@ sealed envelope/scope plus the caller's principal, and hands it to the
 service opaquely. ``require_principal`` here is the same dependency the app
 already applies router-wide, so FastAPI's per-request dependency cache means
 the token is verified once, not twice.
+
+The context also carries a **soft-resolved** owner (issue #208), which is why
+this route does not depend on ``require_owner``: most chat tools are not
+owner-scoped, and one unprovisioned identity should cost the caller the
+portfolio tools, not the whole turn.
 """
 from __future__ import annotations
 
@@ -17,7 +22,7 @@ from fastapi.responses import StreamingResponse
 
 from quantcore.services.chat import TurnContext
 
-from ..auth import Principal, require_principal
+from ..auth import Principal, require_principal, resolve_owner_or_none
 from ..deps import services
 from ..schemas.chat import ChatRequest
 from ..sse import event_stream
@@ -40,6 +45,10 @@ def chat(
         auth_token=principal.token,
         subject=principal.subject,
         model=body.model,
+        # Soft-resolved, not required: an unmapped identity must still get
+        # prices and technicals out of this turn. The portfolio tools are the
+        # only ones that fail on a None here — see resolve_owner_or_none.
+        owner=resolve_owner_or_none(principal),
     )
     events = services().chat.stream_chat(
         [{"role": m.role, "content": m.content} for m in body.messages],

--- a/docs/capabilities-matrix.md
+++ b/docs/capabilities-matrix.md
@@ -2,8 +2,8 @@
 
 This document is a comprehensive inventory of every user-facing capability in the StockPortfolioManager project, mapped to the surface(s) through which it can be accessed.
 
-**Last Updated:** 2026-07-20
-**MCP Tools:** 51 unique (53 registrations across 5 servers — 2 tools are dual-registered) | **REST Endpoints:** 91 operations (see `docs/openapi-surface.txt`) | **WebUI Pages:** 7 (+ Sidekick chat rail) | **CLI Tools:** 1 | **Standalone Scripts:** ~10
+**Last Updated:** 2026-08-14
+**MCP Tools:** 62 across 7 servers (no tool is dual-registered) | **REST Endpoints:** 91 operations (see `docs/openapi-surface.txt`) | **WebUI Pages:** 8 nav pages + 2 drill-downs (+ Sidekick chat rail) | **CLI Tools:** 1 | **Standalone Scripts:** ~10
 
 > **Refactor status:** Phases 1–3 of [`proposals/architectural-standard-v2.md`](proposals/architectural-standard-v2.md) are **complete**, prod rollout is **complete** (`quantcore-prod-20260606`, promoted by digest via `prod-rollout.yml`), QuantUI is deployed behind IAP in both projects, and **BYOK is live as of 2026-07-18** (browser key vault + Settings page + `keyproxy` credential-isolation service; per-user ES256 JWTs replaced the static UI→API token). Phase 3 Step 1 closed the residual MCP-tool→REST-endpoint gaps, so **every MCP tool now has a REST equivalent**. Issue #93 ("Recover Phases 3-7: Support-Level Analysis Tools", PR #108, merged 2026-07-20) added 4 more analysis tools (volume profile, support confluence, OI-change analysis, signed GEX profile) — all REST-exposed, one (`get_support_confluence`) is also WebUI-surfaced. The surface-parity problem this document originally tracked has moved almost entirely to the WebUI layer. See the section immediately below.
 
@@ -13,13 +13,21 @@ This document is a comprehensive inventory of every user-facing capability in th
 
 **Headline finding, refreshed 2026-07-20.** The REST tier exposes 91 operations, but the React frontend calls only a subset of them. Everything listed here is fully built, tested, and reachable over REST today — surfacing it is **frontend-only work** (no backend changes needed). Items are grouped by likely user value.
 
+> **Partially superseded — the gap list below was last fully audited 2026-07-20.** Issue #147 Parts C
+> and D have since shipped the **Watchlist** and **Fundamentals** pages, which closed the
+> cross-symbol fundamentals gap (top-N, upcoming earnings, sector breakdown, 90-day score changes,
+> cache freshness). Rows known to be closed are corrected below; the rest have **not** been
+> re-verified since 2026-07-20, so read an unstruck row as "was true then", not "is true now".
+> The 2026-08-14 pass (issue #208) refreshed the MCP/Sidekick inventory, not this section — a full
+> UI-gap re-audit is its own piece of work.
+
 ### Tier 1 — High-value analysis synthesis (flagship tools, invisible to UI users)
 
 | Capability | REST endpoint (live today) | What the UI needs |
 |---|---|---|
 | **Composite trade recommendation** (19 signals → BUY/SELL/HOLD + confidence + suggested position size) | `GET /api/securities/{ticker}/recommendation?capital=` | A "Recommendation" tab or card on Security Detail — arguably the single most valuable unsurfaced feature |
 | **Stop-loss synthesis** (7 sub-analyses: BB, VWAP, MACD, RSI, DAOI, drawdown, short interest → concrete stop price) | `GET /api/securities/{ticker}/stop-loss` | Panel on Security Detail (pairs naturally with the recommendation) |
-| **Fundamentals profile** (composite score −14..+14, revenue growth/CAGR, earnings acceleration, signal) | `GET /api/securities/{ticker}/fundamentals` (+ `/score`, `/revenue-growth`, `/earnings-acceleration`, `/history`) | A "Fundamentals" tab on Security Detail. The UI currently shows earnings dates only |
+| **Fundamentals profile** (composite score −14..+14, revenue growth/CAGR, earnings acceleration, signal) | `GET /api/securities/{ticker}/fundamentals` (+ `/score`, `/revenue-growth`, `/earnings-acceleration`, `/history`) | A "Fundamentals" tab on Security Detail — still open. Security Detail shows earnings dates only; the `/fundamentals` page added in #147 Part D is cross-symbol, not per-ticker |
 | **Market microstructure panel** (short interest + squeeze potential, dark-pool proxy, bid/ask fear gauge) | `GET /api/securities/{ticker}/microstructure` (fan-out; also `/short-interest`, `/dark-pool`, `/bid-ask-spread` individually) | A "Microstructure" section on the Signals tab |
 | **Relative strength vs SPY/QQQ/sector** (+ history series for trend) | `GET /api/securities/{ticker}/relative-strength` and `/relative-strength/history` | Chart overlay or Signals-tab card |
 
@@ -42,7 +50,7 @@ This document is a comprehensive inventory of every user-facing capability in th
 | **ATR bands + chandelier trailing stop** (issue #93) | `GET /api/securities/{ticker}/atr-bands` | Overlay on the Price & MAs chart |
 | **Anchored VWAP** (auto-anchors: earnings, 52w H/L, gaps, swings) (issue #93) | `GET /api/securities/{ticker}/anchored-vwap` | Overlay on the Price & MAs chart |
 | **Volume profile** (POC, value area, HVN/LVN nodes) (issue #93) | `GET /api/securities/{ticker}/volume-profile` | Overlay/histogram on the Price & MAs chart |
-| **Cross-symbol fundamentals screeners** — top-N by score, upcoming earnings (N days), sector breakdown, 90-day score-change movers, batch scoring | `GET /api/securities/fundamentals/top`, `/upcoming-earnings`, `/sector-breakdown`, `/score-changes`, `POST /fundamentals/scores-batch` | Securities-page screener presets or a dashboard widget (e.g. "earnings this week") |
+| ~~**Cross-symbol fundamentals screeners**~~ — **CLOSED by the `/fundamentals` page** (#147 Part D): top-N, upcoming earnings, sector breakdown, and 90-day score changes each own a panel, over `scope=tracked`. Only `POST /fundamentals/scores-batch` remains unsurfaced | `GET /api/securities/fundamentals/top`, `/upcoming-earnings`, `/sector-breakdown`, `/score-changes`, `/cache-stats` | — (batch scoring is an MCP/API convenience, not obviously a page) |
 | **30-day sentiment trend** (per-day breakdown, net score) | `GET /api/securities/{ticker}/news/trend` | Sparkline/chart next to the existing sentiment badge |
 | **On-demand news collection** (fetch + FinBERT + persist) | `POST /api/securities/{ticker}/news/collect` | A "refresh news" button (mirrors the existing options-snapshot refresh button) |
 | **Portfolio CSV import** (full-sync per-owner) | `POST /api/portfolio/import` | Upload dialog on Dashboard/Securities — today it's the `scripts/import_portfolio.py` CLI only |
@@ -50,7 +58,7 @@ This document is a comprehensive inventory of every user-facing capability in th
 
 **Already surfaced from issue #93:** `get_support_confluence` (14-source composite support/resistance zones) shipped **with** a WebUI card (`SupportConfluenceCard.tsx` on the Technical Analysis tab) in the same PR — the only issue #93 tool that isn't in the backlog above.
 
-**Sidekick partially mitigates Tier 1:** the chat rail's tool vocabulary (`quantcore/services/chat_tools.py`) includes `get_fundamental_score`, `get_technical_signals`, `get_news_sentiment`, and `price_vertical_spread`, so a UI user *can* ask Sidekick for these. But chat is discoverable-on-demand, not glanceable — the dashboard/detail-page panels above remain the durable fix.
+**Sidekick partially mitigates Tier 1:** the chat rail's tool vocabulary (`quantcore/services/chat_tools.py`) is **13 data tools + `show_component`, rendering 15 components** (issue #208), and covers Tier 1 through `get_fundamental_score`, `get_technical_signals`, `get_news_sentiment`, and `price_vertical_spread` — so a UI user *can* ask Sidekick for these. But chat is discoverable-on-demand, not glanceable — the dashboard/detail-page panels above remain the durable fix.
 
 ---
 
@@ -60,8 +68,8 @@ This document is a comprehensive inventory of every user-facing capability in th
 |---|---|---|---|---|
 | **MCP Tool** | Claude Code / AI clients via `.mcp.json` | Model Context Protocol | Prod Cloud Run wrappers (`https://quantcore-<svc>-…run.app/mcp`) or `*-local` compose stack | Thin HTTP gateway wrappers (`mcp_gateway/rest_client.py`) — every tool call becomes one REST request |
 | **REST Endpoint** | HTTP to the FastAPI tier | JSON over HTTP (OpenAPI at `/docs`) | `uvicorn api.main:app --port 5001`; prod `quantcore-api` (JWT-enforced) | The canonical surface — all business logic reachable here; enables WebUI, MCP, and external integrations |
-| **WebUI** | Browser (IAP-gated QuantUI on Cloud Run; `npm run dev` locally) | React SPA | Test/prod `quantui` services; Vite dev proxy locally | 7 pages: Dashboard, Securities, Security Detail (6 tabs), Plans, Plan Detail, Symbols, Settings |
-| **Sidekick Chat** | Chat rail on every WebUI page | SSE via `POST /api/chat` → keyproxy → Anthropic (BYOK) | Same as WebUI | LLM with 7 data tools + `show_component` (renders `signals`, `live_price`, `price_chart`, `spread_payoff` cards inline) |
+| **WebUI** | Browser (IAP-gated QuantUI on Cloud Run; `npm run dev` locally) | React SPA | Test/prod `quantui` services; Vite dev proxy locally | Declared once in `frontend/src/navigation.tsx`: Portfolio, Plans, Harvester, Securities, Watchlist, Fundamentals, Arbitrage, Settings, plus the Plan-detail and Security-detail drill-downs. The Symbols page was retired in #147 Part G1 |
+| **Sidekick Chat** | Chat rail on every WebUI page | SSE via `POST /api/chat` → keyproxy → Anthropic (BYOK) | Same as WebUI | LLM with 13 data tools + `show_component` (renders 15 components inline — price/technical, spread payoff, the four arbitrage cards, portfolio/lots, watchlist + fundamentals rankings). Tools dispatch **in-process to the services**, not over MCP |
 | **CLI Tool** | `python fastMCPTest/options_analysis.py --flags` | argparse | N/A | Hybrid: also runs as the options-analysis MCP server |
 | **Standalone Script** | `python script.py` | Direct execution | `main.py` runs daily as a prod Cloud Run Job | Report generation, position monitors, operational utilities |
 
@@ -71,16 +79,20 @@ This document is a comprehensive inventory of every user-facing capability in th
 
 | Surface | Count | Examples |
 |---|---|---|
-| MCP Tools (5 servers) | 51 unique (53 registrations) | `get_stock_price`, `price_vertical_spread`, `get_fundamental_score`, `get_news_sentiment`, `get_short_interest`, `analyze_options_watchlist` |
+| MCP Tools (7 servers) | 62 | `get_stock_price`, `price_vertical_spread`, `get_fundamental_score`, `get_news_sentiment`, `get_short_interest`, `analyze_options_watchlist`, `scan_arbitrage`, `get_portfolio` |
 | REST Endpoints | 91 operations | `GET /api/securities/{ticker}/technicals`, `POST /api/plans`, `GET /api/securities/screen`, `GET /api/securities/{ticker}/recommendation`, `POST /api/chat` |
-| WebUI Pages | 7 + chat rail | Dashboard, Securities, Security Detail (Price & MAs · Technical Analysis · Options Chain · Options Performance · Options Analytics · Signals), Plans, Plan Detail, Symbols, Settings (BYOK keys) |
-| Sidekick chat tools | 7 + 4 components | `get_stock_price`, `get_technical_signals`, `get_rsi`, `get_macd`, `get_fundamental_score`, `get_news_sentiment`, `price_vertical_spread`; renders `signals`/`live_price`/`price_chart`/`spread_payoff` |
+| WebUI Pages | 8 + 2 drill-downs + chat rail | Portfolio, Plans, Harvester, Securities, Watchlist, Fundamentals, Arbitrage, Settings (BYOK keys); drill-downs: Plan Detail, Security Detail (Price & MAs · Technical Analysis · Options Chain · Options Performance · Options Analytics · Signals) |
+| Sidekick chat tools | 13 + 15 components | `get_stock_price`, `get_technical_signals`, `get_rsi`, `get_macd`, `get_fundamental_score`, `get_news_sentiment`, `price_vertical_spread`, `list_arbitrage_universe`, `analyze_arbitrage_pair`, `scan_arbitrage`, `discover_arbitrage_pairs`, `get_portfolio_summary`, `get_symbol_lots`; renders `signals`, `live_price`, `price_chart`, `spread_payoff`, `arbitrage_pair`, `arbitrage_spread`, `arbitrage_premium`, `arbitrage_scan`, `arbitrage_discovery`, `portfolio_table`, `portfolio_allocation`, `symbol_lots`, `watchlist_fundamentals`, `fundamentals_top`, `fundamentals_score_changes` |
 | CLI Tools | 1 | `fastMCPTest/options_analysis.py` (strategy screening; hybrid CLI + MCP server). `collect_options.py` has been **deleted** |
 | Standalone Scripts | ~10 | `main.py` (daily report Job), watchlist fundamentals report, INTC/WMT spread monitors, `import_portfolio.py`, migration/ops scripts |
 
-**MCP tool count by server (verified against source, 2026-07-20):** stock-price 29 · company-fundamentals 12 · options-analysis 5 · news-sentiment 4 · market-analysis 3 = 53 registrations, 51 unique tools. `get_option_contracts` and `price_vertical_spread` appear on both stock-price and options-analysis (shared `quantcore/services/options_contracts.py`), accounting for the 2-tool overlap.
+**MCP tool count by server (verified against source, 2026-08-14 — issue #208):** stock-price 21 · company-fundamentals 12 · options-analysis 11 · portfolio 6 · arbitrage 5 · news-sentiment 4 · market-analysis 3 = **62 tools across 7 servers**. **No tool is dual-registered.** The prior revision of this document claimed `get_option_contracts` and `price_vertical_spread` appeared on both stock-price and options-analysis; they do not — `60e4bcd` ("consolidate options tools onto options-analysis-server") moved every options tool off stock-price, which is the whole of the 29→21 drop. The claim appears only in this document — `CLAUDE.md` never carried it, though it did say "5 remote MCP servers in `.mcp.json`" when there are 7, corrected in the same PR as this refresh.
 
-**New since the 2026-07-19 refresh (issue #93 / PR #108, merged 2026-07-20):** 4 new stock-price MCP tools + REST endpoints — `get_volume_profile`, `get_support_confluence`, `get_oi_change_analysis`, `get_gex_profile` (stock-price grew 25→29); new `gex_history` DB table (daily signed-GEX summary, upserted per call); new frontend `SupportConfluenceCard.tsx` on the Technical Analysis tab (the one issue #93 capability that shipped with WebUI surfacing).
+Count it with the **anchored** grep — `grep -c "^@mcp.tool" fastMCPTest/*.py`. The unanchored form over-counts: `fastMCPTest/options_analysis.py` mentions `@mcp.tool()` inside its module docstring, which reads as a 12th tool that does not exist.
+
+**New since the 2026-07-20 refresh (issue #208):** two MCP servers this document never listed — **`arbitrage-server`** (5 tools, new domain section below) and **`portfolio-server`** (6 tools) — plus the options consolidation described above. Sidekick grew from 7 data tools to 13: the three arbitrage tools that shipped with the scanner, and three added by issue #208 — `discover_arbitrage_pairs` (its `arbitrage_discovery` component was registered on both sides with no tool to feed it) and `get_portfolio_summary` / `get_symbol_lots` (portfolio-server had zero chat coverage, so Sidekick could render a portfolio card but not reason over the numbers in prose).
+
+**New in the 2026-07-19 refresh (issue #93 / PR #108, merged 2026-07-20):** 4 new stock-price MCP tools + REST endpoints — `get_volume_profile`, `get_support_confluence`, `get_oi_change_analysis`, `get_gex_profile` (stock-price grew 25→29 at the time); new `gex_history` DB table (daily signed-GEX summary, upserted per call); new frontend `SupportConfluenceCard.tsx` on the Technical Analysis tab (the one issue #93 capability that shipped with WebUI surfacing).
 
 ---
 
@@ -123,8 +135,8 @@ Capabilities are organized by domain. **Bold ⚠ rows** are built-but-not-in-UI 
 |---|---|---|---|---|
 | Latest options snapshot (price, P/C ratio, nearest-expiry chains) | via `get_stock_price` | `GET .../options/latest` | Options Chain tab | — |
 | **⚠ Full options chain (all strikes/expirations)** | `get_full_options_chain` | `GET .../options/chain`, `.../options/full-chain` | **—** (tab shows latest snapshot only) | — |
-| **⚠ Exact contract lookup by expiry/strike** | `get_option_contracts` (both servers) | `GET .../options/contracts` | **—** | — |
-| Vertical spread pricing (debit, max P/L, breakeven, liquidity) | `price_vertical_spread` (both servers) | `POST .../options/vertical-spread` | Sidekick only (`spread_payoff` card, interactive strike repricing) — **no direct UI form** | — |
+| **⚠ Exact contract lookup by expiry/strike** | `get_option_contracts` | `GET .../options/contracts` | **—** | — |
+| Vertical spread pricing (debit, max P/L, breakeven, liquidity) | `price_vertical_spread` | `POST .../options/vertical-spread` | Sidekick only (`spread_payoff` card, interactive strike repricing) — **no direct UI form** | — |
 | Unusual call sweep detection | `get_unusual_calls` | `GET .../options/unusual-calls`, `/signals/options-flow` | Signals tab (aggregated) | — |
 | Delta-Adjusted OI (DAOI, gamma wall, delta flip) | `get_delta_adjusted_oi` | `GET .../options/delta-adjusted-oi`, `/signals/options-flow` | Signals tab (aggregated) | — |
 | **⚠ Gamma wall history (daily MM hedge-bias trend)** | `get_gamma_wall_history` | `GET .../options/gamma-wall-history` | **—** | — |
@@ -142,6 +154,32 @@ Capabilities are organized by domain. **Bold ⚠ rows** are built-but-not-in-UI 
 
 ---
 
+### Domain: Arbitrage
+
+Securities whose price has stretched against a structurally linked underlying, across three
+families — **nav_vehicle** (the only one with a computable fair value), **commodity_etf**, and
+**producer**. Curated links live in `arb_universe.yaml`. Fully surfaced on all four surfaces; the
+design rationale is [`docs/arbitrage-scanner-usage.md`](arbitrage-scanner-usage.md).
+
+| Capability | MCP Tool | REST Endpoint | WebUI | Sidekick |
+|---|---|---|---|---|
+| Curated pair universe (links, families, why each exists) | `list_arbitrage_universe` | `GET /api/arbitrage/universe` | Arbitrage page → family filters | `list_arbitrage_universe` |
+| Scan the universe (ranked by convergence mechanism, not spread width) | `scan_arbitrage` | `GET /api/arbitrage/scan` | Arbitrage page (`ScanTable`) | `scan_arbitrage`, `arbitrage_scan` card |
+| Single-pair workup (NAV, `factors` breakdown, `reasons`, `breaks_on`) | `analyze_arbitrage_pair` | `GET /api/arbitrage/pairs/{security}` | Arbitrage page → selected row | `analyze_arbitrage_pair`, `arbitrage_pair` card |
+| Spread history (z-score series) | — | `GET /api/arbitrage/pairs/{security}/spread-history` | Arbitrage page (`SpreadChart`) | `arbitrage_spread` card |
+| Premium/discount history | — | `GET /api/arbitrage/pairs/{security}/premium-history` | Arbitrage page (`PremiumChart`) | `arbitrage_premium` card |
+| Statistical sweep for undeclared cointegrated links (candidates for curation — no NAV, no convergence claim) | `discover_arbitrage_pairs` | `GET /api/arbitrage/discover` | Arbitrage page (`DiscoveryScatter`) | `discover_arbitrage_pairs`, `arbitrage_discovery` card |
+| MCP wrapper health check | `mcp_health_check` | (wrapper-local) | — | — |
+
+Two things about the discovery path are load-bearing rather than incidental. A discovered pair is a
+**curation candidate, not a signal** — presenting correlation as an opportunity is exactly what the
+curated universe exists to prevent, so the tool description says so and a test asserts it. And the
+25-symbol / 10-reference caps live on `ArbitrageService` (`MAX_DISCOVER_SYMBOLS`,
+`MAX_DISCOVER_REFERENCES`), re-asserted by **both** the REST route and the Sidekick handler —
+Sidekick dispatches in-process and would otherwise bypass a cap that only guarded HTTP.
+
+---
+
 ### Domain: Fundamental Analysis
 
 **Every fundamentals tool is now REST-exposed; none of it (except the earnings date) reaches the UI.** This is the largest whole-domain UI gap.
@@ -155,11 +193,11 @@ Capabilities are organized by domain. **Bold ⚠ rows** are built-but-not-in-UI 
 | **⚠ Earnings acceleration (CAN SLIM "A")** | `get_earnings_acceleration` | `GET /{ticker}/fundamentals/earnings-acceleration` | **—** | — |
 | **⚠ Historical score snapshots + trend** | `get_fundamental_history` | `GET /{ticker}/fundamentals/history` | **—** | — |
 | **⚠ Batch scoring (multi-symbol, ranked)** | `get_fundamental_scores_batch` | `POST /api/securities/fundamentals/scores-batch` | **—** | — |
-| **⚠ Top-N stocks by score (per sector, from cache)** | `get_top_fundamental_stocks` | `GET /api/securities/fundamentals/top` | **—** | — |
-| **⚠ Upcoming earnings within N days** | `get_upcoming_earnings` | `GET /api/securities/fundamentals/upcoming-earnings` | **—** | — |
-| **⚠ Sector fundamental breakdown** | `get_sector_fundamental_breakdown` | `GET /api/securities/fundamentals/sector-breakdown` | **—** | — |
-| **⚠ Score change tracking (90-day movers)** | `get_fundamental_score_changes` | `GET /api/securities/fundamentals/score-changes` | **—** | — |
-| Cache statistics | `get_cache_stats` | `GET /api/securities/fundamentals/cache-stats` | — (admin/debug) | — |
+| Top-N stocks by score (per sector, from cache) | `get_top_fundamental_stocks` | `GET /api/securities/fundamentals/top` | **Fundamentals page** (`TopFundamentalsPanel`) | `fundamentals_top` card (the panel's own `variant="rail"`) |
+| Upcoming earnings within N days | `get_upcoming_earnings` | `GET /api/securities/fundamentals/upcoming-earnings` | **Fundamentals page** (`UpcomingEarningsStrip`) | — |
+| Sector fundamental breakdown | `get_sector_fundamental_breakdown` | `GET /api/securities/fundamentals/sector-breakdown` | **Fundamentals page** (`SectorBreakdownPanel`) | — |
+| Score change tracking (90-day movers) | `get_fundamental_score_changes` | `GET /api/securities/fundamentals/score-changes` | **Fundamentals page** (`ScoreChangesPanel`) | `fundamentals_score_changes` card (same hook + react-query key as the panel) |
+| Cache statistics | `get_cache_stats` | `GET /api/securities/fundamentals/cache-stats` | Fundamentals page (`CacheFreshnessBanner`) | — |
 
 ---
 
@@ -205,18 +243,28 @@ Fully surfaced — REST + WebUI, no gaps.
 
 ### Domain: Portfolio & Watchlist Management
 
-Positions are DB-backed with multi-owner support (`positions` table, `owner` column); `portfolio.csv` is now a per-owner import format.
+Positions are DB-backed with multi-owner support (`positions` table, `owner` column); `portfolio.csv` is now a per-owner import format. The watchlist, by contrast, is **global** — one shared list, no `owner` column (issue #83).
 
-| Capability | REST Endpoint | WebUI | CLI/Script |
-|---|---|---|---|
-| View portfolio positions (`?owner=`, default `john`) | `GET /api/portfolio` | Dashboard, Securities page | `main.py` (report) |
-| Add / remove position | `POST /api/portfolio`, `DELETE /api/portfolio/{ticker}` | AddSecurityDialog / remove action | — |
-| **⚠ Bulk CSV import (full-sync per owner)** | `POST /api/portfolio/import` | **—** | `scripts/import_portfolio.py --csv portfolio.csv --owner john` |
-| View / add watchlist | `GET`/`POST /api/watchlist` | Securities page + AddSecurityDialog | — |
-| Combined portfolio + watchlist view | `GET /api/securities` | Securities page DataGrid | — |
-| Symbol lookup (name/sector/industry) | `GET /api/securities/lookup` | AddSecurityDialog autocomplete | — |
-| HTML portfolio report (charts, gain/loss, S3 upload) | — | — | `main.py` (daily prod Cloud Run Job) |
-| Watchlist returns + fundamentals HTML report | — | — | `scripts/generate_watchlist_fundamentals_report.py` |
+**Nothing here lets a caller choose whose holdings it reads.** MCP tools and Sidekick tools alike take no `owner` argument: the MCP wrappers pass the caller's own identity through, and the Sidekick tools are dispatched with an owner resolved from the signed-in principal at the route boundary, with any model-supplied `owner` key discarded before dispatch (issue #126 decision #20). An identity with no portfolio mapping gets a clear "not linked" tool result rather than a guess or someone else's numbers.
+
+| Capability | MCP Tool | REST Endpoint | WebUI | Sidekick | CLI/Script |
+|---|---|---|---|---|---|
+| Per-symbol position rows (quantity, basis, current value, gain/loss, `active_plan_id`) | `get_portfolio` | `GET /api/portfolio/symbols` | Portfolio, Securities pages | `portfolio_table` / `portfolio_allocation` cards | `main.py` (report) |
+| Portfolio totals (cost basis, current value, gain/loss $ and %, $/day) | `get_portfolio_summary` | `GET /api/portfolio/symbols` → `totals` | Portfolio page header | `get_portfolio_summary` (issue #208) | — |
+| Per-symbol lots (quantity, purchase price, date, gain/loss) | `get_symbol_lots` | `GET /api/portfolio/lots` (filtered to the ticker by the caller) | Portfolio page → symbol drill-down | `get_symbol_lots` (issue #208), `symbol_lots` card | — |
+| Legacy flat position list | — | `GET /api/portfolio` | — | — | — |
+| Add / remove position | — | `POST /api/portfolio`, `DELETE /api/portfolio/{ticker}` | AddSecurityDialog / remove action | — | — |
+| Lot lifecycle (create / edit / delete / close) | — | `POST`/`PATCH`/`DELETE /api/portfolio/lots[/{id}]`, `POST .../lots/{id}/close` | Portfolio page lot dialogs | — | — |
+| **⚠ Bulk CSV import (full-sync per owner)** | — | `POST /api/portfolio/import` | **—** | — | `scripts/import_portfolio.py --csv portfolio.csv --owner john` |
+| View / add watchlist | `list_watchlist`, `add_to_watchlist` | `GET`/`POST /api/watchlist` | Securities page + AddSecurityDialog | — | `scripts/import_watchlist.py` |
+| Watchlist returns + fundamentals (ranked, 6 queries, 0 network calls) | — | `GET /api/watchlist/fundamentals` | **Watchlist page** | `watchlist_fundamentals` card | — |
+| Remove from watchlist (**UI-only by design** — the MCP seam has no `delete` verb, so no agent can drop symbols off a shared list) | — | `DELETE /api/watchlist/{ticker}` | Watchlist / Securities page | — | — |
+| Retag a watchlist entry (replaces the tag set, does not merge) | — | `PATCH /api/watchlist/{ticker}` | Watchlist page chips | — | — |
+| Combined portfolio + watchlist view | — | `GET /api/securities` | Securities page DataGrid | — | — |
+| Symbol lookup (name/sector/industry) | — | `GET /api/securities/lookup` | AddSecurityDialog autocomplete | — | — |
+| HTML portfolio report (charts, gain/loss, S3 upload) | — | — | — | — | `scripts/generate_portfolio_report.py` (Pi, via `runOnPi.sh`) |
+| Discord alerts + options/fundamentals capture | — | — | — | — | `main.py` (daily prod Cloud Run Job) |
+| MCP wrapper health check | `mcp_health_check` | (wrapper-local) | — | — | — |
 
 ---
 
@@ -224,8 +272,9 @@ Positions are DB-backed with multi-owner support (`positions` table, `owner` col
 
 | Capability | Surface | Notes |
 |---|---|---|
-| Conversational analysis (streaming, tool-using LLM) | `POST /api/chat` (SSE) → Sidekick rail on every page | Tools: stock price, technical signals, RSI, MACD, fundamental score, news sentiment, vertical-spread pricing |
-| Inline rendered components in chat | `show_component` directive | `signals`, `live_price`, `price_chart`, `spread_payoff` (interactive: strike select/reprice backchannel) |
+| Conversational analysis (streaming, tool-using LLM) | `POST /api/chat` (SSE) → Sidekick rail on every page | **13 data tools:** `get_stock_price`, `get_technical_signals`, `get_rsi`, `get_macd`, `get_fundamental_score`, `get_news_sentiment`, `price_vertical_spread`, `list_arbitrage_universe`, `analyze_arbitrage_pair`, `scan_arbitrage`, `discover_arbitrage_pairs`, `get_portfolio_summary`, `get_symbol_lots`. They dispatch **in-process to the services** — Sidekick is not an MCP client, so a tool here is a separate design decision from the MCP tool of the same name |
+| Inline rendered components in chat | `show_component` directive | **15 components**, registered on both sides (`chat_tools.BACKEND_COMPONENT_REGISTRY` ↔ `frontend/src/chat/componentRegistry.tsx`, strict prop specs, extra props rejected): `signals`, `live_price`, `price_chart`, `spread_payoff` (interactive: strike select/reprice backchannel), `arbitrage_pair`, `arbitrage_spread`, `arbitrage_premium`, `arbitrage_scan`, `arbitrage_discovery`, `portfolio_table`, `portfolio_allocation`, `symbol_lots`, `watchlist_fundamentals`, `fundamentals_top`, `fundamentals_score_changes` |
+| Owner scoping for the portfolio tools | resolved at the route from the signed-in principal | No tool takes an `owner`; a model-supplied one is discarded at dispatch. An unlinked identity degrades to a recoverable per-tool error, **not** a 403 on the whole turn — one unprovisioned portfolio mapping must not fail the price and technical tools in the same conversation |
 | BYOK key vault (add/rotate/unlock Anthropic key) | Settings page (`frontend/src/vault/`) | IndexedDB, passphrase PBKDF2 + AES-GCM; single-use envelope per turn |
 | Keyproxy handshake | `GET /api/keyproxy/publickey`, `POST /api/keyproxy/validate` | Envelope encryption pin + key validation; keyproxy itself is a separate IAM-locked Cloud Run service (`keyproxy/`) |
 
@@ -300,7 +349,7 @@ One unified **QuantCore** PostgreSQL database (17 tables, `psycopg2` via `QUANTC
 The React frontend has kept pace with options analytics and harvest workflows but not with the analysis synthesis tools. In priority order (full detail in the ⭐ section at top):
 
 1. **Trade recommendation + stop-loss panels** — the two most powerful synthesis endpoints, invisible in the UI.
-2. **A Fundamentals tab** — the entire 12-tool fundamentals domain surfaces only an earnings date.
+2. **A Fundamentals tab on Security Detail** — the cross-symbol half of the domain shipped as the `/fundamentals` page (#147 Part D), but the *per-ticker* half (composite score, revenue growth, earnings acceleration, score history) still surfaces only an earnings date.
 3. **Microstructure section on the Signals tab** — 3 ready endpoints, zero UI.
 4. **Options screener page** — covered-call/put screening exists as CLI/MCP/REST but not UI.
 5. **Chart overlays** — ATR bands, anchored VWAP, volume profile, relative strength; all one GET away.
@@ -311,11 +360,12 @@ The React frontend has kept pace with options analytics and harvest workflows bu
 1. Add a **Recommendation card** to Security Detail (`GET .../recommendation` + `.../stop-loss`) — highest value-to-effort ratio in the codebase.
 2. Add a **Fundamentals tab** to Security Detail reusing the existing tab pattern (`.../fundamentals` fan-out already aggregates score/revenue/acceleration).
 3. Append a **Microstructure section** to the existing Signals tab (`.../microstructure` returns all three signals in one call).
-4. Add **"Upcoming earnings" and "Top fundamentals" widgets** to the Dashboard (`/fundamentals/upcoming-earnings`, `/fundamentals/top`).
+4. ~~Add **"Upcoming earnings" and "Top fundamentals" widgets**~~ — **done**: both are panels on the `/fundamentals` page, and `fundamentals_top` / `fundamentals_score_changes` render as Sidekick cards off the same hooks.
 5. Delete `html_summary.py` / `simple_text_summary.py` (superseded legacy reports).
 
 ---
 
-**Document Version:** 2.1
-**Last Updated:** 2026-07-20 (merge-conflict reconciliation of the 2026-07-19 UI-gap-analysis refresh with the 2026-07-20 issue #93 support-tools recovery [PR #108]; MCP tool/REST endpoint counts re-verified against source rather than either prior document — 51 unique MCP tools / 53 registrations, 91 REST operations)
+**Document Version:** 2.2
+**Last Updated:** 2026-08-14 (issue #208 — the Sidekick tool audit. Added the missing `arbitrage-server` and `portfolio-server`, a new Arbitrage domain section, and MCP/Sidekick columns on Portfolio & Watchlist; corrected the tool count from "51 unique / 53 registrations across 5 servers" to **62 across 7**; deleted the dual-registration claim, which was never true in code; refreshed the Sidekick surface from 7 tools / 4 components to 13 / 15 and the page list to `navigation.tsx`. Counts verified with `grep -c "^@mcp.tool" fastMCPTest/*.py` — anchored, because the unanchored form counts a docstring)
+**Prior version:** 2.1, 2026-07-20 (merge-conflict reconciliation of the 2026-07-19 UI-gap-analysis refresh with the issue #93 support-tools recovery [PR #108])
 **Maintained By:** John Funk

--- a/docs/proposals/architectural-standard-v2.md
+++ b/docs/proposals/architectural-standard-v2.md
@@ -120,7 +120,8 @@ Thin adapters to external systems (yfinance, Polygon.io, future broker). Own API
 
 - Thin semantic wrappers: expose tool schemas, translate tool calls into HTTP requests against the REST tier, forward auth headers.
 - Generated from the FastAPI OpenAPI spec where sensible (`FastMCP.from_fastapi()` / `fastapi-mcp`), with **hand-curated** tool selection and LLM-facing descriptions.
-- **Never blanket-mirror the whole API.** Exposing an endpoint as a tool is a deliberate curation decision.
+- **The AI surface is a first-class client, and most REST capabilities should reach it.** What is forbidden is the *mechanical* mirror — one tool per endpoint, with parameters and descriptions inherited verbatim from the HTTP shape. A tool is designed against a model's context budget, not against the endpoint's response shape: `scan_arbitrage` returns summary rows rather than full per-pair statistics, because ten candidates with complete statistics each would crowd out the conversation they were meant to inform.
+- **Every new REST capability owes one of two artifacts, in the same PR:** a designed MCP tool — name, parameters, LLM-facing description, and what it deliberately omits — or a written decision recording why it stays REST-only. **Silence is not a decision.** The point of the rule is to force the design conversation while the endpoint is still being written, not to bias the answer toward "no": both outcomes are fine, and only the unrecorded one is a defect. Record it wherever the capability's design lives (the plan doc under `docs/proposals/`, or the [capabilities matrix](../capabilities-matrix.md) row), so the next reader can tell a deliberate omission from an oversight — the two are indistinguishable after the fact, which is how `discover_arbitrage_pairs` shipped a registered UI component with no tool to feed it.
 - Read-only by default. Write operations (plan mutations, future order placement) require explicit gating: confirmation step, idempotency key, full audit trail.
 
 ### 5.6 CLI / Cron
@@ -201,7 +202,7 @@ Target state for every capability in the [capabilities matrix](../capabilities-m
 
 1. **One service function** is the canonical implementation.
 2. **REST is the canonical remote surface** — every capability that any remote client needs gets an endpoint.
-3. **MCP and WebUI exposure are per-capability curation decisions**, not defaults. The matrix's surface columns become a checklist, not an accident of history.
+3. **MCP and WebUI exposure are per-capability design decisions that must be recorded** — see §5.5 for the MCP obligation. The matrix's surface columns become a checklist, not an accident of history: an empty cell should mean someone decided, and wrote down why.
 
 Approved idiom carried over from the matrix: **"MCP writes, REST reads"** for snapshot-style data (e.g., the options-chain flow where collection persists a snapshot and dashboards read the store) — provided both sides go through the same service.
 

--- a/docs/proposals/sidekick-tool-audit-plan.md
+++ b/docs/proposals/sidekick-tool-audit-plan.md
@@ -1,0 +1,326 @@
+# Sidekick's tool vocabulary — close the accidental gaps, make the deliberate ones legible
+
+**Source issue:** [#208](https://github.com/JohnFunkCode/StockPortfolioManager/issues/208)
+**Status:** **IN PROGRESS** — plan approved 2026-08-14, implementation started
+**Shape:** one PR, six commits (auth/route plumbing → `chat.py` → `chat_tools.py` → `registry.py` → tests → docs)
+**Related:** [`architectural-standard-v2.md`](architectural-standard-v2.md) (§5.5 is itself amended
+by this work), [`../capabilities-matrix.md`](../capabilities-matrix.md) (the doc the issue asks to
+re-align), [`byok-key-proxy-plan.md`](byok-key-proxy-plan.md) (#100 — the identity model the
+portfolio tools have to live inside)
+
+Line numbers were captured on **2026-08-14** against `main` at `988263b`. If one has drifted,
+search for the quoted code.
+
+---
+
+## The question, and the actual answer
+
+Issue #208 asks why Sidekick doesn't have access to all the tools across the MCP servers. The audit
+found three separate answers, and only one of them is the thing the title suspected.
+
+**1. Most of the gap is deliberate policy, working as designed.**
+[`architectural-standard-v2.md`](architectural-standard-v2.md) §5.5 already says exposing an
+endpoint as a tool is a curation decision, and commit `c5df10f` shows the reasoning applied
+concretely — `scan_arbitrage` returns summary rows rather than full per-pair statistics, because
+"ten candidates with complete statistics each would crowd the conversation's context window." That
+is not drift. Sidekick having 10 tools against the MCP servers' 62 is mostly a feature.
+
+**2. But `SYSTEM_PROMPT` is stale, and that is the likeliest cause of the reported symptom.**
+[`quantcore/services/chat.py:47`](../../quantcore/services/chat.py) names four components
+(`signals`, `live_price`, `price_chart`, `spread_payoff`) out of the **fourteen** registered in
+`BACKEND_COMPONENT_REGISTRY`, and never mentions the arbitrage, portfolio, or fundamentals tools at
+all. A model does not reach for a tool its own prompt never names. Every registry entry can be
+perfectly wired and the capability still won't surface in a conversation.
+
+**3. Two gaps are genuinely accidental.**
+
+| Gap | Evidence it was an oversight |
+|---|---|
+| `discover_arbitrage_pairs` | Its UI component `arbitrage_discovery` is **already registered on both sides** — `BACKEND_COMPONENT_REGISTRY` and `frontend/src/chat/componentRegistry.tsx` — with no tool able to produce the data it renders. Commit `45b9214` added four arbitrage viz components; commit `c5df10f` had added only three of the four arbitrage tools. |
+| `portfolio-server` | Zero chat-tool coverage across all six tools, while `portfolio_table` / `portfolio_allocation` / `symbol_lots` are all registered components. Sidekick can *render* a portfolio card but cannot reason over the numbers in prose — "how's my portfolio doing?" has no answer path. |
+
+## The second problem: the docs that hid all of this
+
+[`docs/capabilities-matrix.md`](../capabilities-matrix.md) exists specifically to keep
+MCP/REST/WebUI/Sidekick parity visible. It is stale on **both** sides of the comparison it is meant
+to make:
+
+| Claim in the matrix | Verified reality |
+|---|---|
+| 5 MCP servers, 51 unique tools (53 registrations) | **7 servers, 62 tools** |
+| `stock-price-server` has 29 tools | 21 |
+| `get_option_contracts` / `price_vertical_spread` are dual-registered on two servers | **False** — both exist only on `options-analysis-server`. No tool is dual-registered anywhere. |
+| Sidekick has 7 data tools + 4 components | 10 tools + 14 components (13 + 14 after this work) |
+| — | No "Domain: Arbitrage" section exists at all |
+| — | "Portfolio & Watchlist Management" has no MCP or Sidekick columns despite six MCP tools |
+
+**Correction, found during Step 4:** the dual-registration claim is *not* in
+[`CLAUDE.md`](../../CLAUDE.md) — that was an assumption in the original plan, and checking it before
+writing the fix is what caught it. CLAUDE.md carries a different stale number in the same class:
+"The 5 remote MCP servers in `.mcp.json`", when there are 7. That one *is* worse for the reason the
+plan gave — CLAUDE.md is auto-loaded into every agent session, so its wrong number is where every
+future agent starts. Fixed in this PR, with the count and the counting command written in beside it.
+
+Verified per-server counts — note the **anchored** pattern, `grep -c "^@mcp.tool" fastMCPTest/*.py`:
+
+| Server | Tools |
+|---|---|
+| `arbitrage-server` | 5 |
+| `company-fundamentals-server` | 12 |
+| `market-analysis-server` | 3 |
+| `news-sentiment-server` | 4 |
+| `options-analysis-server` | 11 |
+| `portfolio-server` | 6 |
+| `stock-price-server` | 21 |
+| **Total** | **62** |
+
+**Gotcha — anchor the grep.** The unanchored `grep -c "@mcp.tool"` reports **12** for
+`options-analysis` instead of 11: the module docstring in `fastMCPTest/options_analysis.py` mentions
+`@mcp.tool()` in prose, and it counts. Total comes out 63, one tool that does not exist. Every count
+in this plan and in the matrix was taken with `^@mcp.tool`.
+
+## The third problem: §5.5 says the opposite of what it means
+
+> **Never blanket-mirror the whole API.** Exposing an endpoint as a tool is a deliberate curation
+> decision.
+
+Read cold, that discourages exposure. The actual intent is the opposite: most APIs *should* reach an
+MCP tool — thoughtfully shaped rather than mechanically derived. As written, the rule gives cover to
+simply not exposing something, and never requires anyone to say why. That is precisely how
+`discover_arbitrage_pairs` and `portfolio-server` fell through: silence looked like compliance.
+
+---
+
+## Step 1 — Rewrite §5.5 of the architectural standard
+
+[`docs/proposals/architectural-standard-v2.md:119-124`](architectural-standard-v2.md). Invert the
+rule from *default closed* to *default considered*:
+
+- Most REST capabilities **should** reach an MCP tool — the AI surface is a first-class client, not
+  an afterthought. What is forbidden is the **mechanical** mirror: one tool per endpoint, with
+  parameters and descriptions inherited verbatim from the HTTP shape.
+- A tool's shape is designed against a model's context budget, not the endpoint's response shape.
+  Cite `scan_arbitrage` as the worked precedent.
+- **Every new REST capability owes one of two artifacts in the same PR**: a designed MCP tool (name,
+  parameters, LLM-facing description, and what it deliberately omits), or a written decision
+  recording why it stays REST-only. **Silence is not a decision.**
+- The read-only-by-default and write-gating bullets stay unchanged.
+
+Then update §7 item 3 (line 204) to point at the strengthened §5.5 rather than restating
+"curation decisions, not defaults" on its own terms.
+
+**How to know it worked:** a reader who has just added a REST endpoint can tell from §5.5 alone what
+they now owe, and reviewers have something checkable to ask for.
+
+## Step 2 — Three new tools
+
+### 2a. `quantcore/services/chat_tools.py` — three `TOOL_SCHEMAS` entries
+
+Modeled on the existing arbitrage entries: say what the tool does, what it deliberately *isn't*, and
+which `show_component` call to pair it with.
+
+| Tool | Parameters | Notes |
+|---|---|---|
+| `discover_arbitrage_pairs` | `symbols` (required, comma-separated), `references`, `days`, `min_abs_correlation`, `require_economic_link` | Description must state that discovered pairs get **no NAV math and no convergence claim** — they are candidates for curation into `arb_universe.yaml`, not signals. Pairs with `show_component('arbitrage_discovery', …)`. |
+| `get_portfolio_summary` | none | Cost basis, current value, gain/loss $ and %, dollars-per-day. |
+| `get_symbol_lots` | `ticker` | Per-lot quantity, purchase price, trade date, gain/loss. |
+
+**No `owner` parameter on any of them, ever.** This extends the existing `show_component` decision
+(the model never picks whose data it sees) from component props to tool arguments. `show_component`'s
+own schema needs no change — all four target components are already registered on both sides.
+
+### 2b. `quantcore/services/chat.py` — handlers, and the owner question
+
+`_handlers` gains `discover_arbitrage_pairs` inside the existing `if arbitrage is not None:` block
+([`chat.py:351`](../../quantcore/services/chat.py)), plus a parallel `if portfolio is not None:`
+block for the two portfolio tools. Handlers call services directly in-process, matching how the
+arbitrage handlers already work — the documented Sidekick exception to Rule 6.
+
+**The crux: how a BYOK chat session resolves `owner`.** `PortfolioService` methods all take `owner`.
+The only existing resolver, `require_owner` ([`api/auth.py:240`](../../api/auth.py)), **403s the
+entire request** on an unmapped identity. Three options, and why the third wins:
+
+| Option | Why not |
+|---|---|
+| Reuse `require_owner` on the chat route | A chat turn serves many non-owner-scoped tools. Failing the whole turn — killing `get_stock_price` too — because portfolio identity is unprovisioned is a bad trade. |
+| Default to `"john"` | A silent cross-user data leak the moment a second identity exists. Directly contradicts the principle behind decision #20. |
+| **Soft-resolve at the route, degrade per tool call** | Fails closed on the one capability that needs an owner, leaves the rest of the turn standing. |
+
+The chosen design:
+
+1. Add `resolve_owner_or_none(principal)` beside `require_owner` in
+   [`api/auth.py`](../../api/auth.py) — identical logic, returns `None` instead of raising, logs a
+   **distinct** event name (`unmapped_principal_soft`) so the soft path stays distinguishable from
+   the hard 403 in monitoring. Never auto-provisions.
+2. [`api/routers/chat.py`](../../api/routers/chat.py) stays on `require_principal` and threads the
+   result into a new `TurnContext.owner` field.
+3. In `stream_chat`'s dispatch loop, add one owner-scoped special case beside the existing
+   `show_component` one ([`chat.py:447`](../../quantcore/services/chat.py)): strip any
+   model-supplied `owner` key, and if `context.owner is None`, emit a recoverable `is_error` tool
+   result explaining the account isn't linked — **without ever touching the portfolio service**.
+   Otherwise inject the resolved owner and fall through to the generic dispatch, reusing its
+   existing status/error/logging machinery.
+
+`registry.py` gains `portfolio=portfolio` on the `ChatService(...)` call. `portfolio` is already
+constructed above `chat`, so no ordering change. `IdentityService` deliberately stays **out** of
+`ChatService` — owner resolution belongs at the route boundary, and threading identity into the chat
+service would give it a dependency it has so far avoided.
+
+**One guard worth flagging in review:** the 25-symbol / 10-reference caps on discovery live only in
+[`api/routers/arbitrage.py:29-30`](../../api/routers/arbitrage.py), not in
+`ArbitrageService.discover_pairs()`. Sidekick calls the service directly, bypassing that route, so
+the cap must be re-asserted in the handler as a `ValueError` — which `stream_chat` already surfaces
+as a recoverable tool error — or an LLM tool call can trigger an uncapped sweep. This makes
+discovery stricter than its arbitrage siblings (`analyze_arbitrage_pair` and `scan_arbitrage` have
+schema-declared day bounds that nothing enforces server-side); say so in the PR so it doesn't read
+as accidental inconsistency.
+
+## Step 3 — Fix `SYSTEM_PROMPT`
+
+Targeted rewrite of the intro paragraphs, not a restructure. It should:
+
+- name the tool **categories** including arbitrage and portfolio;
+- say all fourteen components exist and that `show_component`'s own description is the authority on
+  their props — re-enumerating props in the prompt only guarantees it re-stales;
+- state plainly that portfolio tools always read the caller's own holdings, and that the
+  unlinked-account case gets reported rather than guessed around.
+
+Spot-check the rest of the prompt for other four-component-era references while in there.
+
+## Step 4 — Re-align `docs/capabilities-matrix.md`
+
+In document order: header stats + `Last Updated`; the Tier-1 mitigation note; the Six Surfaces
+table's Sidekick row; the Capability Summary table (MCP count, and the Sidekick row's full 13-name
+list — this table is the right home for an exhaustive list, unlike the system prompt); the
+per-server tool-count footnote (full rewrite to the verified numbers, dual-registration claim
+dropped); the Options Analysis table's false `(both servers)` parentheticals; a **new Domain:
+Arbitrage section** placed after Options Analysis; Portfolio & Watchlist expanded from 4 columns to
+6 with MCP Tool and Sidekick columns; the Sidekick Chat & BYOK domain's tool and component lists;
+footer version `2.1` → `2.2` with a changelog line naming this issue.
+
+Also fix the same false dual-registration claim in [`CLAUDE.md`](../../CLAUDE.md) — a stale number in
+the auto-loaded file is the one that propagates furthest.
+
+## Step 5 — Tests
+
+- [`tests/test_chat_protocol.py`](../../tests/test_chat_protocol.py) — three new names in
+  `EXPECTED_TOOLS` (14 total). Add a schema-level assertion that `"owner"` is never a property on
+  the two portfolio tools, mirroring the component-level `owner` rejection test already in
+  [`tests/test_chat_tools.py`](../../tests/test_chat_tools.py).
+- [`tests/test_chat_service.py`](../../tests/test_chat_service.py) — extend `ChatServiceTestBase`
+  with a `portfolio` mock, then add `TestArbitrageDiscoveryTool` and `TestPortfolioTools` following
+  the existing `TestArbitrageTools` patterns. The four cases that matter:
+  1. comma-split parsing of `symbols` / `references`;
+  2. over-cap rejection **without** calling the service;
+  3. `context.owner is None` degrades gracefully **without touching the portfolio mock**;
+  4. a model-hallucinated `owner` argument is discarded in favour of the resolved one.
+- `tests/test_chat_tools.py` needs no changes — its component-directive coverage already spans all
+  four target components.
+- **No frontend changes.** No new component is registered, so `componentRegistry.tsx` and its vitest
+  suite are untouched.
+
+## Verification
+
+```bash
+python -m unittest tests.test_chat_protocol tests.test_chat_service tests.test_chat_tools
+```
+
+```bash
+python -m unittest discover -s tests -t .
+```
+
+Then exercise it rather than trusting the unit tests. Start the API
+(`uvicorn api.main:app --host 127.0.0.1 --port 5001`) and in one Sidekick session ask:
+
+1. "find cointegrated pairs among MSTR, COIN, MARA" — should call the new tool **and** render
+   `arbitrage_discovery`;
+2. "how's my portfolio doing?" — prose totals, not just a card;
+3. "how many shares of AAPL do I own and what's my basis?"
+
+Confirm the unlinked-owner path separately: a principal with no identity mapping should get a clear
+explanation for the portfolio question while price/technical questions in the same turn still work.
+
+Re-check the finished matrix counts against `grep -c "^@mcp.tool" fastMCPTest/*.py` — **anchored**,
+per the gotcha above — rather than against this document.
+
+---
+
+## Checkpoint log
+
+*(Append one entry as each step lands — including what misled you, not just what worked.)*
+
+- **2026-08-14 — plan approved.** Scope set by two explicit decisions from John: the stale
+  `SYSTEM_PROMPT` is in scope (not deferred to a follow-up issue), and the two accidental tool gaps
+  get **implemented**, not merely recommended. The §5.5 rewrite was added to scope mid-planning.
+
+- **2026-08-14 — Step 1 landed (§5.5).** Rewrote the rule from a prohibition ("never blanket-mirror
+  the whole API") into a design gate: most REST capabilities *should* reach a tool, what's forbidden
+  is the mechanical one-tool-per-endpoint mirror, and **every new REST capability owes one of two
+  artifacts in the same PR** — a designed tool, or a written decision that it stays REST-only.
+  Silence stops counting as a decision. §7 item 3 now points at §5.5 instead of restating it in its
+  own words, so the two can't drift apart.
+
+- **2026-08-14 — Step 2 landed (three tools).** `discover_arbitrage_pairs`,
+  `get_portfolio_summary`, `get_symbol_lots` in `chat_tools.py`; handlers in `chat.py`;
+  `portfolio=portfolio` on the `ChatService(...)` call in `registry.py` (no ordering change —
+  `portfolio` is already constructed above `chat`).
+
+  Two things worth recording. **First, the owner question resolved as designed but the reasoning
+  is the load-bearing part**: `resolve_owner_or_none` sits beside `require_owner` in `api/auth.py`
+  and returns `None` where the other 403s, because a chat turn serves many non-owner-scoped tools
+  and failing all of them over unprovisioned portfolio identity is a bad trade — while defaulting
+  to `"john"` would be a silent cross-user leak the moment a second identity exists. The unlinked
+  case degrades to a recoverable per-tool `is_error`, never a whole-turn failure. A model-supplied
+  `owner` key is stripped at dispatch regardless.
+
+  **Second, the cap on discovery had to be re-asserted in the handler.** `MAX_DISCOVER_SYMBOLS`
+  (25) / `MAX_DISCOVER_REFERENCES` (10) were enforced only in `api/routers/arbitrage.py`. Sidekick
+  dispatches **in-process**, so it never passes through that route — the cap would simply not have
+  existed for chat. They now live on `ArbitrageService` with both the route and the handler
+  asserting them. This is the general hazard, not a one-off: *any* guard implemented at the REST
+  boundary is invisible to Sidekick, because Sidekick is not an MCP client and does not speak HTTP.
+
+- **2026-08-14 — Step 3 landed (`SYSTEM_PROMPT`).** This was the likeliest real cause of the
+  reported symptom, and the fix is deliberately un-clever: the prompt now names the tool
+  *categories* including arbitrage and portfolio, and says `show_component`'s own description is
+  the authority on which components exist and what props they take — **it states no count**. The
+  previous version hard-coded four component names and went stale the moment a fifth was
+  registered; a prompt that points at the registry cannot go stale the same way. That turned out to
+  matter within the hour: an intermediate draft of the docs said 14 components when the registry
+  holds 15, and the prompt needed no correction because it had no number in it.
+
+- **2026-08-14 — Step 5 landed (tests).** `EXPECTED_TOOLS` in `tests/test_chat_protocol.py` grew to
+  14, plus a schema assertion that `"owner"` is never a property on the two portfolio tools.
+  `tests/test_chat_service.py` gained `TestArbitrageDiscoveryTool` and `TestPortfolioTools` over a
+  new `portfolio` mock on `ChatServiceTestBase`. The four cases that carry weight: comma-split
+  parsing; over-cap rejection **without** the service being called; `context.owner is None`
+  degrading gracefully **without touching the portfolio mock at all**; and a hallucinated `owner`
+  argument being discarded in favour of the resolved one. Full suite green — `OK (skipped=5)`.
+
+- **2026-08-14 — Step 4 landed (`capabilities-matrix.md` + `CLAUDE.md`).** Counts corrected from
+  "51 unique / 53 registrations across 5 servers" to **62 across 7**; the dual-registration claim
+  deleted; new Domain: Arbitrage section; Portfolio & Watchlist widened 4 → 6 columns; Sidekick
+  refreshed to 13 tools / 15 components; document version 2.2.
+
+  Three things misled me here, all caught by checking rather than by writing:
+
+  1. **The plan asserted CLAUDE.md repeated the dual-registration claim. It does not** — that was an
+     assumption carried into the plan from the matrix. Had I "fixed" it without looking I'd have
+     either edited nothing and claimed a fix, or invented a sentence to correct. CLAUDE.md's actual
+     stale number was "5 remote MCP servers" (there are 7), now fixed with the counting command
+     written in beside it.
+  2. **I invented a REST path from memory** — `GET /api/portfolio/{ticker}/lots` — for the
+     `get_symbol_lots` row. The real surface is `GET /api/portfolio/symbols` (positions, and
+     `totals` for the summary) and `GET /api/portfolio/lots` (all lots, filtered to the ticker by
+     the caller). A plausible-looking path is the easiest thing in a doc like this to get wrong and
+     the hardest for a reader to doubt.
+  3. **The 29 → 21 drop on stock-price needed a cause, not a guess.** `git log` on
+     `fastMCPTest/stock_price_server.py` gives it: `60e4bcd`, "consolidate options tools onto
+     options-analysis-server". The footnote cites the commit, so the next person who finds an old
+     29 somewhere can resolve it instead of re-deriving it.
+
+  The ⭐ "Built But Not Yet Surfaced" section was **not** re-audited — that is its own piece of
+  work. Rows known false were corrected (the cross-symbol fundamentals screeners are closed by the
+  `/fundamentals` page, #147 Part D), and the section carries a dated caveat saying the rest was
+  last verified 2026-07-20. A stale-but-labelled list beats both a confidently wrong one and an
+  unscoped re-audit bolted onto this PR.

--- a/quantcore/services/arbitrage.py
+++ b/quantcore/services/arbitrage.py
@@ -73,6 +73,15 @@ REFERENCE_PANEL = {
 STALE_HOLDINGS_DAYS = 45
 DEFAULT_HORIZON_DAYS = 180
 
+# Discovery caps. ``discover_pairs`` itself does not enforce these — an
+# in-process caller with a deliberate list is allowed a big sweep — but every
+# caller that takes its symbol list from *outside* must, because the work is
+# O(symbols x references) history fetches. The constants live here rather than
+# in api/routers/arbitrage.py so the REST route and the Sidekick tool handler
+# (issue #208) cannot drift to different numbers; they are the same limit.
+MAX_DISCOVER_SYMBOLS = 25
+MAX_DISCOVER_REFERENCES = 10
+
 
 def _round(val, digits: int = 2):
     try:

--- a/quantcore/services/chat.py
+++ b/quantcore/services/chat.py
@@ -33,6 +33,8 @@ import math
 import os
 import uuid
 from dataclasses import dataclass, field
+from datetime import date, datetime
+from decimal import Decimal
 from typing import Callable, Iterator, Protocol
 
 from quantcore.error_text import safe_error_text
@@ -45,23 +47,37 @@ from quantcore.services.chat_tools import (
 logger = logging.getLogger(__name__)
 
 SYSTEM_PROMPT = """You are the QuantCore sidekick — a market-analysis assistant embedded in the
-QuantUI portfolio dashboard. You have data tools for prices, technical signals,
-RSI, MACD, fundamental scores, news sentiment, and vertical option spread
-pricing (price_vertical_spread — real contracts, real bid/ask).
+QuantUI portfolio dashboard. Your data tools span prices and technical signals
+(RSI, MACD, and the rest), company fundamental scores, news sentiment,
+vertical option spread pricing (price_vertical_spread — real contracts, real
+bid/ask), arbitrage (the curated pair universe, a scan across it, a workup on
+one pair, and a statistical sweep for undeclared links), and the signed-in
+user's own portfolio (totals, and the lots behind a single symbol). Each
+tool's own description — not this prompt — is the authority on what it takes,
+what it returns, and what it deliberately leaves out; read it before reaching
+for the tool.
+
+The portfolio tools always read the holdings of whoever is signed in. They
+take no owner, there is no way to ask for anyone else's, and you must never
+try. If one comes back saying the account is not linked to a portfolio, say
+exactly that and that an administrator has to link it — never guess at,
+estimate, or invent positions to fill the gap.
 
 You can also render live UI components inline in the conversation with the
-show_component tool: 'signals' (full technical/options/risk signal panel),
-'live_price' (compact auto-refreshing price chip), 'price_chart' (price
-history chart with moving averages), and 'spread_payoff' (interactive risk
-graph for a vertical spread — expiration payoff plus a value-today curve).
-After pricing a spread with price_vertical_spread, always render it with
-show_component('spread_payoff', {ticker, expiration, long_strike,
-short_strike, kind}) using the exact same parameters. After discussing a
-single ticker, prefer showing the relevant component so the user sees live
-data — the component fetches its own data; don't restate numbers that a
-component you just rendered is already showing. Components are single-ticker
-only: when the user asks about several symbols at once, give the numbers in
-prose instead.
+show_component tool. Its own description lists every available component and
+the exact props each one takes; treat that list as the authority rather than
+anything you remember. They cover technical signals and price history, spread
+payoff diagrams, the arbitrage cards, portfolio and per-symbol lot views, and
+the watchlist and fundamentals rankings. After pricing a spread with
+price_vertical_spread, always render it with show_component('spread_payoff',
+{ticker, expiration, long_strike, short_strike, kind}) using the exact same
+parameters. After discussing a single ticker, prefer showing the relevant
+component so the user sees live data — the component fetches its own data;
+don't restate numbers that a component you just rendered is already showing.
+Most components are single-ticker: when the user asks about several symbols at
+once, give the numbers in prose instead, unless a component already covers the
+whole set (the scan, discovery, portfolio, watchlist, and fundamentals cards
+each do).
 
 Rendered components are interactive: when the user clicks inside one (a
 strike on a spread_payoff chart, a point on a price_chart), their message
@@ -206,6 +222,13 @@ class TurnContext:
     # allow-list and the caller's stored setting before use — see
     # ChatService._resolve_model.
     model: str | None = None
+    # Canonical owner for this turn's owner-scoped tools, soft-resolved by the
+    # route (issue #208). ``None`` means the caller's identity has no
+    # owner_identities mapping — the portfolio tools refuse rather than guess,
+    # and every other tool in the turn is unaffected. Never model-supplied:
+    # no tool schema carries an ``owner`` parameter, and the dispatch strips
+    # one if a model invents it.
+    owner: str | None = None
 
 
 ENVELOPE_REQUIRED_MESSAGE = (
@@ -213,6 +236,27 @@ ENVELOPE_REQUIRED_MESSAGE = (
 )
 CHAT_NOT_CONFIGURED_MESSAGE = (
     "The chat sidekick is not configured on this deployment."
+)
+
+# Tools that read the caller's own holdings. The dispatch loop injects
+# TurnContext.owner into these and only these — none of them declares an
+# `owner` parameter in its schema, so the model can neither choose nor
+# influence whose data it sees (the same rule show_component's props follow).
+OWNER_SCOPED_TOOLS = frozenset({"get_portfolio_summary", "get_symbol_lots"})
+
+# Mirrors quantcore/services/arbitrage.py's caps of the same name. They are
+# copied rather than imported because a service module never imports another
+# service module (registry.py's acyclic rule) — and copied numbers drift, so
+# tests/test_chat_service.py asserts the two definitions are equal.
+MAX_DISCOVER_SYMBOLS = 25
+MAX_DISCOVER_REFERENCES = 10
+
+# Returned to the *model* (as a recoverable tool error), not to the user, so it
+# can explain the situation in its own words rather than parroting a string.
+OWNER_UNRESOLVED_MESSAGE = (
+    "This account is not linked to a portfolio, so holdings are unavailable. "
+    "Tell the user their sign-in has no portfolio mapping yet and that an "
+    "administrator has to link it; do not guess at or invent any positions."
 )
 
 
@@ -250,6 +294,39 @@ def _sanitize(value):
         return {k: _sanitize(v) for k, v in value.items()}
     if isinstance(value, (list, tuple)):
         return [_sanitize(v) for v in value]
+    return value
+
+
+def _split_csv(raw) -> list[str]:
+    """Comma-separated tool argument -> upper-cased ticker list.
+
+    Models pass lists as strings here (every multi-symbol tool schema declares
+    a string), and they pass them untidily: trailing commas, stray spaces,
+    lower case. All three are the caller's problem to absorb, not the
+    service's."""
+    if raw is None:
+        return []
+    if isinstance(raw, (list, tuple)):
+        parts = raw
+    else:
+        parts = str(raw).split(",")
+    return [str(p).strip().upper() for p in parts if str(p).strip()]
+
+
+def _plain(value):
+    """Coerce a repository/service value into something json.dumps accepts.
+
+    The portfolio service speaks Decimal and date — correct for money and for
+    the REST tier, which has QuantCoreJSONResponse to encode them. A tool result
+    is hand-serialized with json.dumps instead, and chat.py must not import the
+    api package to borrow its encoder, so the conversion happens here. Decimals
+    become floats deliberately: the model is going to talk about these numbers,
+    not settle a trade with them.
+    """
+    if isinstance(value, Decimal):
+        return float(value)
+    if isinstance(value, (date, datetime)):
+        return value.isoformat()
     return value
 
 
@@ -299,6 +376,7 @@ class ChatService:
         sentiment,
         options,
         arbitrage=None,
+        portfolio=None,
         model: str = "claude-sonnet-5",
         effort: str = "medium",
         max_iterations: int = 8,
@@ -311,6 +389,7 @@ class ChatService:
         self._sentiment = sentiment
         self._options = options
         self._arbitrage = arbitrage
+        self._portfolio = portfolio
         self._model = model
         self._effort = effort
         self._max_iterations = max_iterations
@@ -368,7 +447,117 @@ class ChatService:
                     )
                 ),
                 "list_arbitrage_universe": lambda: self._arbitrage.get_universe(),
+                "discover_arbitrage_pairs": self._discover_arbitrage_pairs,
             })
+        if portfolio is not None:
+            self._handlers.update({
+                "get_portfolio_summary": self._portfolio_summary,
+                "get_symbol_lots": self._symbol_lots,
+            })
+
+    # ------------------------------------------------------------------
+    # Tool handlers that need more than a lambda (issue #208)
+    # ------------------------------------------------------------------
+    def _discover_arbitrage_pairs(
+        self,
+        symbols,
+        references=None,
+        days=365,
+        min_abs_correlation=0.4,
+        require_economic_link=True,
+    ):
+        """Cointegration sweep over an ad-hoc symbol list.
+
+        The caps are re-asserted here on purpose. They are declared in
+        api/routers/arbitrage.py, but Sidekick calls ArbitrageService directly
+        (the documented in-process exception to Rule 6) and so never passes
+        through that route — leaving the service's own `discover_pairs`, which
+        enforces nothing, reachable from a model-authored argument list. A
+        sweep is O(symbols x references) fetches; an LLM that decides to pass
+        200 tickers should get a tool error it can read and retry, which is
+        what raising ValueError here produces.
+        """
+        tickers = _split_csv(symbols)
+        refs = _split_csv(references)
+        if not tickers:
+            raise ValueError("symbols is required: pass at least one ticker.")
+        if len(tickers) > MAX_DISCOVER_SYMBOLS:
+            raise ValueError(
+                f"too many symbols ({len(tickers)}); "
+                f"discovery accepts at most {MAX_DISCOVER_SYMBOLS} per call."
+            )
+        if len(refs) > MAX_DISCOVER_REFERENCES:
+            raise ValueError(
+                f"too many references ({len(refs)}); "
+                f"discovery accepts at most {MAX_DISCOVER_REFERENCES} per call."
+            )
+        return self._arbitrage.discover_pairs(
+            tickers,
+            references=refs or None,
+            days=days,
+            min_abs_correlation=min_abs_correlation,
+            require_economic_link=require_economic_link,
+        )
+
+    def _portfolio_summary(self, owner: str):
+        """Portfolio-wide totals plus one compact line per symbol.
+
+        Deliberately not `symbol_rows()` as-is: each of those rows carries its
+        open lots, period-return columns, hedge bias and allocation segments —
+        the Portfolio page needs all of it to draw, and a conversation needs
+        none of it to answer "how am I doing?". Same reasoning as
+        `scan_arbitrage`'s summary rows. Per-lot detail is a separate tool the
+        model can reach for on one symbol (`get_symbol_lots`).
+        """
+        rows = self._portfolio.symbol_rows(owner)
+        totals = self._portfolio.portfolio_totals(rows)
+        return {
+            "totals": {k: _plain(v) for k, v in totals.items()},
+            "positions": [
+                {
+                    "symbol": row["symbol"],
+                    "lot_count": len(row["lots"]),
+                    **{
+                        k: _plain(row.get(k))
+                        for k in (
+                            "total_investment",
+                            "total_current_value",
+                            "total_gain_loss",
+                            "total_gain_loss_pct",
+                            "total_dollars_per_day",
+                        )
+                    },
+                }
+                for row in rows
+            ],
+        }
+
+    def _symbol_lots(self, owner: str, ticker: str):
+        """The caller's open lots for one symbol, with per-lot gain/loss.
+
+        Filtered from the batched `list_lots()` rather than a per-symbol query
+        so the tool inherits its one cached quote fetch.
+        """
+        symbol = (ticker or "").strip().upper()
+        lots = [
+            {
+                key: _plain(lot.get(key))
+                for key in (
+                    "quantity",
+                    "purchase_price",
+                    "trade_date",
+                    "current_price",
+                    "gain_loss",
+                    "gain_loss_pct",
+                    "days_held",
+                    "dollars_per_day",
+                    "price_stale",
+                )
+            }
+            for lot in self._portfolio.list_lots(owner, status="OPEN")
+            if lot["symbol"] == symbol
+        ]
+        return {"symbol": symbol, "lot_count": len(lots), "lots": lots}
 
     def _resolve_model(self, context: TurnContext) -> str:
         """Requested model wins if allow-listed; else fall back to the
@@ -460,6 +649,29 @@ class ChatService:
                             degraded.append(tu.name)
                         continue
 
+                    call_args = args
+                    if tu.name in OWNER_SCOPED_TOOLS:
+                        # The model never chooses whose holdings it reads. Drop
+                        # any `owner` it invented — no schema declares one, so
+                        # its presence means a hallucination, and passing it
+                        # through would be a cross-user read.
+                        args.pop("owner", None)
+                        if context.owner is None:
+                            # Fail closed on this tool alone: the rest of the
+                            # turn's tools do not need an identity and keep
+                            # working. Never reaches PortfolioService.
+                            yield ToolStatus(tool=tu.name, args=args, state="error")
+                            results.append(
+                                _tool_result(tu.id, OWNER_UNRESOLVED_MESSAGE, is_error=True)
+                            )
+                            degraded.append(tu.name)
+                            continue
+                        # Resolved identity goes to the handler, not into the
+                        # ToolStatus the UI renders — it is plumbing, and the
+                        # user already knows whose portfolio they are asking
+                        # about.
+                        call_args = {**args, "owner": context.owner}
+
                     yield ToolStatus(tool=tu.name, args=args, state="running")
                     handler = self._handlers.get(tu.name)
                     if handler is None:
@@ -470,7 +682,7 @@ class ChatService:
                         degraded.append(tu.name)
                         continue
                     try:
-                        out = handler(**args)
+                        out = handler(**call_args)
                     except Exception as exc:  # noqa: BLE001 — model gets to recover
                         safe_exc = safe_error_text(exc)
                         logger.warning("chat tool %s failed: %s", tu.name, safe_exc)

--- a/quantcore/services/chat_tools.py
+++ b/quantcore/services/chat_tools.py
@@ -350,6 +350,110 @@ TOOL_SCHEMAS: list[dict] = [
         "input_schema": {"type": "object", "properties": {}, "required": []},
     },
     {
+        "name": "discover_arbitrage_pairs",
+        "description": (
+            "Sweep an ad-hoc list of symbols for statistically cointegrated "
+            "links against a reference panel, gated by a sector/industry "
+            "economic-link filter. Use when the user names symbols the curated "
+            "universe does not cover ('is there a pair trade in MARA and "
+            "RIOT?').\n\n"
+            "What this does NOT produce: no NAV, no fair value, no convergence "
+            "mechanism, no verdict. A discovered pair is a statistical "
+            "relationship and a candidate for curation into arb_universe.yaml "
+            "— never present one as a trade or imply the spread will close. "
+            "list_arbitrage_universe and analyze_arbitrage_pair are the tools "
+            "that carry an actual convergence claim.\n\n"
+            "Render the result with "
+            "show_component('arbitrage_discovery', {'symbols': SYMBOLS}) using "
+            "the same comma-separated list you passed here."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "symbols": {
+                    "type": "string",
+                    "description": (
+                        "Comma-separated tickers to sweep, at most 25. Each one "
+                        "costs a price-history fetch, so pass what the user "
+                        "actually asked about rather than a broad list."
+                    ),
+                },
+                "references": {
+                    "type": "string",
+                    "description": (
+                        "Optional comma-separated tickers to test against, at "
+                        "most 10. Omit to use the built-in reference panel."
+                    ),
+                },
+                "days": {
+                    "type": "integer",
+                    "minimum": 30,
+                    "maximum": 3650,
+                    "description": "Days of daily history per pair (default 365)",
+                },
+                "min_abs_correlation": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1,
+                    "description": (
+                        "Correlation floor a pair must clear before the "
+                        "cointegration test runs (default 0.4)"
+                    ),
+                },
+                "require_economic_link": {
+                    "type": "boolean",
+                    "description": (
+                        "Keep only pairs with a plausible sector/industry link "
+                        "(default true). Setting this false surfaces spurious "
+                        "correlations — say so if you use it."
+                    ),
+                },
+            },
+            "required": ["symbols"],
+        },
+    },
+    {
+        "name": "get_portfolio_summary",
+        "description": (
+            "The user's own holdings: portfolio-wide cost basis, current value, "
+            "gain/loss in dollars and percent, and dollars-per-day, plus the "
+            "same five figures per symbol. Use for 'how's my portfolio doing?', "
+            "'what do I own?', or before advising on a symbol, to check whether "
+            "they already hold it.\n\n"
+            "Summary only — no per-lot detail. Call get_symbol_lots for one "
+            "symbol's individual purchases. Pair with "
+            "show_component('portfolio_table', {}) when the user wants the "
+            "table, or 'portfolio_allocation' for the allocation view.\n\n"
+            "Takes no parameters: it always reads the signed-in user's own "
+            "portfolio, and there is no way to ask for anyone else's."
+        ),
+        "input_schema": {"type": "object", "properties": {}, "required": []},
+    },
+    {
+        "name": "get_symbol_lots",
+        "description": (
+            "The user's individual open purchase lots for one symbol they own — "
+            "quantity, purchase price, trade date, current price, and each "
+            "lot's own gain/loss and days held. Use for 'how many shares of X "
+            "do I have?', 'what's my basis in X?', or when a harvest/trim "
+            "question needs to know which lots exist.\n\n"
+            "Returns an empty lots list if the user does not hold the symbol — "
+            "that means they own none of it, not that the lookup failed. Pair "
+            "with show_component('symbol_lots', {'ticker': SYMBOL}).\n\n"
+            "Always reads the signed-in user's own holdings."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "ticker": {
+                    "type": "string",
+                    "description": "Stock symbol, e.g. AAPL",
+                },
+            },
+            "required": ["ticker"],
+        },
+    },
+    {
         "name": "show_component",
         "description": (
             "Render a live, data-bound UI component inline in the conversation. "

--- a/quantcore/services/registry.py
+++ b/quantcore/services/registry.py
@@ -230,6 +230,7 @@ def get_services() -> Services:
         sentiment=sentiment,
         options=options,
         arbitrage=arbitrage,
+        portfolio=portfolio,
         model=chat_model,
         effort=chat_effort,
         max_iterations=int(os.environ.get("CHAT_MAX_TOOL_ITERATIONS", "8")),

--- a/tests/test_chat_protocol.py
+++ b/tests/test_chat_protocol.py
@@ -330,8 +330,12 @@ class TestToolSchemas(unittest.TestCase):
         "analyze_arbitrage_pair",
         "scan_arbitrage",
         "list_arbitrage_universe",
+        "discover_arbitrage_pairs",
+        "get_portfolio_summary",
+        "get_symbol_lots",
         "show_component",
     }
+    OWNER_SCOPED_TOOLS = {"get_portfolio_summary", "get_symbol_lots"}
 
     def test_expected_tool_names_present(self):
         names = {t["name"] for t in TOOL_SCHEMAS}
@@ -377,6 +381,29 @@ class TestToolSchemas(unittest.TestCase):
         self.assertIn("premium_discount_pct", description)
         self.assertIn("gross_premium_discount_pct", description)
         self.assertIn("senior", description.lower())
+
+    def test_portfolio_tools_declare_no_owner_parameter(self):
+        """The model never chooses whose holdings it reads (issue #126 decision
+        #20). The component registry already refuses an `owner` prop; the tool
+        schemas have to refuse it too, or the same cross-user read arrives one
+        layer earlier. ChatService drops a hallucinated `owner` at dispatch —
+        this keeps the model from ever being told the argument exists.
+        """
+        for name in self.OWNER_SCOPED_TOOLS:
+            tool = next(t for t in TOOL_SCHEMAS if t["name"] == name)
+            properties = tool["input_schema"].get("properties", {})
+            self.assertNotIn("owner", properties, name)
+            self.assertNotIn("owner", tool["input_schema"].get("required", []), name)
+
+    def test_discovery_tool_disclaims_a_convergence_verdict(self):
+        """A discovered pair is a curation candidate, not a signal: there is no
+        NAV, no fair value, and no convergence mechanism behind it. A model that
+        presents correlation as an opportunity reproduces exactly what the
+        curated universe exists to prevent."""
+        tool = next(t for t in TOOL_SCHEMAS if t["name"] == "discover_arbitrage_pairs")
+        description = tool["description"].lower()
+        self.assertIn("candidate", description)
+        self.assertIn("convergence", description)
 
     def test_scan_tool_frames_an_empty_result_as_a_finding(self):
         """Most scans return nothing above 'watch'; the model must report that

--- a/tests/test_chat_service.py
+++ b/tests/test_chat_service.py
@@ -11,6 +11,8 @@ the db_safety preamble); services are plain Mocks.
 import json
 import math
 import unittest
+from datetime import date
+from decimal import Decimal
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -73,14 +75,16 @@ class ChatServiceTestBase(unittest.TestCase):
         self.sentiment = Mock()
         self.options = Mock()
         self.arbitrage = Mock()
+        self.portfolio = Mock()
 
-    def make_service(self, client, max_iterations=8, arbitrage=_UNSET):
+    def make_service(self, client, max_iterations=8, arbitrage=_UNSET, portfolio=_UNSET):
         return ChatService(
             prices=self.prices,
             fundamentals=self.fundamentals,
             sentiment=self.sentiment,
             options=self.options,
             arbitrage=self.arbitrage if arbitrage is _UNSET else arbitrage,
+            portfolio=self.portfolio if portfolio is _UNSET else portfolio,
             max_iterations=max_iterations,
             client_factory=lambda context: client,
         )
@@ -88,6 +92,20 @@ class ChatServiceTestBase(unittest.TestCase):
     def run_chat(self, client, **kwargs):
         service = self.make_service(client, **kwargs)
         return list(service.stream_chat([{"role": "user", "content": "hi"}]))
+
+    def tool_turn(self, name, args, context=None, **service_kwargs):
+        """One tool_use turn followed by a text turn; returns (events, client)."""
+        client = ScriptedClient(
+            [
+                {"final": final("tool_use", tool_use("tu_1", name, args))},
+                {"final": final("end_turn", text_block("done"))},
+            ]
+        )
+        service = self.make_service(client, **service_kwargs)
+        events = list(
+            service.stream_chat([{"role": "user", "content": "hi"}], context=context)
+        )
+        return events, client
 
 
 class TestTextOnlyTurn(ChatServiceTestBase):
@@ -935,18 +953,6 @@ class TestModelResolution(ChatServiceTestBase):
 class TestArbitrageTools(ChatServiceTestBase):
     """The sidekick's arbitrage tools dispatch into ArbitrageService."""
 
-    def tool_turn(self, name, args, **service_kwargs):
-        """One tool_use turn followed by a text turn; returns the events."""
-        client = ScriptedClient(
-            [
-                {"final": final("tool_use", tool_use("tu_1", name, args))},
-                {"final": final("end_turn", text_block("done"))},
-            ]
-        )
-        service = self.make_service(client, **service_kwargs)
-        events = list(service.stream_chat([{"role": "user", "content": "hi"}]))
-        return events, client
-
     def test_analyze_pair_dispatch_with_defaults(self):
         self.arbitrage.analyze_pair.return_value = {"security": "MSTR", "score": 9.7}
         self.tool_turn("analyze_arbitrage_pair", {"security": "MSTR"})
@@ -1019,6 +1025,202 @@ class TestArbitrageTools(ChatServiceTestBase):
         result_block = client.calls[1]["messages"][-1]["content"][0]
         self.assertTrue(result_block["is_error"])
         self.assertIn("Unknown tool", result_block["content"])
+
+
+class TestArbitrageDiscoveryTool(ChatServiceTestBase):
+    """discover_arbitrage_pairs — the one tool whose caps live in two files."""
+
+    def test_caps_match_the_service_definition(self):
+        """chat.py mirrors these constants rather than importing them, because
+        a service module never imports another service module. Mirrored numbers
+        drift; this is the guard the mirroring comment promises."""
+        from quantcore.services import arbitrage as arbitrage_service
+        from quantcore.services import chat as chat_service
+
+        self.assertEqual(
+            chat_service.MAX_DISCOVER_SYMBOLS,
+            arbitrage_service.MAX_DISCOVER_SYMBOLS,
+        )
+        self.assertEqual(
+            chat_service.MAX_DISCOVER_REFERENCES,
+            arbitrage_service.MAX_DISCOVER_REFERENCES,
+        )
+
+    def test_splits_and_upcases_the_symbol_string(self):
+        self.arbitrage.discover_pairs.return_value = {"pairs": []}
+        self.tool_turn("discover_arbitrage_pairs", {"symbols": "mstr, coin ,mara"})
+        self.arbitrage.discover_pairs.assert_called_once_with(
+            ["MSTR", "COIN", "MARA"],
+            references=None,
+            days=365,
+            min_abs_correlation=0.4,
+            require_economic_link=True,
+        )
+
+    def test_forwards_references_and_tuning_arguments(self):
+        self.arbitrage.discover_pairs.return_value = {"pairs": []}
+        self.tool_turn(
+            "discover_arbitrage_pairs",
+            {
+                "symbols": "RIOT",
+                "references": "BTC-USD, GLD",
+                "days": 730,
+                "min_abs_correlation": 0.7,
+                "require_economic_link": False,
+            },
+        )
+        self.arbitrage.discover_pairs.assert_called_once_with(
+            ["RIOT"],
+            references=["BTC-USD", "GLD"],
+            days=730,
+            min_abs_correlation=0.7,
+            require_economic_link=False,
+        )
+
+    def test_over_cap_symbol_list_is_rejected_before_the_service_is_touched(self):
+        """The REST route caps this; Sidekick bypasses the route, so an
+        uncapped model-authored sweep would otherwise reach the service as
+        O(symbols x references) history fetches."""
+        from quantcore.services.chat import MAX_DISCOVER_SYMBOLS
+
+        symbols = ",".join(f"SYM{i}" for i in range(MAX_DISCOVER_SYMBOLS + 1))
+        events, client = self.tool_turn("discover_arbitrage_pairs", {"symbols": symbols})
+        self.arbitrage.discover_pairs.assert_not_called()
+        statuses = [e for e in events if isinstance(e, ToolStatus)]
+        self.assertEqual([s.state for s in statuses], ["running", "error"])
+        result_block = client.calls[1]["messages"][-1]["content"][0]
+        self.assertTrue(result_block["is_error"])
+        self.assertIn("too many symbols", result_block["content"])
+
+    def test_over_cap_reference_list_is_rejected(self):
+        from quantcore.services.chat import MAX_DISCOVER_REFERENCES
+
+        references = ",".join(f"REF{i}" for i in range(MAX_DISCOVER_REFERENCES + 1))
+        _, client = self.tool_turn(
+            "discover_arbitrage_pairs", {"symbols": "MSTR", "references": references}
+        )
+        self.arbitrage.discover_pairs.assert_not_called()
+        result_block = client.calls[1]["messages"][-1]["content"][0]
+        self.assertIn("too many references", result_block["content"])
+
+    def test_blank_symbol_string_is_a_recoverable_error(self):
+        _, client = self.tool_turn("discover_arbitrage_pairs", {"symbols": " , "})
+        self.arbitrage.discover_pairs.assert_not_called()
+        result_block = client.calls[1]["messages"][-1]["content"][0]
+        self.assertTrue(result_block["is_error"])
+
+
+class TestPortfolioTools(ChatServiceTestBase):
+    """get_portfolio_summary / get_symbol_lots — owner comes from the turn,
+    never from the model."""
+
+    OWNED = TurnContext(owner="john")
+
+    def setUp(self):
+        super().setUp()
+        self.portfolio.symbol_rows.return_value = [
+            {
+                "symbol": "AAPL",
+                "lots": [{"id": 1}, {"id": 2}],
+                "total_investment": Decimal("1000.00"),
+                "total_current_value": Decimal("1250.00"),
+                "total_gain_loss": Decimal("250.00"),
+                "total_gain_loss_pct": 25.0,
+                "total_dollars_per_day": Decimal("0.50"),
+                # Columns the tool deliberately drops.
+                "allocation_segments": [{"pct": 100}],
+                "hedge_bias": "neutral",
+            }
+        ]
+        self.portfolio.portfolio_totals.return_value = {
+            "total_investment": Decimal("1000.00"),
+            "total_gain_loss": Decimal("250.00"),
+        }
+        self.portfolio.list_lots.return_value = [
+            {
+                "symbol": "AAPL",
+                "quantity": Decimal("10"),
+                "purchase_price": Decimal("100.00"),
+                "trade_date": date(2026, 1, 15),
+                "current_price": Decimal("125.00"),
+                "gain_loss": Decimal("250.00"),
+                "gain_loss_pct": 25.0,
+                "days_held": 200,
+                "dollars_per_day": Decimal("1.25"),
+                "price_stale": False,
+            },
+            {"symbol": "MSFT", "quantity": Decimal("5")},
+        ]
+
+    def test_summary_reads_the_resolved_owner(self):
+        self.tool_turn("get_portfolio_summary", {}, context=self.OWNED)
+        self.portfolio.symbol_rows.assert_called_once_with("john")
+
+    def test_summary_projects_a_compact_row_not_the_page_payload(self):
+        """The Portfolio page's row carries lots, allocation segments and hedge
+        bias; a conversation needs none of it. Same context-budget reasoning as
+        scan_arbitrage's summary rows."""
+        _, client = self.tool_turn("get_portfolio_summary", {}, context=self.OWNED)
+        payload = json.loads(client.calls[1]["messages"][-1]["content"][0]["content"])
+        position = payload["positions"][0]
+        self.assertEqual(position["symbol"], "AAPL")
+        self.assertEqual(position["lot_count"], 2)
+        self.assertEqual(position["total_current_value"], 1250.0)
+        self.assertNotIn("lots", position)
+        self.assertNotIn("allocation_segments", position)
+        self.assertEqual(payload["totals"]["total_gain_loss"], 250.0)
+
+    def test_symbol_lots_filters_to_the_requested_symbol_and_serializes_dates(self):
+        _, client = self.tool_turn(
+            "get_symbol_lots", {"ticker": "aapl"}, context=self.OWNED
+        )
+        self.portfolio.list_lots.assert_called_once_with("john", status="OPEN")
+        payload = json.loads(client.calls[1]["messages"][-1]["content"][0]["content"])
+        self.assertEqual(payload["symbol"], "AAPL")
+        self.assertEqual(payload["lot_count"], 1)
+        self.assertEqual(payload["lots"][0]["trade_date"], "2026-01-15")
+        self.assertEqual(payload["lots"][0]["purchase_price"], 100.0)
+
+    def test_a_model_supplied_owner_is_discarded_not_forwarded(self):
+        """No schema declares an `owner`, so its presence means the model
+        invented one — passing it through would be a cross-user read."""
+        self.tool_turn(
+            "get_portfolio_summary", {"owner": "thomas"}, context=self.OWNED
+        )
+        self.portfolio.symbol_rows.assert_called_once_with("john")
+
+    def test_unresolved_owner_degrades_without_touching_the_service(self):
+        """An identity with no owner mapping loses the portfolio tools and
+        nothing else — the route soft-resolves rather than 403-ing the turn."""
+        events, client = self.tool_turn(
+            "get_portfolio_summary", {}, context=TurnContext(owner=None)
+        )
+        self.assertEqual(self.portfolio.mock_calls, [])
+        statuses = [e for e in events if isinstance(e, ToolStatus)]
+        self.assertEqual([s.state for s in statuses], ["error"])
+        result_block = client.calls[1]["messages"][-1]["content"][0]
+        self.assertTrue(result_block["is_error"])
+        self.assertIn("not linked to a portfolio", result_block["content"])
+
+    def test_the_resolved_owner_never_reaches_the_rendered_tool_status(self):
+        """ToolStatus is streamed to the browser and rendered; the owner is
+        plumbing, and echoing it there would put one identity's resolved owner
+        on another's screen in a shared transcript."""
+        events, _ = self.tool_turn(
+            "get_symbol_lots", {"ticker": "AAPL"}, context=self.OWNED
+        )
+        for status in (e for e in events if isinstance(e, ToolStatus)):
+            self.assertNotIn("owner", status.args)
+
+    def test_without_the_service_the_tools_degrade_to_a_recoverable_error(self):
+        events, client = self.tool_turn(
+            "get_portfolio_summary", {}, context=self.OWNED, portfolio=None
+        )
+        statuses = [e for e in events if isinstance(e, ToolStatus)]
+        self.assertEqual([s.state for s in statuses], ["running", "error"])
+        self.assertIn(
+            "Unknown tool", client.calls[1]["messages"][-1]["content"][0]["content"]
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #208.

## The question, and the actual answer

#208 asked why Sidekick doesn't have access to all the MCP servers' tools. The audit gives a three-part answer, and only one part is what the title suspected.

**1. The curation is deliberate policy, not drift.** `architectural-standard-v2` §5.5 says exposing an endpoint as a tool is a decision, and the arbitrage commit (`c5df10f`) shows that reasoning applied in practice. Working as designed.

**2. `SYSTEM_PROMPT` was stale, and this is the likeliest real cause of the symptom.** It hard-coded 4 of the 15 registered components and never mentioned the arbitrage, portfolio, or fundamentals tools at all. A model does not reach for a tool its own prompt never names.

**3. Two gaps were genuinely accidental.** `arbitrage_discovery` was registered as a component on *both* sides of the registry with no tool able to feed it, and `portfolio-server` had zero chat coverage — Sidekick could render a portfolio card but couldn't reason over the numbers in prose.

## What's here

Six commits, ordered for review: owner plumbing → `chat.py` → `chat_tools.py` → `registry.py` → tests → docs. Splitting it would either duplicate the owner-dispatch plumbing across two PRs or land the docs against a tool count that isn't real yet — which is the exact failure this issue is about.

### Three worth arguing about

**Owner resolution degrades per tool, not per request.** `require_owner` 403s the whole request on an unmapped identity. That's wrong for chat: a turn serves many tools that need no identity, and failing all of them over unprovisioned portfolio identity is a bad trade — while defaulting to `"john"` would be a silent cross-user read the moment a second identity exists. So `resolve_owner_or_none` returns `None`, and the dispatch loop fails that *one* tool with a recoverable error the model can explain. It never auto-provisions, and logs a distinct event so the soft path stays separable from the hard 403 in monitoring.

**Discovery is now stricter than its arbitrage siblings — deliberately.** `MAX_DISCOVER_SYMBOLS` (25) / `MAX_DISCOVER_REFERENCES` (10) lived only in `api/routers/arbitrage.py`. Sidekick dispatches **in-process** and never passes through that route, so the cap would simply not have existed for chat. They now live on `ArbitrageService`, asserted by both. Flagging it so it doesn't read as accidental inconsistency — and the general hazard is worth internalizing: *any* guard implemented at the REST boundary is invisible to Sidekick, because Sidekick is not an MCP client and does not speak HTTP.

**No tool declares an `owner` parameter, and none should.** This extends the existing `show_component` rule (the model never picks whose data) from component props to tool arguments. A model-supplied `owner` means a hallucination, since no schema declares one, and is dropped at dispatch.

### The docs half

The matrix documented **5 servers / 51 tools** against an actual **7 / 62**, omitted two servers entirely, and asserted a dual-registration that doesn't exist in code — `60e4bcd` moved every options tool off stock-price, which is the whole of the 29→21 drop. Counts are now taken with the **anchored** `grep -c "^@mcp.tool" fastMCPTest/*.py`; the unanchored form reports 63 because `options_analysis.py` mentions `@mcp.tool()` in its module docstring. That gotcha is written into the docs rather than left to be re-derived.

§5.5 said "never blanket-mirror the whole API", which reads as *discourage exposure* when the intent is *force a design discussion*. It now says most REST capabilities **should** reach a tool, that what's forbidden is the mechanical one-tool-per-endpoint mirror, and that every new REST capability owes one of two artifacts in the same PR: a designed tool, or a written decision that it stays REST-only. Silence stops counting as a decision.

## Verification

- Full backend suite: **1469 tests, `OK (skipped=5)`** (812s, against the test DB).
- Frontend chat suite: 34 passed. No frontend changes — no new component is registered.
- Handlers exercised in-process against real services: all three registered; caps reject **before** `ArbitrageService` is touched; `get_portfolio_summary` → `{positions, totals}`, `get_symbol_lots` → `{symbol, lots, lot_count}`.

**Not verified, and it's the interesting part.** The model-driven E2E needs a real Anthropic key through the browser vault. The in-process check proves the handlers and caps work; it does **not** prove the model now *reaches for* the new tools with `SYSTEM_PROMPT` naming them — which is the actual hypothesis behind #208. Worth a manual pass: "find cointegrated pairs among MSTR, COIN, MARA", "how's my portfolio doing?", and an unlinked principal (portfolio question should apologize while price questions in the same turn still work).

## Scoped out

The ⭐ "Built But Not Yet Surfaced" section was **not** re-audited. Rows provably closed by the `/fundamentals` page (#147 Part D) are corrected; the rest carries a dated caveat saying it was last verified 2026-07-20. A stale-but-labelled list beats both a confidently wrong one and an unscoped re-audit bolted onto this PR.

Plan and checkpoint log — including the three things that misled me during the docs pass — in `docs/proposals/sidekick-tool-audit-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
