### PR TITLE
docs: drop five citations of a file that was never committed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,9 +147,11 @@ links against a reference panel, gated by a sector/industry economic-link filter
 **The scoring is deliberately inverted: spread width only qualifies a candidate, the
 convergence mechanism ranks it.** `ArbitrageService._score` multiplies named factors —
 `opportunity × evidence × convergence × hedge × carry × trend × freshness` — all returned in
-the `factors` block alongside `reasons` and `breaks_on`, so any score is attributable. The
-design and every penalty trace to
-[`docs/analysis_results/MSTR_BTC_arbitrage_assessment_2026-07-14.md`](docs/analysis_results/MSTR_BTC_arbitrage_assessment_2026-07-14.md);
+the `factors` block alongside `reasons` and `breaks_on`, so any score is attributable. The design
+principle is stated in the `ArbitrageService` module docstring; the penalties are applied in
+six numbered steps in `_score`, and every one of them emits a `reasons` entry explaining
+itself (plus a `breaks_on` entry where it names a way the trade fails), so the scorer is its
+own documentation rather than pointing at a write-up that can drift from it.
 `tests/test_arbitrage_nav.py` is a regression guard that the MSTR inputs still produce a ~10%
 **net** discount rather than the ~37% headline against gross assets. Because the account is
 equity/ETF-only, any pair whose sole clean hedge is a futures contract is flagged

--- a/docs/arbitrage-scanner-usage.md
+++ b/docs/arbitrage-scanner-usage.md
@@ -156,8 +156,9 @@ reported only so the difference is visible.
 `exposure_ratio 1.70` says each $1 of MSTR carries $1.70 of BTC — so a 1:1 dollar short
 leaves the position materially net long.
 
-The reasoning behind every penalty is written up in
-`docs/analysis_results/MSTR_BTC_arbitrage_assessment_2026-07-14.md`.
+Every penalty explains itself in the `reasons` and `breaks_on` entries it emits, so a score
+never needs a separate write-up to interpret; the numbered steps in `ArbitrageService._score`
+are where they are applied.
 
 ### Example scan output (live prod, 2026-07-26)
 

--- a/quantcore/analytics/nav.py
+++ b/quantcore/analytics/nav.py
@@ -5,9 +5,8 @@ the claims that sit ahead of the common, and the share count, these functions
 produce the discount a common holder is actually being offered — and what it
 costs to hold while waiting.
 
-The whole module exists because of one recurring error, documented in
-``docs/analysis_results/MSTR_BTC_arbitrage_assessment_2026-07-14.md``: quoting
-a vehicle's discount against *gross* holdings. Common shareholders do not own
+The whole module exists because of one recurring error: quoting a vehicle's
+discount against *gross* holdings. Common shareholders do not own
 the gross stack. Converts and preferred sit senior to them, so a headline 37%
 discount to gross BTC was really ~10% once ~$16B of senior claims were netted
 out. ``net_nav_per_share`` subtracts senior claims before dividing, and there

--- a/quantcore/services/arbitrage.py
+++ b/quantcore/services/arbitrage.py
@@ -18,7 +18,7 @@ list in July 2026 on a 37% headline gap that was really ~10% once $16.5B of
 converts and preferred were netted out — against negative carry, no redemption
 right, and the GBTC precedent where the identical structure widened from -15%
 to -50% over three years. Every penalty in ``_score`` traces to one of those
-holes; see docs/analysis_results/MSTR_BTC_arbitrage_assessment_2026-07-14.md.
+holes, and each one names itself in the ``reasons``/``breaks_on`` it emits.
 
 Analytics are delegated: spread statistics to ``quantcore.analytics.pairs``,
 NAV arithmetic to ``quantcore.analytics.nav``. This module composes, scores,

--- a/tests/test_arbitrage_nav.py
+++ b/tests/test_arbitrage_nav.py
@@ -1,11 +1,11 @@
 """NAV math tests — the regression guard against the wrong-denominator error.
 
-The centrepiece is ``MstrRegressionTest``: the inputs from
-``docs/analysis_results/MSTR_BTC_arbitrage_assessment_2026-07-14.md`` must
-reproduce that document's conclusions — a ~10% net discount rather than the
-~37% headline, ~2.2%/yr of carry drag, and ~1.6x of underlying exposure per
-dollar of equity. If a future refactor starts dividing gross assets by share
-count again, this file fails.
+The centrepiece is ``MstrRegressionTest``: the July 2026 MSTR assessment
+inputs — recorded verbatim in ``MSTR`` below, which is now their only home —
+must keep reproducing that assessment's conclusions: a ~10% net discount
+rather than the ~37% headline, ~2.2%/yr of carry drag, and ~1.6x of
+underlying exposure per dollar of equity. If a future refactor starts
+dividing gross assets by share count again, this file fails.
 """
 import unittest
 


### PR DESCRIPTION
## What

`docs/analysis_results/MSTR_BTC_arbitrage_assessment_2026-07-14.md` is cited as the design authority for the arbitrage scorer in five places. **It has never existed in this repo.**

Evidence, not inference — it is absent from `git ls-files`, has no add in `git log --all --diff-filter=A`, is not on disk anywhere under `~/Documents/code`, is not gitignored, appears in no issue or PR, and no `Write`/`Edit` tool call in the project's session transcripts ever targeted that path. The citations were introduced by cf409b9 (#137). #212 only corrected their spelling during the `analysis results/` → `analysis_results/` rename; the link was dead before and after, which is how it stayed invisible.

## Why drop rather than write it

Reconstructing the document would mean authoring conclusions and attributing them to a July 2026 analysis nobody can check. The substance that mattered — six input figures and the conclusions they produce — is already in the repo and already executed. So each site now stands on what it carries:

| File | Change |
|---|---|
| `quantcore/analytics/nav.py` | Drops "documented in ⟨file⟩". The docstring already explains the gross-vs-net error in full. |
| `quantcore/services/arbitrage.py` | "see ⟨file⟩" → "each one names itself in the `reasons`/`breaks_on` it emits." The GBTC precedent sentence (−15% → −50% over three years) lives only here and is preserved. |
| `tests/test_arbitrage_nav.py` | Declares the `MSTR` dict **the only home** of the July 2026 inputs. |
| `CLAUDE.md` | Points at the `ArbitrageService` module docstring for the principle and the six numbered steps in `_score` for the penalties. |
| `docs/arbitrage-scanner-usage.md` | Same substitution, reader-facing. |

Net effect: the six figures are now single-homed in a dict that runs on every test invocation, rather than in prose that can drift silently — which is exactly the failure this PR is cleaning up.

## Accuracy of the replacement wording

Checked against the code before writing, since the point is not to swap one unverifiable pointer for another:

- `_score` has **no** docstring — the replacement text does not claim it does.
- The penalties are applied in **six numbered inline steps** (step 6 covers both trend and freshness).
- Every multiplicative penalty (`evidence *= 0.5`, `*= 0.6`, `*= 0.8`, and the carry/trend/freshness ones) sits adjacent to a `reasons.append(...)`, with `breaks_on.append(...)` where a break condition exists.

## Testing

Docs and comments only — no behavior change.

- `python -m unittest tests.test_arbitrage_nav tests.test_arbitrage_service` — **90 passed**
- `py_compile` clean on all three touched Python files
- `git grep MSTR_BTC_arbitrage_assessment` returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)